### PR TITLE
Add PodSelector to virtualNode 

### DIFF
--- a/apis/appmesh/v1beta2/virtualnode_types.go
+++ b/apis/appmesh/v1beta2/virtualnode_types.go
@@ -148,6 +148,10 @@ type VirtualNodeSpec struct {
 	// If unspecified or empty, it defaults to be "${name}_${namespace}" of k8s VirtualNode
 	// +optional
 	AWSName *string `json:"awsName,omitempty"`
+	// PodSelector selects Pods using labels to designate VirtualNode membership.
+	// if unspecified or empty, it selects no pods.
+	// +optional
+	PodSelector *metav1.LabelSelector `json:"podSelector,omitempty"`
 	// The listener that the virtual node is expected to receive inbound traffic from
 	// +kubebuilder:validation:MinItems=0
 	// +kubebuilder:validation:MaxItems=1

--- a/apis/appmesh/v1beta2/zz_generated.deepcopy.go
+++ b/apis/appmesh/v1beta2/zz_generated.deepcopy.go
@@ -1254,6 +1254,11 @@ func (in *VirtualNodeSpec) DeepCopyInto(out *VirtualNodeSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PodSelector != nil {
+		in, out := &in.PodSelector, &out.PodSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Listeners != nil {
 		in, out := &in.Listeners, &out.Listeners
 		*out = make([]Listener, len(*in))

--- a/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
@@ -392,6 +392,50 @@ spec:
               - name
               - uid
               type: object
+            podSelector:
+              description: PodSelector selects Pods using labels to designate VirtualNode
+                membership. if unspecified or empty, it selects no pods.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
             serviceDiscovery:
               description: The service discovery information for the virtual node.
               properties:


### PR DESCRIPTION
Add PodSelector to virtualNode per design: https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/150
The PodSelector is allowed to be optional to express "select no pods". And it's not following standard label selector semantic, when it's specified but empty, it's "select no pods" instead of "select all pods".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
