### PR TITLE
Remove broken makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,9 @@ push-release:
 	docker tag $(IMAGE):$(VERSION) $(REPO):$(VERSION)
 	docker push $(REPO):$(VERSION)
 
-.PHONY: deploy-k8s-dev
-deploy-k8s-dev:
+.PHONY: deploy
+deploy:
 	./scripts/deploy.sh
-
-.PHONY: deploy-k8s-release
-deploy-k8s-release:
-	kubectl apply -f ./deploy/$(VERSION)
 
 .PHONY: example
 example:


### PR DESCRIPTION
The versioned directories in ./deploy were removed so this removes the makefile target that relied on them. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
