### PR TITLE
Allow mesh reuse across namespaces

### DIFF
--- a/pkg/controller/virtualnode.go
+++ b/pkg/controller/virtualnode.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	appmeshv1alpha1 "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/apis/appmesh/v1alpha1"
 	api "k8s.io/api/core/v1"
@@ -45,7 +46,15 @@ func (c *Controller) handleVNode(key string) error {
 		return fmt.Errorf("'MeshName' is a required field")
 	}
 
-	mesh, err := c.meshLister.Meshes(namespace).Get(meshName)
+	// Extract namespace from Mesh name
+	meshNamespace := namespace
+	meshParts := strings.Split(meshName, ".")
+	if len(meshParts) > 1 {
+		meshNamespace = strings.Join(meshParts[1:], ".")
+		meshName = meshParts[0]
+	}
+
+	mesh, err := c.meshLister.Meshes(meshNamespace).Get(meshName)
 	if errors.IsNotFound(err) {
 		return fmt.Errorf("mesh %s for virtual node %s does not exist", meshName, name)
 	}

--- a/pkg/controller/virtualservice.go
+++ b/pkg/controller/virtualservice.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	appmeshv1alpha1 "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/apis/appmesh/v1alpha1"
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,7 +47,15 @@ func (c *Controller) handleVService(key string) error {
 		return fmt.Errorf("'MeshName' is a required field")
 	}
 
-	mesh, err := c.meshLister.Meshes(namespace).Get(meshName)
+	// Extract namespace from Mesh name
+	meshNamespace := namespace
+	meshParts := strings.Split(meshName, ".")
+	if len(meshParts) > 1 {
+		meshNamespace = strings.Join(meshParts[1:], ".")
+		meshName = meshParts[0]
+	}
+
+	mesh, err := c.meshLister.Meshes(meshNamespace).Get(meshName)
 	if errors.IsNotFound(err) {
 		return fmt.Errorf("mesh %s for virtual service %s does not exist", meshName, name)
 	}


### PR DESCRIPTION
This PR allows for a mesh object to be used across namespaces.

Example

Create a mesh in `appmesh-system`:

```yaml
apiVersion: appmesh.k8s.aws/v1alpha1
kind: Mesh
metadata:
  name: global
  namespace: appmesh-system
spec:
  cloudMapNamespaceName: test
  serviceDiscoveryType: cloudmap-http
```

Use the global mesh in virtual nodes and virtual services by specifying the mesh namespace:

```yaml
apiVersion: appmesh.k8s.aws/v1alpha1
kind: VirtualNode
metadata:
  name: backend
  namespace: test
spec:
  meshName: global.appmesh-system
  listeners:
    - portMapping:
        port: 9898
        protocol: http
  serviceDiscovery:
    dns:
      hostName: backend.test.svc.cluster.local
```

This change is backwards compatible, if a mesh is referenced without a namespace, then the operator will search for that mesh in the namespace where the virtual node and virtual service resides.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: stefanprodan <stefan.prodan@gmail.com>
