### PR TITLE
Fix klog error logging before flag.Parse

### DIFF
--- a/cmd/app-mesh-controller/root.go
+++ b/cmd/app-mesh-controller/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws"
 	"os"
@@ -43,6 +44,7 @@ func init() {
 }
 
 func main() {
+	flag.CommandLine.Parse([]string{})
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Parse command line flags at startup to avoid logging errors like:

```
ERROR: logging before flag.Parse: E0312 21:26:47.877844   28050 controller.go:370] 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: stefanprodan <stefan.prodan@gmail.com>