### PR TITLE
Fix documentation to highlight breaking CRD change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ deploy:
 example:
 	./scripts/example.sh
 
+.PHONY: release-example-gen
+release-example-gen:
+	RELEASE=1 ./scripts/example.sh
+
 .PHONY: clean
 clean:
 	rm -rf ./_output

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First, create a Mesh resource, which will trigger the controller to create a Mes
       meshName: my-mesh
       listeners:
         - portMapping:
-            port: 9000
+            port: 9080
             protocol: http
       serviceDiscovery:
         dns:
@@ -52,6 +52,12 @@ First, create a Mesh resource, which will trigger the controller to create a Mes
       namespace: prod
     spec:
       meshName: my-mesh
+      virtualRouter:
+        name: my-svc-a-router
+        listeners:
+          - portMapping:
+              port: 9080
+              protocol: http
       routes:
         - name: route-to-svc-a
           http:

--- a/docs/design.md
+++ b/docs/design.md
@@ -75,6 +75,12 @@ metadata:
   name: colorteller.appmesh-demo.svc.cluster.local
   namespace: appmesh-demo
 spec:
+  virtualRouter:
+    name: color-router
+    listeners:
+    - portMapping:
+        port: 9080
+        protocol: http
   routes:
   - http:
       action:

--- a/docs/example.md
+++ b/docs/example.md
@@ -71,6 +71,12 @@ For example, change the traffic to only forward to black.
 ```bash
 spec:
   meshName: color-mesh
+  virtualRouter:
+    name: color-router
+    listeners:
+    - portMapping:
+        port: 9080
+        protocol: http
   routes:
   - http:
       action:

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,6 +53,8 @@ This will launch the webhook into the appmesh-inject namespace. Now add the corr
 
 Next, launch the controller:
 
+```
+
 ```bash
 curl https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/v0.1.2/deploy/all.yaml | kubectl apply -f -
 ```
@@ -61,6 +63,35 @@ Make sure it's ready:
 
 ```bash
 kubectl rollout status deployment app-mesh-controller -n appmesh-system
+```
+
+__IMPORTANT NOTE__: If you are using older versions (prior v0.1.2) of controller and have existing CRDs, then you need to update the virtualservice CRD specs to include virtualRouter and its listener as shown below.
+```
+spec:
+  meshName: color-mesh
+  routes:
+  - http:
+      action:
+        weightedTargets:
+        - virtualNodeName: colorteller.appmesh-demo
+          weight: 1
+```
+should change to
+```
+spec:
+  meshName: color-mesh
+  virtualRouter:
+    name: color-router
+    listeners:
+    - portMapping:
+        port: 9080
+        protocol: http
+  routes:
+  - http:
+      action:
+        weightedTargets:
+        - virtualNodeName: colorteller.appmesh-demo
+          weight: 1
 ```
 
 Now try following along with [the example](example.md) to get a feel for how it works!

