### PR TITLE
Remove colorgateway VirtualService

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -50,7 +50,6 @@ You should see a collection of virtual services, virtual nodes and a mesh, along
     virtualnode.appmesh.k8s.aws/colorteller-blue-appmesh-demo    3h
     virtualnode.appmesh.k8s.aws/colorteller-red-appmesh-demo     3h
     NAME                                                                         AGE
-    virtualservice.appmesh.k8s.aws/colorgateway.appmesh-demo.svc.cluster.local   3h
     virtualservice.appmesh.k8s.aws/colorteller.appmesh-demo.svc.cluster.local    3h
 
 Verify App Mesh is working

--- a/examples/color.yaml
+++ b/examples/color.yaml
@@ -121,28 +121,6 @@ spec:
             - virtualNodeName: colorteller-black
               weight: 1
 ---
-apiVersion: appmesh.k8s.aws/v1beta1
-kind: VirtualService
-metadata:
-  name: colorgateway.appmesh-demo
-  namespace: appmesh-demo
-spec:
-  meshName: color-mesh
-  virtualRouter:
-    listeners:
-      - portMapping:
-          port: 9080
-          protocol: http
-  routes:
-    - name: gateway-route
-      http:
-        match:
-          prefix: /color
-        action:
-          weightedTargets:
-            - virtualNodeName: colorgateway
-              weight: 1
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/examples/color.yaml.template
+++ b/examples/color.yaml.template
@@ -121,28 +121,6 @@ spec:
             - virtualNodeName: colorteller-black
               weight: 1
 ---
-apiVersion: appmesh.k8s.aws/v1beta1
-kind: VirtualService
-metadata:
-  name: colorgateway.${APP_NAMESPACE}
-  namespace: ${APP_NAMESPACE}
-spec:
-  meshName: ${MESH_NAME}
-  virtualRouter:
-    listeners:
-      - portMapping:
-          port: 9080
-          protocol: http
-  routes:
-    - name: gateway-route
-      http:
-        match:
-          prefix: /color
-        action:
-          weightedTargets:
-            - virtualNodeName: colorgateway
-              weight: 1
----
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
*Issue #, if available:*

#113 

*Description of changes:*

Remove colorgateway VirtualService so new users don't mistake App Mesh as supporting ingress routing (though it [may someday](https://github.com/aws/aws-app-mesh-roadmap/issues/37))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
