### PR TITLE
portMapping under listeners is converted to a required field in VirtualNode CRD

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -109,6 +109,8 @@ spec:
               type: array
               items:
                 type: object
+                required:
+                  - portMapping
                 properties:
                   portMapping:
                     required:

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -111,6 +111,9 @@ spec:
                 type: object
                 properties:
                   portMapping:
+                    required:
+                      - port
+                      - protocol
                     properties:
                       port:
                         type: integer


### PR DESCRIPTION
… in VirtualNode CRD

*Issue #, if available:*
#139
*Description of changes:*
portMapping under listeners is converted to a required field in VirtualNode CRD

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