--- a/examples/color.yaml
+++ b/examples/color.yaml
@@ -1,0 +1,469 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    appmesh.k8s.aws/sidecarInjectorWebhook: enabled
+  name: appmesh-demo
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: Mesh
+metadata:
+  name: color-mesh
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: colorgateway
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  listeners:
+    - portMapping:
+        port: 9080
+        protocol: http
+  serviceDiscovery:
+    dns:
+      hostName: colorgateway.appmesh-demo.svc.cluster.local
+  backends:
+    - virtualService:
+        virtualServiceName: colorteller.appmesh-demo
+    - virtualService:
+        virtualServiceName: tcpecho.appmesh-demo
+  logging:
+    accessLog:
+      file:
+        path: /dev/stdout
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: colorteller
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  listeners:
+    - portMapping:
+        port: 9080
+        protocol: http
+  serviceDiscovery:
+    dns:
+      hostName: colorteller.appmesh-demo.svc.cluster.local
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: colorteller-black
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  listeners:
+    - portMapping:
+        port: 9080
+        protocol: http
+  serviceDiscovery:
+    dns:
+      hostName: colorteller-black.appmesh-demo.svc.cluster.local
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: colorteller-blue
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  listeners:
+    - portMapping:
+        port: 9080
+        protocol: http
+  serviceDiscovery:
+    dns:
+      hostName: colorteller-blue.appmesh-demo.svc.cluster.local
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: colorteller-red
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  listeners:
+    - portMapping:
+        port: 9080
+        protocol: http
+  serviceDiscovery:
+    dns:
+      hostName: colorteller-red.appmesh-demo.svc.cluster.local
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualService
+metadata:
+  name: colorteller.appmesh-demo
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  virtualRouter:
+    name: color-router
+    listeners:
+      - portMapping:
+          port: 9080
+          protocol: http
+  routes:
+    - name: color-route
+      http:
+        match:
+          prefix: /
+        action:
+          weightedTargets:
+            - virtualNodeName: colorteller
+              weight: 1
+            - virtualNodeName: colorteller-blue
+              weight: 1
+            - virtualNodeName: colorteller-black
+              weight: 1
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualService
+metadata:
+  name: colorgateway.appmesh-demo
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  virtualRouter:
+    name: gateway-router
+    listeners:
+      - portMapping:
+          port: 9080
+          protocol: http
+  routes:
+    - name: gateway-route
+      http:
+        match:
+          prefix: /color
+        action:
+          weightedTargets:
+            - virtualNodeName: colorgateway
+              weight: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: colorgateway
+  namespace: appmesh-demo
+  labels:
+    app: colorgateway
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: colorgateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: colorgateway
+  namespace: appmesh-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: colorgateway
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: colorgateway
+        version: v1
+    spec:
+      containers:
+        - name: colorgateway
+          image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/gateway:latest
+          ports:
+            - containerPort: 9080
+          env:
+            - name: "SERVER_PORT"
+              value: "9080"
+            - name: "COLOR_TELLER_ENDPOINT"
+              value: "colorteller.appmesh-demo:9080"
+            - name: "TCP_ECHO_ENDPOINT"
+              value: "tcpecho.appmesh-demo:2701"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: colorteller
+  namespace: appmesh-demo
+  labels:
+    app: colorteller
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: colorteller
+    version: white
+---
+
+# white
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: colorteller
+  namespace: appmesh-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: colorteller
+      version: white
+  template:
+    metadata:
+      labels:
+        app: colorteller
+        version: white
+    spec:
+      containers:
+        - name: colorteller
+          image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest
+          ports:
+            - containerPort: 9080
+          env:
+            - name: "SERVER_PORT"
+              value: "9080"
+            - name: "COLOR"
+              value: "white"
+---
+# black
+apiVersion: v1
+kind: Service
+metadata:
+  name: colorteller-black
+  namespace: appmesh-demo
+  labels:
+    app: colorteller
+    version: black
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: colorteller
+    version: black
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: colorteller-black
+  namespace: appmesh-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: colorteller
+      version: black
+  template:
+    metadata:
+      labels:
+        app: colorteller
+        version: black
+    spec:
+      containers:
+        - name: colorteller
+          image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest
+          ports:
+            - containerPort: 9080
+          env:
+            - name: "SERVER_PORT"
+              value: "9080"
+            - name: "COLOR"
+              value: "black"
+---
+# blue
+apiVersion: v1
+kind: Service
+metadata:
+  name: colorteller-blue
+  namespace: appmesh-demo
+  labels:
+    app: colorteller
+    version: blue
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: colorteller
+    version: blue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: colorteller-blue
+  namespace: appmesh-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: colorteller
+      version: blue
+  template:
+    metadata:
+      labels:
+        app: colorteller
+        version: blue
+    spec:
+      containers:
+        - name: colorteller
+          image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest
+          ports:
+            - containerPort: 9080
+          env:
+            - name: "SERVER_PORT"
+              value: "9080"
+            - name: "COLOR"
+              value: "blue"
+---
+# red
+apiVersion: v1
+kind: Service
+metadata:
+  name: colorteller-red
+  namespace: appmesh-demo
+  labels:
+    app: colorteller
+    version: red
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: colorteller
+    version: red
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: colorteller-red
+  namespace: appmesh-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: colorteller
+      version: red
+  template:
+    metadata:
+      labels:
+        app: colorteller
+        version: red
+    spec:
+      containers:
+        - name: colorteller
+          image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest
+          ports:
+            - containerPort: 9080
+          env:
+            - name: "SERVER_PORT"
+              value: "9080"
+            - name: "COLOR"
+              value: "red"
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: tcpecho
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  listeners:
+    - portMapping:
+        port: 2701
+        protocol: tcp
+  serviceDiscovery:
+    dns:
+      hostName: tcpecho.appmesh-demo.svc.cluster.local
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualService
+metadata:
+  name: tcpecho.appmesh-demo
+  namespace: appmesh-demo
+spec:
+  meshName: color-mesh
+  virtualRouter:
+    name: tcpecho-router
+    listeners:
+      - portMapping:
+          port: 2701
+          protocol: tcp
+  routes:
+    - name: tcpecho-route
+      tcp:
+        action:
+          weightedTargets:
+            - virtualNodeName: tcpecho
+              weight: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcpecho
+  namespace: appmesh-demo
+  labels:
+    app: tcpecho
+spec:
+  ports:
+    - protocol: "TCP"
+      port: 2701
+      targetPort: 2701
+  selector:
+    app: tcpecho
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcpecho
+  namespace: appmesh-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcpecho
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: tcpecho
+        version: v1
+    spec:
+      containers:
+        - name: tcpecho
+          image: cjimti/go-echo
+          ports:
+            - name: tcp-echo-port
+              containerPort: 2701
+          env:
+            - name: TCP_PORT
+              value: "2701"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+---

