### PR TITLE
Add attribution document to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.13-stretch as builder
 WORKDIR /go/src/github.com/aws/aws-app-mesh-controller-for-k8s
 
+ENV GOPRIVATE *
+
 # go.mod and go.sum go into their own layers.
 COPY go.mod .
 COPY go.sum .
@@ -14,5 +16,6 @@ RUN make
 FROM amazonlinux:2
 RUN yum install -y ca-certificates
 COPY --from=builder /go/src/github.com/aws/aws-app-mesh-controller-for-k8s/_output/bin/app-mesh-controller /bin/app-mesh-controller
+COPY --from=builder /go/src/github.com/aws/aws-app-mesh-controller-for-k8s/ATTRIBUTION.txt /ATTRIBUTION.txt
 
 ENTRYPOINT ["/bin/app-mesh-controller"]


### PR DESCRIPTION
*Description of changes:*
* Add open source attribution document to container image (guarantees licenses are present in thing people actually download). 
* Also set GOPRIVATE to *, which is necessary for amazon employees.  Hopefully this doesn't affect non-amazon contributors, we can revisit if it does.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
