### PR TITLE
Use Virtual Service name for Virtual Router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ LDFLAGS?="-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.bui
 GO111MODULE=on
 # Docker
 IMAGE=amazon/app-mesh-controller
-REGION=$(shell aws configure get region)
 REPO=$(AWS_ACCOUNT).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE)
 VERSION=v0.1.2
 

--- a/examples/color.yaml.template
+++ b/examples/color.yaml.template
@@ -103,7 +103,6 @@ metadata:
 spec:
   meshName: ${MESH_NAME}
   virtualRouter:
-    name: color-router
     listeners:
       - portMapping:
           port: 9080
@@ -130,7 +129,6 @@ metadata:
 spec:
   meshName: ${MESH_NAME}
   virtualRouter:
-    name: gateway-router
     listeners:
       - portMapping:
           port: 9080
@@ -392,7 +390,6 @@ metadata:
 spec:
   meshName: ${MESH_NAME}
   virtualRouter:
-    name: tcpecho-router
     listeners:
       - portMapping:
           port: 2701

--- a/pkg/aws/appmesh.go
+++ b/pkg/aws/appmesh.go
@@ -507,16 +507,11 @@ func (c *Cloud) CreateVirtualService(ctx context.Context, vservice *appmeshv1bet
 		Spec: &appmesh.VirtualServiceSpec{
 			Provider: &appmesh.VirtualServiceProvider{
 				// We only support virtual router providers for now
-				VirtualRouter: &appmesh.VirtualRouterServiceProvider{},
+				VirtualRouter: &appmesh.VirtualRouterServiceProvider{
+					VirtualRouterName: aws.String(vservice.Spec.VirtualRouter.Name),
+				},
 			},
 		},
-	}
-
-	if vservice.Spec.VirtualRouter != nil {
-		input.Spec.Provider.VirtualRouter.VirtualRouterName = aws.String(vservice.Spec.VirtualRouter.Name)
-	} else {
-		// We default to a virtual router with the same name as the virtual service
-		input.Spec.Provider.VirtualRouter.VirtualRouterName = aws.String(vservice.Name)
 	}
 
 	if output, err := c.appmesh.CreateVirtualServiceWithContext(ctx, input); err != nil {
@@ -540,16 +535,11 @@ func (c *Cloud) UpdateVirtualService(ctx context.Context, vservice *appmeshv1bet
 		Spec: &appmesh.VirtualServiceSpec{
 			Provider: &appmesh.VirtualServiceProvider{
 				// We only support virtual router providers for now
-				VirtualRouter: &appmesh.VirtualRouterServiceProvider{},
+				VirtualRouter: &appmesh.VirtualRouterServiceProvider{
+					VirtualRouterName: aws.String(vservice.Spec.VirtualRouter.Name),
+				},
 			},
 		},
-	}
-
-	if vservice.Spec.VirtualRouter != nil {
-		input.Spec.Provider.VirtualRouter.VirtualRouterName = aws.String(vservice.Spec.VirtualRouter.Name)
-	} else {
-		// We default to a virtual router with the same name as the virtual service
-		input.Spec.Provider.VirtualRouter.VirtualRouterName = aws.String(vservice.Name)
 	}
 
 	if output, err := c.appmesh.UpdateVirtualServiceWithContext(ctx, input); err != nil {


### PR DESCRIPTION
*Issue #, if available:* #69

*Description of changes:*

Fix for the behavior that should default to the Virtual Service's name if the Virtual Router is not given an explicit name.

*Testing:*

Tested via `make example`. I noticed the app mesh object does not have unit tests. Is the appropriate place [here](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/pkg/controller/virtualservice_test.go)?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
