### PR TITLE
Issue#153 - NameSpace is appended twice to the vNode name resulting i…

### DIFF
--- a/pkg/controller/virtualnode.go
+++ b/pkg/controller/virtualnode.go
@@ -326,7 +326,7 @@ func vnodeLoggingNeedsUpdate(desired *appmeshv1beta1.VirtualNode, target *aws.Vi
 
 func (c *Controller) handleVNodeDelete(ctx context.Context, vnode *appmeshv1beta1.VirtualNode, copy *appmeshv1beta1.VirtualNode) error {
 	if yes, _ := containsFinalizer(vnode, virtualNodeDeletionFinalizerName); yes {
-		if err := c.deregisterInstancesForVirtualNode(ctx, vnode); err != nil {
+		if err := c.deregisterInstancesForVirtualNode(ctx, copy); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
…n a mismatch

*Issue #, if available:*
#153 
*Description of changes:*
NameSpace is appended twice to the vNode name resulting in a mismatch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
