### PR TITLE
Hotfix/issue144

### DIFF
--- a/pkg/controller/virtualservice.go
+++ b/pkg/controller/virtualservice.go
@@ -655,7 +655,7 @@ func (c *Controller) handleVServiceMeshDeleting(ctx context.Context, vservice *a
 
 	// if mesh DeletionTimestamp is set, clean up virtual service via App Mesh API
 	if !mesh.DeletionTimestamp.IsZero() {
-		if err := c.meshclientset.AppmeshV1beta1().VirtualServices(vservice.Namespace).Delete(vservice.Name, &metav1.DeleteOptions{}); err != nil{
+		if err := c.meshclientset.AppmeshV1beta1().VirtualServices(vservice.Namespace).Delete(vservice.Name, &metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("Deletion failed for virtual service: %s - %s", vservice.Name, err)
 			return false
 		}


### PR DESCRIPTION
*Issue #, if available:*
#144 
*Description of changes:*
When a Mesh is deleted, VirtualNode & VirtualService K8S resources associated with that Mesh will be deleted in addition to app mesh resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
