### PR TITLE
Don't fail to delete VS when VR is shared

### DIFF
--- a/examples/color.yaml
+++ b/examples/color.yaml
@@ -30,7 +30,7 @@ spec:
       hostName: colorgateway.appmesh-demo.svc.cluster.local
   backends:
     - virtualService:
-        virtualServiceName: colorteller.appmesh-demo.svc.cluster.local
+        virtualServiceName: colorteller
 ---
 apiVersion: appmesh.k8s.aws/v1alpha1
 kind: VirtualNode
@@ -95,7 +95,7 @@ spec:
 apiVersion: appmesh.k8s.aws/v1alpha1
 kind: VirtualService
 metadata:
-  name: colorteller.appmesh-demo.svc.cluster.local
+  name: colorteller
   namespace: appmesh-demo
 spec:
   meshName: color-mesh
@@ -118,7 +118,7 @@ spec:
 apiVersion: appmesh.k8s.aws/v1alpha1
 kind: VirtualService
 metadata:
-  name: colorgateway.appmesh-demo.svc.cluster.local
+  name: colorgateway
   namespace: appmesh-demo
 spec:
   meshName: color-mesh
@@ -174,7 +174,7 @@ spec:
             - name: "SERVER_PORT"
               value: "9080"
             - name: "COLOR_TELLER_ENDPOINT"
-              value: "colorteller.appmesh-demo.svc.cluster.local:9080"
+              value: "colorteller:9080"
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/aws/appmesh.go
+++ b/pkg/aws/appmesh.go
@@ -864,8 +864,18 @@ func (c *Cloud) DeleteRoute(ctx context.Context, name string, routerName string,
 func IsAWSErrNotFound(err error) bool {
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case appmesh.ErrCodeNotFoundException:
+			if aerr.Code() == appmesh.ErrCodeNotFoundException {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func IsAWSErrResourceInUse(err error) bool {
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == appmesh.ErrCodeResourceInUseException {
 				return true
 			}
 		}


### PR DESCRIPTION
* If two virtual services share a virtual router, we shouldn't fail
  to delete the virtual service when the virtual router returns a
  resource in use exception.
* Also use short service names in example because they are not
  resolved by envoy, only the application.

*Issue #, if available:*
#25 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
