### PR TITLE
Clean Up Objects in App Mesh

### DIFF
--- a/deploy/mesh-definition.yaml
+++ b/deploy/mesh-definition.yaml
@@ -26,19 +26,13 @@ spec:
       properties:
         spec:
           properties:
-            cloudMapNamespaceName:
-              type: string
             serviceDiscoveryType:
               type: string
               enum:
-                - cloudmap-http
+                - dns
         status:
           properties:
             meshArn:
-              type: string
-            cloudMapNamespaceArn:
-              type: string
-            cloudMapRoleArn:
               type: string
             conditions:
               type: array
@@ -50,12 +44,12 @@ spec:
                   type:
                     type: string
                     enum:
-                      - Active
+                      - MeshActive
                   status:
                     type: string
                     enum:
-                      - True
-                      - False
+                      - "True"
+                      - "False"
                       - Unknown
                   lastTransitionTime:
                     type: string

--- a/deploy/virtual-node-definition.yaml
+++ b/deploy/virtual-node-definition.yaml
@@ -91,12 +91,13 @@ spec:
                   type:
                     type: string
                     enum:
-                      - Active
+                      - VirtualNodeActive
+                      - MeshMarkedForDeletion
                   status:
                     type: string
                     enum:
-                      - True
-                      - False
+                      - "True"
+                      - "False"
                       - Unknown
                   lastTransitionTime:
                     type: string

--- a/deploy/virtual-service-definition.yaml
+++ b/deploy/virtual-service-definition.yaml
@@ -78,12 +78,15 @@ spec:
                   type:
                     type: string
                     enum:
-                      - Active
+                      - VirtualServiceActive
+                      - VirtualRouterActive
+                      - RoutesActive
+                      - MeshMarkedForDeletion
                   status:
                     type: string
                     enum:
-                      - True
-                      - False
+                      - "True"
+                      - "False"
                       - Unknown
                   lastTransitionTime:
                     type: string

--- a/examples/color.yaml
+++ b/examples/color.yaml
@@ -12,8 +12,7 @@ metadata:
   name: color-mesh
   namespace: appmesh-demo
 spec:
-  cloudMapNamespaceName: color-namespace
-  serviceDiscoveryType: cloudmap-http
+  serviceDiscoveryType: dns
 ---
 apiVersion: appmesh.k8s.aws/v1alpha1
 kind: VirtualNode

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	k8s.io/api v0.0.0-20181128191700-6db15a15d2d3
 	k8s.io/apimachinery v0.0.0-20181128191346-49ce2735e507
 	k8s.io/client-go v9.0.0+incompatible
+	k8s.io/code-generator v0.0.0-20190311155051-e4c2b1329cf7 // indirect
+	k8s.io/gengo v0.0.0-20190308184658-b90029ef6cd8 // indirect
 	k8s.io/klog v0.2.0
 	k8s.io/kube-openapi v0.0.0-20190222203931-aa8624f5a2df // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,10 @@ k8s.io/apimachinery v0.0.0-20181128191346-49ce2735e507 h1:DRtb2PO1ps3SPBkAUYz9J+
 k8s.io/apimachinery v0.0.0-20181128191346-49ce2735e507/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/client-go v9.0.0+incompatible h1:2kqW3X2xQ9SbFvWZjGEHBLlWc1LG9JIJNXWkuqwdZ3A=
 k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
+k8s.io/code-generator v0.0.0-20190311155051-e4c2b1329cf7 h1:ClecGOuvNNi9TEhJcLkQgc5pdsLf/3aTj8lwiJ2mgpY=
+k8s.io/code-generator v0.0.0-20190311155051-e4c2b1329cf7/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=
+k8s.io/gengo v0.0.0-20190308184658-b90029ef6cd8 h1:iGIzMKJnyjqoTWYflXQ53iBw+qWirpbDFWKJGRAa/U0=
+k8s.io/gengo v0.0.0-20190308184658-b90029ef6cd8/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20190222203931-aa8624f5a2df h1:htvtrqyyVqMSYjR5bmmLx7RVu2+Rp5o1RVOc51x2YrQ=

