### PR TITLE
Allow using Cloud Map Http Namespace

### DIFF
--- a/pkg/aws/cloudmap.go
+++ b/pkg/aws/cloudmap.go
@@ -60,28 +60,20 @@ func (c *Cloud) CloudMapCreateService(ctx context.Context, cloudmapConfig *appme
 		return nil, fmt.Errorf("Could not find namespace in cloudmap with name %s", awssdk.StringValue(cloudmapConfig.NamespaceName))
 	}
 
-	//Only DNS namespaces provide support for applications to resolve service names
-	//to endpoints. HTTP namespaces on the other hand require discover-instances API
-	//to be called to resolve names to endpoints. In App Mesh application uses standard
-	//DNS resolution before Envoy intercepts the traffic and uses discover-instances via
-	//App Mesh's EDS endpoint. Hence, both DNS and discover-instances resolution need to
-	//work. Today only private dns namespaces support this, hence this check.
-	//It is possible to use HTTP namespaces when Envoy supports DNS filter
-	//https://github.com/envoyproxy/envoy/issues/6748
-	//TODO add support for HTTP namespace
-	if namespaceSummary.NamespaceType != servicediscovery.NamespaceTypeDnsPrivate {
-		return nil, fmt.Errorf("Cannot create service under namespace %s with type %s, only namespaces with type %s are supported",
+	if namespaceSummary.NamespaceType == servicediscovery.NamespaceTypeDnsPrivate {
+		return c.createServiceUnderPrivateDNSNamespace(ctx, cloudmapConfig, creatorRequestID, namespaceSummary)
+	} else if namespaceSummary.NamespaceType == servicediscovery.NamespaceTypeHttp {
+		return c.createServiceUnderHTTPNamespace(ctx, cloudmapConfig, creatorRequestID, namespaceSummary)
+	} else {
+		return nil, fmt.Errorf("Cannot create service under namespace %s with type %s, only namespaces with types %v are supported",
 			awssdk.StringValue(cloudmapConfig.NamespaceName),
 			namespaceSummary.NamespaceType,
-			servicediscovery.NamespaceTypeDnsPrivate,
+			[]string{servicediscovery.NamespaceTypeDnsPrivate, servicediscovery.NamespaceTypeHttp},
 		)
 	}
-
-	return c.createServiceUnderPrivateDNSNamespace(ctx, cloudmapConfig, creatorRequestID, namespaceSummary)
 }
 
 func (c *Cloud) createServiceUnderPrivateDNSNamespace(ctx context.Context, cloudmapConfig *appmesh.AwsCloudMapServiceDiscovery, creatorRequestID string, namespaceSummary *CloudMapNamespaceSummary) (*CloudMapServiceSummary, error) {
-	key := c.serviceCacheKey(cloudmapConfig)
 	createServiceInput := &servicediscovery.CreateServiceInput{
 		CreatorRequestId: awssdk.String(creatorRequestID),
 		Name:             cloudmapConfig.ServiceName,
@@ -96,6 +88,21 @@ func (c *Cloud) createServiceUnderPrivateDNSNamespace(ctx context.Context, cloud
 			},
 		},
 	}
+
+	return c.createService(ctx, cloudmapConfig, namespaceSummary, createServiceInput)
+}
+
+func (c *Cloud) createServiceUnderHTTPNamespace(ctx context.Context, cloudmapConfig *appmesh.AwsCloudMapServiceDiscovery, creatorRequestID string, namespaceSummary *CloudMapNamespaceSummary) (*CloudMapServiceSummary, error) {
+	createServiceInput := &servicediscovery.CreateServiceInput{
+		CreatorRequestId: awssdk.String(creatorRequestID),
+		Name:             cloudmapConfig.ServiceName,
+		NamespaceId:      awssdk.String(namespaceSummary.NamespaceID),
+	}
+	return c.createService(ctx, cloudmapConfig, namespaceSummary, createServiceInput)
+}
+
+func (c *Cloud) createService(ctx context.Context, cloudmapConfig *appmesh.AwsCloudMapServiceDiscovery, namespaceSummary *CloudMapNamespaceSummary, createServiceInput *servicediscovery.CreateServiceInput) (*CloudMapServiceSummary, error) {
+	key := c.serviceCacheKey(cloudmapConfig)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*CreateServiceTimeout)
 	defer cancel()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously we disallowed this due the concern that DNS will not resolve. However, service name resolution is decoupled from where virtual-nodes are registered w.r.t service-discovery. Removing this check and allowing HTTP namespace support. Note that the examples still recommend using PrivateDNSNamespace. See https://github.com/kiranmeduri/aws-app-mesh-examples/commit/029bed2ea83cdc5636e41cccdb7dbbe86d9f52df on how to use Kubernetes DNS with cloudmap HTTP namespace support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
