### PR TITLE
Add enum to httpRetryEvents

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -323,6 +323,11 @@ spec:
                             type: array
                             items:
                               type: string
+                              enum:
+                                - 'server-error' # HTTP status codes 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, and 511
+                                - 'gateway-error' # HTTP status codes 502, 503, and 504
+                                - 'client-error' # HTTP status code 409
+                                - 'stream-error' # Retry on refused stream
                           tcpRetryEvents:
                             type: array
                             items:

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,8 +53,6 @@ This will launch the webhook into the appmesh-inject namespace. Now add the corr
 
 Next, launch the controller:
 
-```
-
 ```bash
 curl https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/v0.1.2/deploy/all.yaml | kubectl apply -f -
 ```

--- a/examples/color.yaml
+++ b/examples/color.yaml
@@ -103,7 +103,6 @@ metadata:
 spec:
   meshName: color-mesh
   virtualRouter:
-    name: color-router
     listeners:
       - portMapping:
           port: 9080
@@ -130,7 +129,6 @@ metadata:
 spec:
   meshName: color-mesh
   virtualRouter:
-    name: gateway-router
     listeners:
       - portMapping:
           port: 9080
@@ -392,7 +390,6 @@ metadata:
 spec:
   meshName: color-mesh
   virtualRouter:
-    name: tcpecho-router
     listeners:
       - portMapping:
           port: 2701


### PR DESCRIPTION
*Description of changes:*
* Add HTTP retry policy to the example.
* Add enum to `httpRetryEvents`.
* Fix docs formatting bug.
* Regenerate example (removes explicit router names).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
