### PR TITLE
bump makeFile version to v0.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO111MODULE=on
 # Docker
 IMAGE=amazon/app-mesh-controller
 REPO=$(AWS_ACCOUNT).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE)
-VERSION=v0.3.0
+VERSION=v0.4.0
 DEV_VERSION=$(shell git describe --dirty --tags)
 
 .PHONY: eks-appmesh-controller


### PR DESCRIPTION
bump version in Makefile to v0.4.0
close #https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/141

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
