### PR TITLE
Fix Prometheus scraping, enable pprof and update to go 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM golang:1.12-stretch as builder
+FROM golang:1.13-stretch as builder
 WORKDIR /go/src/github.com/aws/aws-app-mesh-controller-for-k8s
-
-# Force the go compiler to use modules.
-ENV GO111MODULE=on
 
 # go.mod and go.sum go into their own layers.
 COPY go.mod .

--- a/cmd/app-mesh-controller/root.go
+++ b/cmd/app-mesh-controller/root.go
@@ -135,7 +135,7 @@ type controllerConfig struct {
 
 func getConfig() (controllerConfig, error) {
 	viper.SetDefault("master", "")
-	viper.SetDefault("listenAddress", "127.0.0.1:10555")
+	viper.SetDefault("listenAddress", ":10555")
 
 	return controllerConfig{
 		client: controller.ClientOptions{

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/aws/aws-app-mesh-controller-for-k8s
 
+go 1.13
+
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/aws/aws-sdk-go v1.23.18

--- a/pkg/controller/server.go
+++ b/pkg/controller/server.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"fmt"
 	"net/http"
-	"time"
+	_ "net/http/pprof"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -12,20 +12,18 @@ type Handler struct {
 	http.ServeMux
 }
 
-func newHandler() *Handler {
-	h := &Handler{}
-	h.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+func newHandler() *http.ServeMux {
+	mux := http.DefaultServeMux
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
-	h.Handle("/metrics", promhttp.Handler())
-	return h
+	mux.Handle("/metrics", promhttp.Handler())
+	return mux
 }
 
 func NewServer(cfg ServerOptions) *http.Server {
 	return &http.Server{
-		Handler:      newHandler(),
-		Addr:         cfg.Address,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 5 * time.Second,
+		Handler: newHandler(),
+		Addr:    cfg.Address,
 	}
 }


### PR DESCRIPTION
This PR binds the controller server on all IPs so that Prometheus can scrape the `/metrics` endpoint and enables profiling:

```sh
kubectl -n appmesh-system port-forward deploy/appmesh-controller 10555:10555

go tool pprof http://localhost:10555/debug/pprof/profile
```

Fix: #79
Fix: #80
Fix: #83

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
