### PR TITLE
upgrade aws-k8s-tester to v0.7.8

### DIFF
--- a/scripts/ci_e2e_test.sh
+++ b/scripts/ci_e2e_test.sh
@@ -4,7 +4,7 @@ set -ueo pipefail
 
 # AWS environment
 AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-"us-west-2"}
-AWS_K8S_TESTER_VERSION="v0.7.6"
+AWS_K8S_TESTER_VERSION="v0.7.8"
 source $(dirname "${BASH_SOURCE}")/lib/cluster.sh
 source $(dirname "${BASH_SOURCE}")/lib/ecr.sh
 


### PR DESCRIPTION
*Description of changes:*
1. upgrade aws-k8s-tester to v0.7.8 to fix cluster bootstrap issues(a S3 bucket is required in v0.7.5-v0.7.7, which shouldn't)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