--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -2,33 +2,30 @@
 
 set -e
 
-if [ -z "${AWS_ACCOUNT}" ]; then
-    echo "AWS_ACCOUNT must be set."
-    exit 1
-fi
-
-if [ -z "${AWS_REGION}" ]; then
-    echo "AWS_REGION must be set."
-    exit 1
-fi
-
-if [ -z "${MESH_NAME}" ]; then
-    echo "MESH_NAME must be set."
-    exit 1
-fi
-
-APP_NAMESPACE=${APP_NAMESPACE:-"appmesh-demo"}
-
 DIR=$(cd "$(dirname "$0")"; pwd)/..
-EXAMPLES_OUT_DIR="${DIR}/_output/examples/"
-mkdir -p ${EXAMPLES_OUT_DIR}
 
-COLOR_GATEWAY_IMAGE=${COLOR_GATEWAY_IMAGE:-"970805265562.dkr.ecr.us-west-2.amazonaws.com/gateway:latest"}
-COLOR_TELLER_IMAGE=${COLOR_TELLER_IMAGE:-"970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest"}
+if [ -z "${RELEASE}" ]; then
+    MESH_NAME=${MESH_NAME:-"color-mesh"}
+    APP_NAMESPACE=${APP_NAMESPACE:-"appmesh-demo"}
+    COLOR_GATEWAY_IMAGE=${COLOR_GATEWAY_IMAGE:-"970805265562.dkr.ecr.us-west-2.amazonaws.com/gateway:latest"}
+    COLOR_TELLER_IMAGE=${COLOR_TELLER_IMAGE:-"970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest"}
+    EXAMPLES_OUT_DIR=${EXAMPLES_OUT_DIR:-"${DIR}/_output/examples/"}
+    mkdir -p ${EXAMPLES_OUT_DIR}
+else
+    MESH_NAME="color-mesh"
+    APP_NAMESPACE="appmesh-demo"
+    COLOR_GATEWAY_IMAGE="970805265562.dkr.ecr.us-west-2.amazonaws.com/gateway:latest"
+    COLOR_TELLER_IMAGE="970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest"
+    EXAMPLES_OUT_DIR="${DIR}/examples/"
+fi
 
 eval "cat <<EOF
 $(<${DIR}/examples/color.yaml.template)
 EOF
 " > ${EXAMPLES_OUT_DIR}/color.yaml
 
-kubectl apply -f ${EXAMPLES_OUT_DIR}/color.yaml
+if [ -z "${RELEASE}" ]; then
+    kubectl apply -f ${EXAMPLES_OUT_DIR}/color.yaml
+    exit 0
+fi
+


### PR DESCRIPTION
*Issue #, if available:*
#63, #62 

*Description of changes:*
Non backward behavior was introduced to virtual-service CRD that adds a new required field virtual-router as dictated by App Mesh API. This broke existing CRD and examples elsewhere lingering on the web. Any users using latest controller (v0.1.2+) with old CRDs will face this problem and will be unable to create virtual-services.

This change updates docs to highlight this problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
