### PR TITLE
Implement Prometheus instrumentation 

### DIFF
--- a/cmd/app-mesh-controller/root.go
+++ b/cmd/app-mesh-controller/root.go
@@ -15,16 +15,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 
-	// TODO(nic) Don't depend on k8s.io/kubernetes, just duplicate the logic in this package -- it will be a
-	// smaller headache.
-	//_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
-	//_ "k8s.io/kubernetes/pkg/util/reflector/prometheus" // for reflector metric registration
-	//_ "k8s.io/kubernetes/pkg/util/workqueue/prometheus" // for workqueue metric registration
-
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws"
 	meshclientset "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/client/clientset/versioned"
 	meshinformers "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/client/informers/externalversions"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/controller"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/metrics"
 )
 
 var (
@@ -89,7 +84,8 @@ var rootCmd = &cobra.Command{
 			klog.Fatal(err)
 		}
 
-		cloud, err := aws.NewCloud(cfg.aws)
+		stats := metrics.NewRecorder(true)
+		cloud, err := aws.NewCloud(cfg.aws, stats)
 		if err != nil {
 			klog.Fatal(err)
 		}
@@ -117,6 +113,7 @@ var rootCmd = &cobra.Command{
 			meshInformerFactory.Appmesh().V1beta1().Meshes(),
 			meshInformerFactory.Appmesh().V1beta1().VirtualNodes(),
 			meshInformerFactory.Appmesh().V1beta1().VirtualServices(),
+			stats,
 		)
 
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.2
+	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.3.1

--- a/pkg/aws/appmesh.go
+++ b/pkg/aws/appmesh.go
@@ -76,6 +76,11 @@ func (v *Mesh) Name() string {
 
 // GetMesh calls describe mesh.
 func (c *Cloud) GetMesh(ctx context.Context, name string) (*Mesh, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("mesh", name, "get", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DescribeMeshTimeout)
 	defer cancel()
 
@@ -96,6 +101,11 @@ func (c *Cloud) GetMesh(ctx context.Context, name string) (*Mesh, error) {
 
 // CreateMesh converts the desired mesh spec into CreateMeshInput and calls create mesh.
 func (c *Cloud) CreateMesh(ctx context.Context, mesh *appmeshv1beta1.Mesh) (*Mesh, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("mesh", mesh.Name, "create", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*CreateMeshTimeout)
 	defer cancel()
 
@@ -116,6 +126,11 @@ func (c *Cloud) CreateMesh(ctx context.Context, mesh *appmeshv1beta1.Mesh) (*Mes
 
 // DeleteMesh deletes the given mesh
 func (c *Cloud) DeleteMesh(ctx context.Context, name string) (*Mesh, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("mesh", name, "delete", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DeleteMeshTimeout)
 	defer cancel()
 
@@ -231,6 +246,11 @@ func (v *VirtualNode) BackendsSet() set.Set {
 
 // GetVirtualNode calls describe virtual node.
 func (c *Cloud) GetVirtualNode(ctx context.Context, name string, meshName string) (*VirtualNode, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_node", name, "get", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DescribeVirtualNodeTimeout)
 	defer cancel()
 
@@ -253,6 +273,11 @@ func (c *Cloud) GetVirtualNode(ctx context.Context, name string, meshName string
 // CreateVirtualNode converts the desired virtual node spec into CreateVirtualNodeInput and calls create
 // virtual node.
 func (c *Cloud) CreateVirtualNode(ctx context.Context, vnode *appmeshv1beta1.VirtualNode) (*VirtualNode, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_node", vnode.Name, "create", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*CreateVirtualNodeTimeout)
 	defer cancel()
 
@@ -341,6 +366,11 @@ func (c *Cloud) CreateVirtualNode(ctx context.Context, vnode *appmeshv1beta1.Vir
 // UpdateVirtualNode converts the desired virtual node spec into UpdateVirtualNodeInput and calls update
 // virtual node.
 func (c *Cloud) UpdateVirtualNode(ctx context.Context, vnode *appmeshv1beta1.VirtualNode) (*VirtualNode, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_node", vnode.Name, "update", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*UpdateVirtualNodeTimeout)
 	defer cancel()
 
@@ -427,6 +457,11 @@ func (c *Cloud) UpdateVirtualNode(ctx context.Context, vnode *appmeshv1beta1.Vir
 }
 
 func (c *Cloud) DeleteVirtualNode(ctx context.Context, name string, meshName string) (*VirtualNode, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_node", name, "delete", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DeleteVirtualNodeTimeout)
 	defer cancel()
 
@@ -476,6 +511,11 @@ func (v *VirtualService) Status() string {
 
 // GetVirtualService calls describe virtual service.
 func (c *Cloud) GetVirtualService(ctx context.Context, name string, meshName string) (*VirtualService, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_service", name, "get", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DescribeVirtualServiceTimeout)
 	defer cancel()
 
@@ -498,6 +538,11 @@ func (c *Cloud) GetVirtualService(ctx context.Context, name string, meshName str
 // CreateVirtualService converts the desired virtual service spec into CreateVirtualServiceInput and calls create
 // virtual service.
 func (c *Cloud) CreateVirtualService(ctx context.Context, vservice *appmeshv1beta1.VirtualService) (*VirtualService, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_service", vservice.Name, "create", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*CreateVirtualServiceTimeout)
 	defer cancel()
 
@@ -526,6 +571,11 @@ func (c *Cloud) CreateVirtualService(ctx context.Context, vservice *appmeshv1bet
 }
 
 func (c *Cloud) UpdateVirtualService(ctx context.Context, vservice *appmeshv1beta1.VirtualService) (*VirtualService, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_service", vservice.Name, "update", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*UpdateVirtualServiceTimeout)
 	defer cancel()
 
@@ -554,6 +604,11 @@ func (c *Cloud) UpdateVirtualService(ctx context.Context, vservice *appmeshv1bet
 }
 
 func (c *Cloud) DeleteVirtualService(ctx context.Context, name string, meshName string) (*VirtualService, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_service", name, "delete", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DeleteVirtualServiceTimeout)
 	defer cancel()
 
@@ -593,6 +648,11 @@ func (v *VirtualRouter) Status() string {
 
 // GetVirtualRouter calls describe virtual router.
 func (c *Cloud) GetVirtualRouter(ctx context.Context, name string, meshName string) (*VirtualRouter, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_router", name, "get", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DescribeVirtualRouterTimeout)
 	defer cancel()
 
@@ -615,6 +675,11 @@ func (c *Cloud) GetVirtualRouter(ctx context.Context, name string, meshName stri
 // CreateVirtualRouter converts the desired virtual service spec into CreateVirtualServiceInput and calls create
 // virtual router.
 func (c *Cloud) CreateVirtualRouter(ctx context.Context, vrouter *appmeshv1beta1.VirtualRouter, meshName string) (*VirtualRouter, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_router", vrouter.Name, "create", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*CreateVirtualRouterTimeout)
 	defer cancel()
 
@@ -652,6 +717,11 @@ func (c *Cloud) CreateVirtualRouter(ctx context.Context, vrouter *appmeshv1beta1
 
 // UpdateVirtualRouter converts the desired virtual router spec into UpdateVirtualRouter calls
 func (c *Cloud) UpdateVirtualRouter(ctx context.Context, vrouter *appmeshv1beta1.VirtualRouter, meshName string) (*VirtualRouter, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_router", vrouter.Name, "update", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*UpdateVirtualRouterTimeout)
 	defer cancel()
 
@@ -688,6 +758,11 @@ func (c *Cloud) UpdateVirtualRouter(ctx context.Context, vrouter *appmeshv1beta1
 }
 
 func (c *Cloud) DeleteVirtualRouter(ctx context.Context, name string, meshName string) (*VirtualRouter, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_router", name, "delete", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DeleteVirtualRouterTimeout)
 	defer cancel()
 
@@ -948,6 +1023,11 @@ func (r Routes) RouteByName(name string) Route {
 
 // GetRoute calls describe route.
 func (c *Cloud) GetRoute(ctx context.Context, name string, routerName string, meshName string) (*Route, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_route", name, "get", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DescribeRouteTimeout)
 	defer cancel()
 
@@ -970,6 +1050,11 @@ func (c *Cloud) GetRoute(ctx context.Context, name string, routerName string, me
 
 // CreateRoute converts the desired virtual service spec into CreateVirtualServiceInput and calls create route.
 func (c *Cloud) CreateRoute(ctx context.Context, route *appmeshv1beta1.Route, routerName string, meshName string) (*Route, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_route", route.Name, "create", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*CreateRouteTimeout)
 	defer cancel()
 
@@ -992,6 +1077,11 @@ func (c *Cloud) CreateRoute(ctx context.Context, route *appmeshv1beta1.Route, ro
 }
 
 func (c *Cloud) GetRoutesForVirtualRouter(ctx context.Context, routerName string, meshName string) (Routes, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_router", routerName, "get", time.Since(begin))
+	}()
+
 	listctx, cancel := context.WithTimeout(ctx, time.Second*ListRoutesTimeout)
 	defer cancel()
 
@@ -1025,6 +1115,11 @@ func (c *Cloud) GetRoutesForVirtualRouter(ctx context.Context, routerName string
 
 // UpdateRoute converts the desired virtual service spec into UpdateRouteInput and calls update route.
 func (c *Cloud) UpdateRoute(ctx context.Context, route *appmeshv1beta1.Route, routerName string, meshName string) (*Route, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_route", route.Name, "update", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*UpdateRouteTimeout)
 	defer cancel()
 
@@ -1047,6 +1142,11 @@ func (c *Cloud) UpdateRoute(ctx context.Context, route *appmeshv1beta1.Route, ro
 }
 
 func (c *Cloud) DeleteRoute(ctx context.Context, name string, routerName string, meshName string) (*Route, error) {
+	begin := time.Now()
+	defer func() {
+		c.stats.SetRequestDuration("virtual_route", name, "delete", time.Since(begin))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*DeleteRouteTimeout)
 	defer cancel()
 

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/metrics"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/appmesh"
 	"github.com/aws/aws-sdk-go/service/appmesh/appmeshiface"
@@ -28,6 +28,8 @@ type Cloud struct {
 
 	namespaceIDCache cache.Store
 	serviceIDCache   cache.Store
+
+	stats *metrics.Recorder
 }
 
 type cloudmapServiceCacheItem struct {
@@ -50,7 +52,7 @@ type CloudMapNamespaceSummary struct {
 	NamespaceType string
 }
 
-func NewCloud(opts CloudOptions) (CloudAPI, error) {
+func NewCloud(opts CloudOptions, stats *metrics.Recorder) (CloudAPI, error) {
 	cfg := &aws.Config{Region: aws.String(opts.Region)}
 
 	session, err := session.NewSession(cfg)
@@ -77,5 +79,6 @@ func NewCloud(opts CloudOptions) (CloudAPI, error) {
 		serviceIDCache: cache.NewTTLStore(func(obj interface{}) (string, error) {
 			return obj.(*cloudmapServiceCacheItem).key, nil
 		}, 60*time.Second),
+		stats: stats,
 	}, nil
 }

--- a/pkg/controller/mesh.go
+++ b/pkg/controller/mesh.go
@@ -35,6 +35,7 @@ func (c *Controller) handleMesh(key string) error {
 	// Resources with finalizers are not deleted immediately,
 	// instead the deletion timestamp is set when a client deletes them.
 	if !mesh.DeletionTimestamp.IsZero() {
+		c.stats.SetMeshInactive(mesh.Name)
 		// Resource is being deleted, process finalizers
 		return c.handleMeshDelete(ctx, mesh)
 	}
@@ -64,6 +65,8 @@ func (c *Controller) handleMesh(key string) error {
 			return fmt.Errorf("error updating mesh status: %s", err)
 		}
 	}
+
+	c.stats.SetMeshActive(mesh.Name)
 
 	return nil
 }

--- a/pkg/controller/virtualnode.go
+++ b/pkg/controller/virtualnode.go
@@ -52,6 +52,7 @@ func (c *Controller) handleVNode(key string) error {
 	// Resources with finalizers are not deleted immediately,
 	// instead the deletion timestamp is set when a client deletes them.
 	if !vnode.DeletionTimestamp.IsZero() {
+		c.stats.SetVirtualNodeInactive(vnode.Name, vnode.Spec.MeshName)
 		// Resource is being deleted, process finalizers
 		return c.handleVNodeDelete(ctx, vnode, copy)
 	}
@@ -107,6 +108,8 @@ func (c *Controller) handleVNode(key string) error {
 			klog.Infof("Updated virtual node %s", vnode.Name)
 		}
 	}
+
+	c.stats.SetVirtualNodeActive(vnode.Name, vnode.Spec.MeshName)
 
 	updated, err := c.updateVNodeStatus(copy, targetNode)
 	if err != nil {

--- a/pkg/controller/virtualservice.go
+++ b/pkg/controller/virtualservice.go
@@ -79,6 +79,7 @@ func (c *Controller) handleVService(key string) error {
 	// Resources with finalizers are not deleted immediately,
 	// instead the deletion timestamp is set when a client deletes them.
 	if !vservice.DeletionTimestamp.IsZero() {
+		c.stats.SetVirtualServiceInactive(vservice.Name, vservice.Spec.MeshName)
 		// Resource is being deleted, process finalizers
 		return c.handleVServiceDelete(ctx, vservice, copy)
 	}
@@ -173,6 +174,8 @@ func (c *Controller) handleVService(key string) error {
 			klog.Infof("Updated virtual service %s", vservice.Name)
 		}
 	}
+
+	c.stats.SetVirtualServiceActive(vservice.Name, vservice.Spec.MeshName)
 
 	if updated, err := c.updateVServiceStatus(copy, targetService); err != nil {
 		return fmt.Errorf("error updating virtual service status: %s", err)

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -1,0 +1,95 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+// Subsystem represents the Prometheus metrics prefix
+const Subsystem = "appmesh"
+
+// Recorder exports mesh stats as Prometheus metrics
+type Recorder struct {
+	meshState           *prometheus.GaugeVec
+	virtualNodeState    *prometheus.GaugeVec
+	virtualServiceState *prometheus.GaugeVec
+	apiRequestDuration  *prometheus.HistogramVec
+}
+
+// NewRecorder registers the App Mesh metrics
+func NewRecorder(register bool) *Recorder {
+	meshState := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: Subsystem,
+		Name:      "mesh_state",
+		Help:      "Mesh state.",
+	}, []string{"name"})
+
+	virtualNodeState := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: Subsystem,
+		Name:      "virtual_node_state",
+		Help:      "Virtual node state.",
+	}, []string{"name", "mesh"})
+
+	virtualServiceState := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: Subsystem,
+		Name:      "virtual_service_state",
+		Help:      "Virtual service state.",
+	}, []string{"name", "mesh"})
+
+	apiRequestDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: Subsystem,
+		Name:      "api_request_duration_seconds",
+		Help:      "Seconds spent performing App Mesh API calls.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"kind", "object", "operation"})
+
+	if register {
+		prometheus.MustRegister(meshState)
+		prometheus.MustRegister(virtualNodeState)
+		prometheus.MustRegister(virtualServiceState)
+		prometheus.MustRegister(apiRequestDuration)
+	}
+
+	return &Recorder{
+		meshState:           meshState,
+		virtualNodeState:    virtualNodeState,
+		virtualServiceState: virtualServiceState,
+		apiRequestDuration:  apiRequestDuration,
+	}
+}
+
+// SetMeshActive sets the mesh gauge to 1
+func (r *Recorder) SetMeshActive(name string) {
+	r.meshState.WithLabelValues(name).Set(1)
+}
+
+// SetMeshActive sets the mesh gauge to 0 indicating that the object was deleted
+func (r *Recorder) SetMeshInactive(name string) {
+	r.meshState.WithLabelValues(name).Set(0)
+}
+
+// SetVirtualNodeActive sets the virtual node gauge to 1
+func (r *Recorder) SetVirtualNodeActive(name string, mesh string) {
+	r.virtualNodeState.WithLabelValues(name, mesh).Set(1)
+}
+
+// SetVirtualNodeInactive sets the mesh gauge to 0 indicating that the object was deleted
+func (r *Recorder) SetVirtualNodeInactive(name string, mesh string) {
+	r.virtualNodeState.WithLabelValues(name, mesh).Set(0)
+}
+
+// SetVirtualServiceActive sets the virtual service gauge to 1
+func (r *Recorder) SetVirtualServiceActive(name string, mesh string) {
+	r.virtualServiceState.WithLabelValues(name, mesh).Set(1)
+}
+
+// SetVirtualServiceInactive sets the mesh gauge to 0 indicating that the object was deleted
+func (r *Recorder) SetVirtualServiceInactive(name string, mesh string) {
+	r.virtualServiceState.WithLabelValues(name, mesh).Set(0)
+}
+
+// SetRequestDuration records the duration of App Mesh API calls based on object kind, name and operation type
+// The operation type can be get, create, update, delete
+func (r *Recorder) SetRequestDuration(kind string, object string, operation string, duration time.Duration) {
+	r.apiRequestDuration.WithLabelValues(kind, object, operation).Observe(duration.Seconds())
+}

--- a/pkg/metrics/recorder_test.go
+++ b/pkg/metrics/recorder_test.go
@@ -1,0 +1,110 @@
+package metrics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promdto "github.com/prometheus/client_model/go"
+)
+
+func TestRecorder_SetMesh(t *testing.T) {
+	stats := NewRecorder(true)
+
+	stats.SetMeshActive("test-mesh")
+
+	name := "appmesh_mesh_state"
+	metric, err := lookupMetric(name, promdto.MetricType_GAUGE, "name", "test-mesh")
+	if err != nil {
+		t.Fatalf("Error collecting %s metric: %v", name, err)
+	}
+
+	if int(*metric.Gauge.Value) != 1 {
+		t.Errorf("%s expected value %v got %v", name, 1, *metric.Gauge.Value)
+	}
+
+	stats.SetMeshInactive("test-mesh")
+	metric, err = lookupMetric(name, promdto.MetricType_GAUGE, "name", "test-mesh")
+	if err != nil {
+		t.Fatalf("Error collecting %s metric: %v", name, err)
+	}
+
+	if int(*metric.Gauge.Value) != 0 {
+		t.Errorf("%s expected value %v got %v", name, 0, *metric.Gauge.Value)
+	}
+}
+
+func TestRecorder_SetVirtualNode(t *testing.T) {
+	stats := NewRecorder(true)
+
+	stats.SetVirtualNodeActive("test-vt", "test-mesh")
+
+	name := "appmesh_virtual_node_state"
+	metric, err := lookupMetric(name, promdto.MetricType_GAUGE, "name", "test-vt", "mesh", "test-mesh")
+	if err != nil {
+		t.Fatalf("Error collecting %s metric: %v", name, err)
+	}
+
+	if int(*metric.Gauge.Value) != 1 {
+		t.Errorf("%s expected value %v got %v", name, 1, *metric.Gauge.Value)
+	}
+
+	stats.SetVirtualNodeInactive("test-vt", "test-mesh")
+	metric, err = lookupMetric(name, promdto.MetricType_GAUGE, "name", "test-vt", "mesh", "test-mesh")
+	if err != nil {
+		t.Fatalf("Error collecting %s metric: %v", name, err)
+	}
+
+	if int(*metric.Gauge.Value) != 0 {
+		t.Errorf("%s expected value %v got %v", name, 0, *metric.Gauge.Value)
+	}
+}
+
+func TestRecorder_SetVirtualService(t *testing.T) {
+	stats := NewRecorder(true)
+
+	stats.SetVirtualServiceActive("test-vs", "test-mesh")
+
+	name := "appmesh_virtual_service_state"
+	metric, err := lookupMetric(name, promdto.MetricType_GAUGE, "name", "test-vs", "mesh", "test-mesh")
+	if err != nil {
+		t.Fatalf("Error collecting %s metric: %v", name, err)
+	}
+
+	if int(*metric.Gauge.Value) != 1 {
+		t.Errorf("%s expected value %v got %v", name, 1, *metric.Gauge.Value)
+	}
+
+	stats.SetVirtualServiceInactive("test-vs", "test-mesh")
+	metric, err = lookupMetric(name, promdto.MetricType_GAUGE, "name", "test-vs", "mesh", "test-mesh")
+	if err != nil {
+		t.Fatalf("Error collecting %s metric: %v", name, err)
+	}
+
+	if int(*metric.Gauge.Value) != 0 {
+		t.Errorf("%s expected value %v got %v", name, 0, *metric.Gauge.Value)
+	}
+}
+
+func lookupMetric(name string, metricType promdto.MetricType, labels ...string) (*promdto.Metric, error) {
+	metricsRegistry := prometheus.DefaultRegisterer.(*prometheus.Registry)
+	if metrics, err := metricsRegistry.Gather(); err == nil {
+		for _, metricFamily := range metrics {
+			if *metricFamily.Name == name {
+				if *metricFamily.Type != metricType {
+					return nil, fmt.Errorf("metric types for %v doesn't correpond: %v != %v", name, metricFamily.Type, metricType)
+				}
+				for _, metric := range metricFamily.Metric {
+					if len(labels) != len(metric.Label)*2 {
+						return nil, fmt.Errorf("metric labels length for %v doesn't correpond: %v != %v", name, len(labels)*2, len(metric.Label))
+					}
+					return metric, nil
+				}
+				return nil, fmt.Errorf("can't find metric %v with appropriate labels in registry", name)
+			}
+		}
+		return nil, fmt.Errorf("can't find metric %v in registry", name)
+	} else {
+		return nil, fmt.Errorf("error reading metrics registry %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds instrumentation for the controller App Mesh API calls and exports Prometheus metrics for meshes, virtual nodes and virtual services.

Metrics:
- `appmesh_mesh_state{name}` gauge
- `appmesh_virtual_node_state{name, mesh}` gauge
- `appmesh_virtual_service_state{name, mesh}`  gauge
- `appmesh_api_request_duration_seconds{kind, object, operation}`  histogram

The controller instrumentationr records mesh, virtual node and virtual service operations as gauges. For each object the gauge value represents the current state, `1` means that the object is active while `0` means that the object has been deleted.

The API client instrumentation records the duration of App Mesh API calls based on object kind, name and operation type. The operation type can be get, create, update or delete. The object kind can be mesh, virtual node, virtual route, virtual router or virtual service. 

The `appmesh_api_request_duration_seconds` histogram helps track issues like #96 

Fix: #98 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
