### PR TITLE
Disambiguate router names in example

### DIFF
--- a/examples/color.yaml.template
+++ b/examples/color.yaml.template
@@ -103,6 +103,7 @@ metadata:
 spec:
   meshName: ${MESH_NAME}
   virtualRouter:
+    name: color-router
     listeners:
       - portMapping:
           port: 9080
@@ -129,12 +130,13 @@ metadata:
 spec:
   meshName: ${MESH_NAME}
   virtualRouter:
+    name: gateway-router
     listeners:
       - portMapping:
           port: 9080
           protocol: http
   routes:
-    - name: color-route
+    - name: gateway-route
       http:
         match:
           prefix: /color
@@ -390,6 +392,7 @@ metadata:
 spec:
   meshName: ${MESH_NAME}
   virtualRouter:
+    name: tcpecho-router
     listeners:
       - portMapping:
           port: 2701


### PR DESCRIPTION
*Description of changes:*

The current example template referenced in https://github.com/aws/aws-app-mesh-examples/blob/master/walkthroughs/eks/base.md has an error that results in the colorteller virtual router mapping to the color gateway's route.

This change disambiguates the routers and routes by naming the routers accordingly.

Are router names intended to be optional in the controller? If so, there is a broader bug here that warrants a separate pull request.

*Testing:*
Followed the guide at the walkthrough link above, observed 500 error and invalid router to route mapping in App Mesh configuration. Updated with proposed changes and mapping works as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
