### PR TITLE
Add go fmt check to CI and fix code formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
           keys:
             - go-mod-{{ checksum "go.sum" }}
       - run:
+          name: Lint
+          command: make go-fmt
+      - run:
           name: Build
           command: make linux
       - run:

--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,6 @@ test:
 
 cover: test
 	go tool cover -html=coverage-all.out
+
+go-fmt:
+	gofmt -l pkg/* | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi;

--- a/pkg/aws/cloudmap.go
+++ b/pkg/aws/cloudmap.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/klog"
-
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/appmesh"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 )
 
 const (

--- a/pkg/aws/config.go
+++ b/pkg/aws/config.go
@@ -1,7 +1,5 @@
 package aws
 
-import ()
-
 type CloudOptions struct {
 	Region string
 }

--- a/pkg/controller/virtualnode_test.go
+++ b/pkg/controller/virtualnode_test.go
@@ -6,15 +6,16 @@ import (
 	"strings"
 	"testing"
 
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/stretchr/testify/mock"
+
 	appmeshv1beta1 "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/apis/appmesh/v1beta1"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws"
 	ctrlawsmocks "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/mocks"
 	appmeshv1beta1mocks "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/client/clientset/versioned/mocks"
 	appmeshv1beta1typedmocks "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/client/clientset/versioned/typed/appmesh/v1beta1/mocks"
-	awssdk "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/appmesh"
-	"github.com/aws/aws-sdk-go/service/servicediscovery"
-	"github.com/stretchr/testify/mock"
 )
 
 // newAWSVirtualNode is a helper function to generate an Kubernetes Custom Resource API object.
@@ -141,7 +142,6 @@ func newAWSVirtualNodeWithCloudMap(ports []int64, protocols []string, backends [
 }
 
 func TestVNodeNeedsUpdate(t *testing.T) {
-
 	var (
 		// defaults
 		port80       int64 = 80

--- a/pkg/controller/virtualservice_test.go
+++ b/pkg/controller/virtualservice_test.go
@@ -5,15 +5,16 @@ import (
 	"reflect"
 	"testing"
 
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	appmeshv1beta1 "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/apis/appmesh/v1beta1"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws"
 	ctrlawsmocks "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/mocks"
 	appmeshv1beta1mocks "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/client/clientset/versioned/mocks"
 	appmeshv1beta1typedmocks "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/client/clientset/versioned/typed/appmesh/v1beta1/mocks"
-	awssdk "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/appmesh"
-	"github.com/stretchr/testify/mock"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // newAWSVirtualService is a helper function to generate an Kubernetes Custom Resource API object.


### PR DESCRIPTION
This PR adds `go fmt` check job to CI, it will fail the build if a PR contains malformatted code. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
