### PR TITLE
Update example.md

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -54,9 +54,9 @@ You should see a collection of virtual services, virtual nodes and a mesh, along
 
 Verify App Mesh is working
 ```
-kubectl run -n appmesh-demo -it curler --image=pstauffer/curl sh
+kubectl run -n appmesh-demo -it curler --image=curlimages/curl sh
 
-for i in 1 2 3 4 5 6 7 8 9 10; do curl colorgateway:9080/color; echo; done
+for i in {`seq ..100`}; do curl colorgateway:9080/color; echo; done
 # Expect to see even distribution of three colors
 # {"color":"white", "stats": {"black":0.36,"blue":0.32,"white":0.32}}
 ```

--- a/docs/example.md
+++ b/docs/example.md
@@ -54,9 +54,9 @@ You should see a collection of virtual services, virtual nodes and a mesh, along
 
 Verify App Mesh is working
 ```
-kubectl run -n appmesh-demo -it curler --image=tutum/curl /bin/bash
+kubectl run -n appmesh-demo -it curler --image=pstauffer/curl sh
 
-for i in {1..100}; do curl colorgateway:9080/color; echo; done
+for i in 1 2 3 4 5 6 7 8 9 10; do curl colorgateway:9080/color; echo; done
 # Expect to see even distribution of three colors
 # {"color":"white", "stats": {"black":0.36,"blue":0.32,"white":0.32}}
 ```

--- a/docs/example.md
+++ b/docs/example.md
@@ -56,7 +56,7 @@ Verify App Mesh is working
 ```
 kubectl run -n appmesh-demo -it curler --image=curlimages/curl sh
 
-for i in {`seq 1..100`}; do curl colorgateway:9080/color; echo; done
+for i in {`seq 1 100`}; do curl colorgateway:9080/color; echo; done
 # Expect to see even distribution of three colors
 # {"color":"white", "stats": {"black":0.36,"blue":0.32,"white":0.32}}
 ```

--- a/docs/example.md
+++ b/docs/example.md
@@ -56,7 +56,7 @@ Verify App Mesh is working
 ```
 kubectl run -n appmesh-demo -it curler --image=curlimages/curl sh
 
-for i in {`seq ..100`}; do curl colorgateway:9080/color; echo; done
+for i in {`seq 1..100`}; do curl colorgateway:9080/color; echo; done
 # Expect to see even distribution of three colors
 # {"color":"white", "stats": {"black":0.36,"blue":0.32,"white":0.32}}
 ```


### PR DESCRIPTION
*Issue*
https://github.com/aws/aws-app-mesh-examples/issues/238

*Description of changes:*
The tutum curler image fails to curl the apps. 80% of the calls fail, which becomes an issue when trying to get started with app mesh.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
