### PR TITLE
Fixed example issues

### DIFF
--- a/examples/color.yaml
+++ b/examples/color.yaml
@@ -103,11 +103,11 @@ spec:
           prefix: /
         action:
           weightedTargets:
-            - virtualNodeName: colorteller.appmesh-demo
+            - virtualNodeName: colorteller
               weight: 1
             - virtualNodeName: colorteller-blue
               weight: 1
-            - virtualNodeName: colorteller-black.appmesh-demo
+            - virtualNodeName: colorteller-black
               weight: 1
 ---
 apiVersion: appmesh.k8s.aws/v1beta1


### PR DESCRIPTION
Removed ".appmesh-demo" from the VirtualNode names on the routes, this was causing issues and the VirtualService was not being created

*Issue #, if available:*
colorteller.appmesh-demo VirtualService was not being created because of issues on the configuration file

*Description of changes:*
Removed ".appmesh-demo" from the VirtualNode names on the routes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
