### PR TITLE
Add ready-only meshRef for all namespace scoped CRD apis.

### DIFF
--- a/apis/appmesh/v1beta2/types.go
+++ b/apis/appmesh/v1beta2/types.go
@@ -1,5 +1,7 @@
 package v1beta2
 
+import "k8s.io/apimachinery/pkg/types"
+
 // +kubebuilder:validation:Enum=s;ms
 type DurationUnit string
 
@@ -207,4 +209,12 @@ type VirtualRouterReference struct {
 	Namespace *string `json:"namespace,omitempty"`
 	// Name is the name of VirtualRouter CR
 	Name string `json:"name"`
+}
+
+// MeshReference holds a reference to Mesh.appmesh.k8s.aws
+type MeshReference struct {
+	// Name is the name of Mesh CR
+	Name string `json:"name"`
+	// UID is the UID of Mesh CR
+	UID types.UID `json:"uid"`
 }

--- a/apis/appmesh/v1beta2/virtualnode_types.go
+++ b/apis/appmesh/v1beta2/virtualnode_types.go
@@ -165,6 +165,14 @@ type VirtualNodeSpec struct {
 	// The inbound and outbound access logging information for the virtual node.
 	// +optional
 	Logging *Logging `json:"logging,omitempty"`
+
+	// A reference to k8s Mesh CR that this VirtualNode belongs to.
+	// The admission controller populates it using Meshes's selector, and prevents users from setting this field.
+	//
+	// Populated by the system.
+	// Read-only.
+	// +optional
+	MeshRef *MeshReference `json:"meshRef,omitempty"`
 }
 
 // VirtualNodeStatus defines the observed state of VirtualNode

--- a/apis/appmesh/v1beta2/virtualrouter_types.go
+++ b/apis/appmesh/v1beta2/virtualrouter_types.go
@@ -326,6 +326,14 @@ type VirtualRouterSpec struct {
 	// The routes associated with VirtualRouter
 	// +optional
 	Routes []Route `json:"routes,omitempty"`
+
+	// A reference to k8s Mesh CR that this VirtualRouter belongs to.
+	// The admission controller populates it using Meshes's selector, and prevents users from setting this field.
+	//
+	// Populated by the system.
+	// Read-only.
+	// +optional
+	MeshRef *MeshReference `json:"meshRef,omitempty"`
 }
 
 // VirtualRouterStatus defines the observed state of VirtualRouter

--- a/apis/appmesh/v1beta2/virtualservice_types.go
+++ b/apis/appmesh/v1beta2/virtualservice_types.go
@@ -75,6 +75,14 @@ type VirtualServiceSpec struct {
 
 	// The provider for virtual services. You can specify a single virtual node or virtual router.
 	Provider VirtualServiceProvider `json:"provider"`
+
+	// A reference to k8s Mesh CR that this VirtualService belongs to.
+	// The admission controller populates it using Meshes's selector, and prevents users from setting this field.
+	//
+	// Populated by the system.
+	// Read-only.
+	// +optional
+	MeshRef *MeshReference `json:"meshRef,omitempty"`
 }
 
 // VirtualServiceStatus defines the observed state of VirtualService

--- a/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
@@ -363,6 +363,22 @@ spec:
                       type: object
                   type: object
               type: object
+            meshRef:
+              description: "A reference to k8s Mesh CR that this VirtualNode belongs
+                to. The admission controller populates it using Meshes's selector,
+                and prevents users from setting this field. \n Populated by the system.
+                Read-only."
+              properties:
+                name:
+                  description: Name is the name of Mesh CR
+                  type: string
+                uid:
+                  description: UID is the UID of Mesh CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
             serviceDiscovery:
               description: The service discovery information for the virtual node.
               properties:

--- a/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
@@ -72,6 +72,22 @@ spec:
               maxItems: 1
               minItems: 1
               type: array
+            meshRef:
+              description: "A reference to k8s Mesh CR that this VirtualRouter belongs
+                to. The admission controller populates it using Meshes's selector,
+                and prevents users from setting this field. \n Populated by the system.
+                Read-only."
+              properties:
+                name:
+                  description: Name is the name of Mesh CR
+                  type: string
+                uid:
+                  description: UID is the UID of Mesh CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
             routes:
               description: The routes associated with VirtualRouter
               items:

--- a/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
@@ -38,6 +38,22 @@ spec:
               description: AWSName is the AppMesh VirtualService object's name. If
                 unspecified, it defaults to be "${name}" of k8s VirtualService
               type: string
+            meshRef:
+              description: "A reference to k8s Mesh CR that this VirtualService belongs
+                to. The admission controller populates it using Meshes's selector,
+                and prevents users from setting this field. \n Populated by the system.
+                Read-only."
+              properties:
+                name:
+                  description: Name is the name of Mesh CR
+                  type: string
+                uid:
+                  description: UID is the UID of Mesh CR
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
             provider:
               description: The provider for virtual services. You can specify a single
                 virtual node or virtual router.


### PR DESCRIPTION
Add meshRef for all namespace scoped CRD apis.

The meshRef is ready-only and populated by admission controller to persist mesh allocation for objects.
Note: an UID is included to uniquely identify a unique mesh instance in history. (to guarantee it's reference the same mesh)

High level logic for lifecycle management:
1. Up on CR creation, a mutating webhook will designate mesh membership based on existing mesh's selector and namespace's labels. CR creation will be rejected if no mesh found or multiple mesh found.
2. Un on mesh deletion, a Finalizer for the mesh will be running, which will delete all CR objects belong to this mesh.

Alternative designs considered:
1. use a meta.OwnerReference. 
    we can use a meta.OwnerReference of object to contain a reference a mesh to persist mesh allocation information.
    cons:
    1. the current k8s garbage collector only GC objects when all owner specified by OwnerReference is gone. So if a user create a virtualNode owned by some objectA, he may intend to have the virtualNode to be automatically deleted once objectA is deleted. But if we patch an additional OwnerReference into virtualNode, it won't happen.
2. use an annotation like "appmesh.k8s.io/mesh: xxx".
    cons:
     1. not user friendly, they cannot easily find the mesh that this object belongs to

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
