### PR TITLE
fix example to work with iam-for-pods

### DIFF
--- a/examples/color.yaml
+++ b/examples/color.yaml
@@ -152,6 +152,8 @@ spec:
         app: colorgateway
         version: v1
     spec:
+      securityContext:
+        fsGroup: 1337
       containers:
         - name: colorgateway
           image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/gateway:latest
@@ -199,6 +201,8 @@ spec:
         app: colorteller
         version: white
     spec:
+      securityContext:
+        fsGroup: 1337
       containers:
         - name: colorteller
           image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest
@@ -244,6 +248,8 @@ spec:
         app: colorteller
         version: black
     spec:
+      securityContext:
+        fsGroup: 1337
       containers:
         - name: colorteller
           image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest
@@ -289,6 +295,8 @@ spec:
         app: colorteller
         version: blue
     spec:
+      securityContext:
+        fsGroup: 1337
       containers:
         - name: colorteller
           image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest
@@ -334,6 +342,8 @@ spec:
         app: colorteller
         version: red
     spec:
+      securityContext:
+        fsGroup: 1337
       containers:
         - name: colorteller
           image: 970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest
@@ -412,6 +422,8 @@ spec:
         app: tcpecho
         version: v1
     spec:
+      securityContext:
+        fsGroup: 1337
       containers:
         - name: tcpecho
           image: cjimti/go-echo


### PR DESCRIPTION
Fix the example to work with iam-for-pods.

The envoy controller **is not running as root**, thus requires the fsGroup: 1337 setting to be able to read credentials mounted by iam-for-pods, otherwise, it just fails silently without obvious error logs.

Add this `fsGroup: 1337` setting will make this example works for both EC2 node(with/without iam-for-pods) and Fargate(requires iam-for-pods)

reference: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#pod-configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