--- a/pkg/apis/appmesh/v1alpha1/types.go
+++ b/pkg/apis/appmesh/v1alpha1/types.go
@@ -19,9 +19,9 @@ type Mesh struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +optional
-	Spec *MeshSpec `json:"spec,omitempty"`
+	Spec MeshSpec `json:"spec,omitempty"`
 	// +optional
-	Status *MeshStatus `json:"status,omitempty"`
+	Status MeshStatus `json:"status,omitempty"`
 }
 
 type MeshServiceDiscoveryType string
@@ -56,7 +56,7 @@ type MeshConditionType string
 
 const (
 	// MeshActive is Active when the Appmesh Mesh has been created or found via the API
-	MeshActive MeshConditionType = "Active"
+	MeshActive MeshConditionType = "MeshActive"
 )
 
 type MeshCondition struct {
@@ -95,9 +95,9 @@ type VirtualService struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +optional
-	Spec *VirtualServiceSpec `json:"spec,omitempty"`
+	Spec VirtualServiceSpec `json:"spec,omitempty"`
 	// +optional
-	Status *VirtualServiceStatus `json:"status,omitempty"`
+	Status VirtualServiceStatus `json:"status,omitempty"`
 }
 
 // VirtualServiceSpec is the spec for a VirtualService resource
@@ -154,7 +154,10 @@ type VirtualServiceConditionType string
 
 const (
 	// VirtualServiceActive is Active when the Appmesh Service has been created or found via the API
-	VirtualServiceActive VirtualServiceConditionType = "Active"
+	VirtualServiceActive                VirtualServiceConditionType = "VirtualServiceActive"
+	VirtualRouterActive                 VirtualServiceConditionType = "VirtualRouterActive"
+	RoutesActive                        VirtualServiceConditionType = "RoutesActive"
+	VirtualServiceMeshMarkedForDeletion VirtualServiceConditionType = "MeshMarkedForDeletion"
 )
 
 type VirtualServiceCondition struct {
@@ -193,9 +196,9 @@ type VirtualNode struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +optional
-	Spec *VirtualNodeSpec `json:"spec,omitempty"`
+	Spec VirtualNodeSpec `json:"spec,omitempty"`
 	// +optional
-	Status *VirtualNodeStatus `json:"status,omitempty"`
+	Status VirtualNodeStatus `json:"status,omitempty"`
 }
 
 // VirtualNodeSpec is the spec for a VirtualNode resource
