### PR TITLE
Update installation instruction for aws-app-mesh-inject

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,11 +5,11 @@ Although the controller can be used independently from the aws-app-mesh-inject w
 ```bash
 # use `export MESH_NAME=color-mesh` to work with the example in this repository.
 export MESH_NAME="<my-mesh-name>"
-curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/v0.1.5/scripts/install.sh | bash
+curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/scripts/install.sh | bash
 ```
 
 This will launch the webhook into the appmesh-inject namespace. Now add the correct permissions to your worker nodes (or your pod identity solution, like kube2iam):
-
+```json
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -46,6 +46,7 @@ This will launch the webhook into the appmesh-inject namespace. Now add the corr
             }
         ]
     }
+```
 
 Next, launch the controller:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,43 +9,44 @@ curl https://raw.githubusercontent.com/aws/aws-app-mesh-inject/master/scripts/in
 ```
 
 This will launch the webhook into the appmesh-inject namespace. Now add the correct permissions to your worker nodes (or your pod identity solution, like kube2iam):
+
 ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "appmesh:DescribeMesh",
-                    "appmesh:DescribeVirtualNode",
-                    "appmesh:DescribeVirtualService",
-                    "appmesh:DescribeVirtualRouter",
-                    "appmesh:DescribeRoute",
-                    "appmesh:CreateMesh",
-                    "appmesh:CreateVirtualNode",
-                    "appmesh:CreateVirtualService",
-                    "appmesh:CreateVirtualRouter",
-                    "appmesh:CreateRoute",
-                    "appmesh:UpdateMesh",
-                    "appmesh:UpdateVirtualNode",
-                    "appmesh:UpdateVirtualService",
-                    "appmesh:UpdateVirtualRouter",
-                    "appmesh:UpdateRoute",
-                    "appmesh:ListMeshes",
-                    "appmesh:ListVirtualNodes",
-                    "appmesh:ListVirtualServices",
-                    "appmesh:ListVirtualRouters",
-                    "appmesh:ListRoutes",
-                    "appmesh:DeleteMesh",
-                    "appmesh:DeleteVirtualNode",
-                    "appmesh:DeleteVirtualService",
-                    "appmesh:DeleteVirtualRouter",
-                    "appmesh:DeleteRoute"
-                ],
-                "Resource": "*"
-            }
-        ]
-    }
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "appmesh:DescribeMesh",
+                "appmesh:DescribeVirtualNode",
+                "appmesh:DescribeVirtualService",
+                "appmesh:DescribeVirtualRouter",
+                "appmesh:DescribeRoute",
+                "appmesh:CreateMesh",
+                "appmesh:CreateVirtualNode",
+                "appmesh:CreateVirtualService",
+                "appmesh:CreateVirtualRouter",
+                "appmesh:CreateRoute",
+                "appmesh:UpdateMesh",
+                "appmesh:UpdateVirtualNode",
+                "appmesh:UpdateVirtualService",
+                "appmesh:UpdateVirtualRouter",
+                "appmesh:UpdateRoute",
+                "appmesh:ListMeshes",
+                "appmesh:ListVirtualNodes",
+                "appmesh:ListVirtualServices",
+                "appmesh:ListVirtualRouters",
+                "appmesh:ListRoutes",
+                "appmesh:DeleteMesh",
+                "appmesh:DeleteVirtualNode",
+                "appmesh:DeleteVirtualService",
+                "appmesh:DeleteVirtualRouter",
+                "appmesh:DeleteRoute"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
 ```
 
 Next, launch the controller:


### PR DESCRIPTION
*Issue*
* aws-app-mesh-inject  `v0.1.5` does not work with EKS v1.13.x. A new version has been released (V0.1.6) that fixed the problem.
* The aws-app-mesh-inject project now uses the `master` branch in the installation instruction.
* @geremyCohen created a PR to the official AWS doc to deploy the aws-app-mesh-inject using the `master` branch.
* With this PR I would like to align the controller documentation with the inject documentation and the soon to be released AWS official documentation for aws-app-mesh (PR).

*Description of changes:*
* I replaced `v.0.1.5` by `master` in the URL used to deploy `aws-app-mesh-inject`
* I updated the format of the policy to json (minor visual change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