@@ -259,7 +262,8 @@ type VirtualNodeConditionType string
 
 const (
 	// VirtualNodeActive is Active when the Appmesh Node has been created or found via the API
-	VirtualNodeActive VirtualNodeConditionType = "Active"
+	VirtualNodeActive                VirtualNodeConditionType = "VirtualNodeActive"
+	VirtualNodeMeshMarkedForDeletion VirtualNodeConditionType = "MeshMarkedForDeletion"
 )
 
 type VirtualNodeCondition struct {

--- a/pkg/apis/appmesh/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/appmesh/v1alpha1/zz_generated.deepcopy.go
@@ -146,16 +146,8 @@ func (in *Mesh) DeepCopyInto(out *Mesh) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.Spec != nil {
-		in, out := &in.Spec, &out.Spec
-		*out = new(MeshSpec)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Status != nil {
-		in, out := &in.Status, &out.Status
-		*out = new(MeshStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 
@@ -368,16 +360,8 @@ func (in *VirtualNode) DeepCopyInto(out *VirtualNode) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.Spec != nil {
-		in, out := &in.Spec, &out.Spec
-		*out = new(VirtualNodeSpec)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Status != nil {
-		in, out := &in.Status, &out.Status
-		*out = new(VirtualNodeStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 
@@ -559,16 +543,8 @@ func (in *VirtualService) DeepCopyInto(out *VirtualService) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.Spec != nil {
-		in, out := &in.Spec, &out.Spec
-		*out = new(VirtualServiceSpec)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Status != nil {
-		in, out := &in.Status, &out.Status
-		*out = new(VirtualServiceStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -24,6 +24,8 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	AppmeshV1alpha1() appmeshv1alpha1.AppmeshV1alpha1Interface
+	// Deprecated: please explicitly pick a version if possible.
+	Appmesh() appmeshv1alpha1.AppmeshV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -35,6 +37,12 @@ type Clientset struct {
 
 // AppmeshV1alpha1 retrieves the AppmeshV1alpha1Client
 func (c *Clientset) AppmeshV1alpha1() appmeshv1alpha1.AppmeshV1alpha1Interface {
+	return c.appmeshV1alpha1
+}
+
+// Deprecated: Appmesh retrieves the default version of AppmeshClient.
+// Please explicitly pick a version.
+func (c *Clientset) Appmesh() appmeshv1alpha1.AppmeshV1alpha1Interface {
 	return c.appmeshV1alpha1
 }
 

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -71,3 +71,8 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) AppmeshV1alpha1() appmeshv1alpha1.AppmeshV1alpha1Interface {
 	return &fakeappmeshv1alpha1.FakeAppmeshV1alpha1{Fake: &c.Fake}
 }
+
+// Appmesh retrieves the AppmeshV1alpha1Client
+func (c *Clientset) Appmesh() appmeshv1alpha1.AppmeshV1alpha1Interface {
+	return &fakeappmeshv1alpha1.FakeAppmeshV1alpha1{Fake: &c.Fake}
+}

--- a/pkg/controller/controller_util.go
+++ b/pkg/controller/controller_util.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+func containsFinalizer(obj interface{}, finalizer string) (bool, error) {
+	metaobj, err := meta.Accessor(obj)
+	if err != nil {
+		return false, fmt.Errorf("object has no meta: %v", err)
+	}
+	for _, f := range metaobj.GetFinalizers() {
+		if f == finalizer {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func addFinalizer(obj interface{}, finalizer string) error {
+	metaobj, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("object has no meta: %v", err)
+	}
+	metaobj.SetFinalizers(append(metaobj.GetFinalizers(), finalizer))
+	return nil
+}
+
+func removeFinalizer(obj interface{}, finalizer string) error {
+	metaobj, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("object has no meta: %v", err)
+	}
+
+	var finalizers []string
+	for _, f := range metaobj.GetFinalizers() {
+		if f == finalizer {
+			continue
+		}
+		finalizers = append(finalizers, f)
+	}
+	metaobj.SetFinalizers(finalizers)
+	return nil
+}
+
+// parseMeshName returns meshName, namespace given the meshName reference and namespace of a virtual node or virtual
+// service.  In order to support mesh references for meshes in different namespaces, we allow the format
+// meshName.meshNamespace in the meshName reference field of a virtual node or virtual service.
+func parseMeshName(meshName string, namespace string) (string, string) {
+	meshNamespace := namespace
+	meshParts := strings.Split(meshName, ".")
+	if len(meshParts) > 1 {
+		meshNamespace = strings.Join(meshParts[1:], ".")
+		meshName = meshParts[0]
+	}
+	return meshName, meshNamespace
+}

--- a/pkg/controller/virtualservice.go
+++ b/pkg/controller/virtualservice.go
@@ -7,6 +7,7 @@ import (
 
 	appmeshv1alpha1 "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/apis/appmesh/v1alpha1"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws"
+	"github.com/aws/aws-sdk-go/service/appmesh"
 	set "github.com/deckarep/golang-set"
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,9 +26,6 @@ func (c *Controller) handleVService(key string) error {
 	shared, err := c.virtualServiceLister.VirtualServices(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		klog.V(2).Infof("Virtual service %s has been deleted", key)
-
-		// TODO(nic) cleanup VirtualService
-
 		return nil
 	}
 	if err != nil {
@@ -37,9 +35,26 @@ func (c *Controller) handleVService(key string) error {
 	// Make copy here so we never update the shared copy
 	vservice := shared.DeepCopy()
 
-	// Initialize status if empty
-	if err = c.initVServiceStatus(vservice); err != nil {
-		return fmt.Errorf("error updating virtual service status: %s", err)
+	// Resources with finalizers are not deleted immediately,
+	// instead the deletion timestamp is set when a client deletes them.
+	if !vservice.DeletionTimestamp.IsZero() {
+		// Resource is being deleted, process finalizers
+		return c.handleVServiceDelete(ctx, vservice)
+	}
+
+	// This is not a delete, add the deletion finalizer if it doesn't exist
+	if yes, _ := containsFinalizer(vservice, virtualServiceDeletionFinalizerName); !yes {
+		if err := addFinalizer(vservice, virtualServiceDeletionFinalizerName); err != nil {
+			return fmt.Errorf("error adding finalizer %s to virtual service %s: %s", virtualServiceDeletionFinalizerName, vservice.Name, err)
+		}
+		if err := c.updateVServiceResource(vservice); err != nil {
+			return fmt.Errorf("error adding finalizer %s to virtual service %s: %s", virtualServiceDeletionFinalizerName, vservice.Name, err)
+		}
+	}
+
+	if processVService := c.handleVServiceMeshDeleting(ctx, vservice); !processVService {
+		klog.Infof("skipping processing virtual service %s", vservice.Name)
+		return nil
 	}
 
 	// Get Mesh for virtual service
@@ -49,13 +64,7 @@ func (c *Controller) handleVService(key string) error {
 	}
 
 	// Extract namespace from Mesh name
-	meshNamespace := namespace
-	meshParts := strings.Split(meshName, ".")
-	if len(meshParts) > 1 {
-		meshNamespace = strings.Join(meshParts[1:], ".")
-		meshName = meshParts[0]
-		vservice.Spec.MeshName = meshParts[0]
-	}
+	meshName, meshNamespace := parseMeshName(meshName, vservice.Namespace)
 
 	mesh, err := c.meshLister.Meshes(meshNamespace).Get(meshName)
 	if errors.IsNotFound(err) {
@@ -78,21 +87,44 @@ func (c *Controller) handleVService(key string) error {
 		} else {
 			return fmt.Errorf("error describing virtual router: %s", err)
 		}
+		if vservice, err = c.updateVRouterStatus(vservice, targetRouter); err != nil {
+			return fmt.Errorf("error updating virtual service status: %s", err)
+		}
 	}
 
 	desiredRoutes := getRoutes(vservice)
 	existingRoutes, err := c.cloud.GetRoutesForVirtualRouter(ctx, virtualRouter.Name, meshName)
+	if err != nil {
+		return fmt.Errorf("error getting routes for virtual service %s: %s", vservice.Name, err)
+	}
 	if err = c.updateRoutes(ctx, meshName, virtualRouter.Name, desiredRoutes, existingRoutes); err != nil {
-		return fmt.Errorf("error updating routes for service %s: %s", vservice.Name, err)
+		return fmt.Errorf("error updating routes for virtual service %s: %s", vservice.Name, err)
+	}
+
+	routes, err := c.cloud.GetRoutesForVirtualRouter(ctx, virtualRouter.Name, meshName)
+	if err != nil {
+		klog.Errorf("Unable to check status of routes for virtual router %s: %s", virtualRouter.Name, err)
+	} else {
+		var status api.ConditionStatus
+		if allRoutesActive(routes) {
+			status = api.ConditionTrue
+		} else {
+			status = api.ConditionFalse
+		}
+		if updated, err := c.updateRoutesActive(vservice, status); err != nil {
+			return fmt.Errorf("error updating routes status: %s", err)
+		} else if updated != nil {
+			vservice = updated
+		}
 	}
 
 	// Create virtual service if it does not exist
-	if targetService, err := c.cloud.GetVirtualService(ctx, vservice.Name, meshName); err != nil {
+	targetService, err := c.cloud.GetVirtualService(ctx, vservice.Name, meshName)
+	if err != nil {
 		if aws.IsAWSErrNotFound(err) {
 			if targetService, err = c.cloud.CreateVirtualService(ctx, vservice); err != nil {
 				return fmt.Errorf("error creating virtual service: %s", err)
 			}
-			klog.Infof("Created virtual service %s", targetService.Name())
 		} else {
 			return fmt.Errorf("error describing virtual service: %s", err)
 		}
@@ -105,22 +137,63 @@ func (c *Controller) handleVService(key string) error {
 		}
 	}
 
+	if updated, err := c.updateVServiceStatus(vservice, targetService); err != nil {
+		return fmt.Errorf("error updating virtual service status: %s", err)
+	} else if updated != nil {
+		vservice = updated
+	}
+
 	// TODO(nic) Need to determine if we need to clean up the old router here.  This needs to happen if we switched
 	// routers for the service.  For now, the old router will be orphaned if the user changes a router name.
 
 	return nil
 }
 
-func (c *Controller) updateVServiceActive(vservice *appmeshv1alpha1.VirtualService) error {
-	return c.updateVServiceCondition(vservice, appmeshv1alpha1.VirtualServiceActive, api.ConditionTrue)
+func (c *Controller) updateVServiceResource(vservice *appmeshv1alpha1.VirtualService) error {
+	_, err := c.meshclientset.AppmeshV1alpha1().VirtualServices(vservice.Namespace).Update(vservice)
+	return err
 }
 
-func (c *Controller) updateVServiceCondition(vservice *appmeshv1alpha1.VirtualService, conditionType appmeshv1alpha1.VirtualServiceConditionType, status api.ConditionStatus) error {
+func (c *Controller) updateVServiceStatus(vservice *appmeshv1alpha1.VirtualService, target *aws.VirtualService) (*appmeshv1alpha1.VirtualService, error) {
+	switch target.Status() {
+	case appmesh.VirtualServiceStatusCodeActive:
+		return c.updateVServiceActive(vservice, api.ConditionTrue)
+	case appmesh.VirtualServiceStatusCodeInactive:
+		return c.updateVServiceActive(vservice, api.ConditionFalse)
+	case appmesh.VirtualServiceStatusCodeDeleted:
+		return c.updateVServiceActive(vservice, api.ConditionFalse)
+	}
+	return nil, nil
+}
+
+func (c *Controller) updateVRouterStatus(vservice *appmeshv1alpha1.VirtualService, target *aws.VirtualRouter) (*appmeshv1alpha1.VirtualService, error) {
+	switch target.Status() {
+	case appmesh.VirtualRouterStatusCodeActive:
+		return c.updateVRouterActive(vservice, api.ConditionTrue)
+	case appmesh.VirtualRouterStatusCodeInactive:
+		return c.updateVRouterActive(vservice, api.ConditionFalse)
+	case appmesh.VirtualRouterStatusCodeDeleted:
+		return c.updateVRouterActive(vservice, api.ConditionFalse)
+	}
+	return nil, nil
+}
+
+func (c *Controller) updateVServiceActive(vservice *appmeshv1alpha1.VirtualService, status api.ConditionStatus) (*appmeshv1alpha1.VirtualService, error) {
+	return c.updateVServiceCondition(vservice, appmeshv1alpha1.VirtualServiceActive, status)
+}
+
+func (c *Controller) updateVRouterActive(vservice *appmeshv1alpha1.VirtualService, status api.ConditionStatus) (*appmeshv1alpha1.VirtualService, error) {
+	return c.updateVServiceCondition(vservice, appmeshv1alpha1.VirtualRouterActive, status)
+}
+
+func (c *Controller) updateRoutesActive(vservice *appmeshv1alpha1.VirtualService, status api.ConditionStatus) (*appmeshv1alpha1.VirtualService, error) {
+	return c.updateVServiceCondition(vservice, appmeshv1alpha1.RoutesActive, status)
+}
+
+func (c *Controller) updateVServiceCondition(vservice *appmeshv1alpha1.VirtualService, conditionType appmeshv1alpha1.VirtualServiceConditionType, status api.ConditionStatus) (*appmeshv1alpha1.VirtualService, error) {
 	now := metav1.Now()
-
 	condition := getVServiceCondition(conditionType, vservice.Status)
-
-	if condition == nil {
+	if condition == (appmeshv1alpha1.VirtualServiceCondition{}) {
 		// condition does not exist
 		newCondition := appmeshv1alpha1.VirtualServiceCondition{
 			Type:               conditionType,
@@ -130,42 +203,24 @@ func (c *Controller) updateVServiceCondition(vservice *appmeshv1alpha1.VirtualSe
 		vservice.Status.Conditions = append(vservice.Status.Conditions, newCondition)
 	} else if condition.Status == status {
 		// Already is set to status
-		return nil
+		return nil, nil
 	} else {
 		// condition exists and not set to status
 		condition.Status = status
 		condition.LastTransitionTime = &now
 	}
 
-	_, err := c.meshclientset.AppmeshV1alpha1().VirtualServices(vservice.Namespace).UpdateStatus(vservice)
-	return err
+	return c.meshclientset.AppmeshV1alpha1().VirtualServices(vservice.Namespace).UpdateStatus(vservice)
 }
 
-func (c *Controller) initVServiceStatus(vservice *appmeshv1alpha1.VirtualService) error {
-	if vservice.Status == nil {
-		vservice.Status = &appmeshv1alpha1.VirtualServiceStatus{
-			Conditions: []appmeshv1alpha1.VirtualServiceCondition{},
-		}
-		_, err := c.meshclientset.AppmeshV1alpha1().VirtualServices(vservice.Namespace).UpdateStatus(vservice)
-		return err
-	}
-	return nil
-}
-
-func checkVServiceActive(vservice *appmeshv1alpha1.VirtualService) bool {
-	condition := getVServiceCondition(appmeshv1alpha1.VirtualServiceActive, vservice.Status)
-	return condition != nil && condition.Status == api.ConditionTrue
-}
-
-func getVServiceCondition(conditionType appmeshv1alpha1.VirtualServiceConditionType, status *appmeshv1alpha1.VirtualServiceStatus) *appmeshv1alpha1.VirtualServiceCondition {
-	if status != nil {
-		for _, condition := range status.Conditions {
-			if condition.Type == conditionType {
-				return &condition
-			}
+func getVServiceCondition(conditionType appmeshv1alpha1.VirtualServiceConditionType, status appmeshv1alpha1.VirtualServiceStatus) appmeshv1alpha1.VirtualServiceCondition {
+	for _, condition := range status.Conditions {
+		if condition.Type == conditionType {
+			return condition
 		}
 	}
-	return nil
+
+	return appmeshv1alpha1.VirtualServiceCondition{}
 }
 
 func getVirtualRouter(vservice *appmeshv1alpha1.VirtualService) *appmeshv1alpha1.VirtualRouter {
@@ -217,12 +272,14 @@ func (c *Controller) updateRoutes(ctx context.Context, meshName string, routerNa
 			if routeNeedsUpdate(d, e) {
 				if _, err := c.cloud.UpdateRoute(ctx, &d, routerName, meshName); err != nil {
 					routeNamesWithErrors = append(routeNamesWithErrors, d.Name)
+					klog.Errorf("Error updating route %s: %s", d.Name, err)
 				}
 			}
 		} else {
 			// Create route because no existing route exists by the desired name
 			if _, err := c.cloud.CreateRoute(ctx, &d, routerName, meshName); err != nil {
 				routeNamesWithErrors = append(routeNamesWithErrors, d.Name)
+				klog.Errorf("Error creating route %s: %s", d.Name, err)
 			}
 		}
 	}
@@ -231,13 +288,24 @@ func (c *Controller) updateRoutes(ctx context.Context, meshName string, routerNa
 		if !desiredNames.Contains(ex.Name()) {
 			if _, err := c.cloud.DeleteRoute(ctx, ex.Name(), routerName, meshName); err != nil {
 				routeNamesWithErrors = append(routeNamesWithErrors, ex.Name())
+				klog.Errorf("Error deleting route %s: %s", ex.Name, err)
 			}
 		}
 	}
+
 	if len(routeNamesWithErrors) > 0 {
 		return fmt.Errorf("error updating routes: %s", strings.Join(routeNamesWithErrors, " "))
 	}
 	return nil
+}
+
+func allRoutesActive(routes aws.Routes) bool {
+	for _, r := range routes {
+		if r.Status() != appmesh.RouteStatusCodeActive {
+			return false
+		}
+	}
+	return true
 }
 
 func routeNeedsUpdate(desired appmeshv1alpha1.Route, target aws.Route) bool {
@@ -255,4 +323,75 @@ func routeNeedsUpdate(desired appmeshv1alpha1.Route, target aws.Route) bool {
 		return true
 	}
 	return false
+}
+
+func (c *Controller) handleVServiceDelete(ctx context.Context, vservice *appmeshv1alpha1.VirtualService) error {
+	if yes, _ := containsFinalizer(vservice, virtualServiceDeletionFinalizerName); yes {
+
+		if err := c.deleteVServiceResources(ctx, vservice); err != nil {
+			return err
+		}
+
+		if err := removeFinalizer(vservice, virtualServiceDeletionFinalizerName); err != nil {
+			return fmt.Errorf("error removing finalizer %s to virtual service %s during deletion: %s", virtualServiceDeletionFinalizerName, vservice.Name, err)
+		}
+		if err := c.updateVServiceResource(vservice); err != nil {
+			return fmt.Errorf("error removing finalizer %s to virtual service %s during deletion: %s", virtualServiceDeletionFinalizerName, vservice.Name, err)
+		}
+	}
+	return nil
+}
+
+func (c *Controller) handleVServiceMeshDeleting(ctx context.Context, vservice *appmeshv1alpha1.VirtualService) (processVService bool) {
+	meshName, meshNamespace := parseMeshName(vservice.Spec.MeshName, vservice.Namespace)
+	mesh, err := c.meshLister.Meshes(meshNamespace).Get(meshName)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// If mesh doesn't exist, do nothing
+			klog.Infof("mesh doesn't exist, skipping processing virtual service %s", vservice.Name)
+		} else {
+			klog.Errorf("error getting mesh: %s", err)
+		}
+		return false
+	}
+
+	// if mesh DeletionTimestamp is set, clean up virtual service via App Mesh API
+	if !mesh.DeletionTimestamp.IsZero() {
+		if err := c.deleteVServiceResources(ctx, vservice); err != nil {
+			klog.Error(err)
+		} else {
+			klog.Infof("Deleted resources for virtual service %s because mesh %s is being deleted", vservice.Name, vservice.Spec.MeshName)
+		}
+		return false
+	}
+	return true
+}
+
+func (c *Controller) deleteVServiceResources(ctx context.Context, vservice *appmeshv1alpha1.VirtualService) error {
+	// Cleanup routes
+	for _, r := range vservice.Spec.Routes {
+		if _, err := c.cloud.DeleteRoute(ctx, r.Name, vservice.Spec.VirtualRouter.Name, vservice.Spec.MeshName); err != nil {
+			if !aws.IsAWSErrNotFound(err) {
+				return fmt.Errorf("failed to clean up route %s for virtual service %s during deletion: %s", r.Name, vservice.Name, err)
+			}
+		}
+	}
+
+	// TODO(nic): if we support a force delete, we can delete the rest of the routes attached to the virtual router here
+
+	// Cleanup virtual service
+	if _, err := c.cloud.DeleteVirtualService(ctx, vservice.Name, vservice.Spec.MeshName); err != nil {
+		if !aws.IsAWSErrNotFound(err) {
+			return fmt.Errorf("failed to clean up virtual service %s during deletion: %s", vservice.Name, err)
+		}
+	}
+
+	// Cleanup virtual router
+	if _, err := c.cloud.DeleteVirtualRouter(ctx, vservice.Spec.VirtualRouter.Name, vservice.Spec.MeshName); err != nil {
+		if !aws.IsAWSErrNotFound(err) {
+			return fmt.Errorf("failed to clean up virtual router %s for virtual service %s during deletion: %s", vservice.Spec.VirtualRouter.Name, vservice.Name, err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
- [x] Uses a finalizer to implement a delete hook.
- [x] When custom resource is deleted, clean up corresponding objects in App Mesh.
  - [x] Virtual Node -> Virtual Node.
  - [x] Virtual Service -> Virtual Service, Virtual Router, Routes.
  - [x] Mesh -> Mesh, and all resources in the mesh.
  - [x] Do not process virtual nodes, virtual services when the mesh doesn't exist or is deleting.
- [ ] Status should reflect the current state of the object in App Mesh.
  - [x] Condition for Mesh Deleting on Virtual Nodes, Virtual Services.
  - [ ] ARN of resources in status.
  - [ ] Resources shouldn't be active when they have been deleted.
  - [x] Update conditions based on describe.
    - [x] Virtual Service
    - [x] Virtual Node
    - [x] Mesh
- [ ] Unit tests
- [ ] Godocs

*Issue #, if available:*
#10, #11

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
