### PR TITLE
add default throttling and supports override via --aws-api-throttle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/exp v0.0.0-20200228211341-fcea875c7e85 // indirect
 	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d // indirect
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20200316212524-3e76bee198d8 // indirect
 	gonum.org/v1/gonum v0.7.0
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/aws/config.go
+++ b/pkg/aws/config.go
@@ -1,5 +1,8 @@
 package aws
 
+import "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/throttle"
+
 type CloudOptions struct {
-	Region string
+	Region               string
+	AWSAPIThrottleConfig *throttle.ServiceOperationsThrottleConfig
 }

--- a/pkg/aws/throttle/condition.go
+++ b/pkg/aws/throttle/condition.go
@@ -1,0 +1,32 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/aws/request"
+	"regexp"
+)
+
+type Condition func(r *request.Request) bool
+
+func matchService(serviceID string) Condition {
+	return func(r *request.Request) bool {
+		return r.ClientInfo.ServiceID == serviceID
+	}
+}
+
+func matchServiceOperation(serviceID string, operation string) Condition {
+	return func(r *request.Request) bool {
+		if r.Operation == nil {
+			return false
+		}
+		return r.ClientInfo.ServiceID == serviceID && r.Operation.Name == operation
+	}
+}
+
+func matchServiceOperationPattern(serviceID string, operationPtn *regexp.Regexp) Condition {
+	return func(r *request.Request) bool {
+		if r.Operation == nil {
+			return false
+		}
+		return r.ClientInfo.ServiceID == serviceID && operationPtn.Match([]byte(r.Operation.Name))
+	}
+}

--- a/pkg/aws/throttle/condition_test.go
+++ b/pkg/aws/throttle/condition_test.go
@@ -1,0 +1,207 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/aws/client/metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func Test_matchService(t *testing.T) {
+	type args struct {
+		serviceID string
+	}
+	tests := []struct {
+		name string
+		args args
+		req  *request.Request
+		want bool
+	}{
+		{
+			name: "service matches",
+			args: args{
+				serviceID: "App Mesh",
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "service mismatches",
+			args: args{
+				serviceID: "App Mesh",
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "S3",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predict := matchService(tt.args.serviceID)
+			got := predict(tt.req)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_matchServiceOperation(t *testing.T) {
+	type args struct {
+		serviceID string
+		operation string
+	}
+	tests := []struct {
+		name string
+		args args
+		req  *request.Request
+		want bool
+	}{
+		{
+			name: "operation matches",
+			args: args{
+				serviceID: "App Mesh",
+				operation: "CreateMesh",
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operation mismatches",
+			args: args{
+				serviceID: "App Mesh",
+				operation: "CreateMesh",
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "DescribeMesh",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predict := matchServiceOperation(tt.args.serviceID, tt.args.operation)
+			got := predict(tt.req)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_matchServiceOperationPattern(t *testing.T) {
+	type args struct {
+		serviceID    string
+		operationPtn *regexp.Regexp
+	}
+	tests := []struct {
+		name string
+		args args
+		req  *request.Request
+		want bool
+	}{
+		{
+			name: "operationPtn matches - case 1",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("Create"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operationPtn matches - case 2",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("Create.*"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operationPtn matches - case 3",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("^Create"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operationPtn matches - case 4",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("Mesh"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operationPtn mismatches",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("Describe"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predict := matchServiceOperationPattern(tt.args.serviceID, tt.args.operationPtn)
+			got := predict(tt.req)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/aws/throttle/config.go
+++ b/pkg/aws/throttle/config.go
@@ -1,0 +1,102 @@
+package throttle
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"golang.org/x/time/rate"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type throttleConfig struct {
+	operationPtn *regexp.Regexp
+	r            rate.Limit
+	burst        int
+}
+
+var _ pflag.Value = &ServiceOperationsThrottleConfig{}
+
+// serviceOperationsThrottleConfig is throttleConfig for each service's operations.
+// It supports to be configured using flags with format like "${serviceID}:${operationRegex}={rate}:{burst}"
+// e.g. "appmesh:DescribeMesh=1.3:5,appmesh:Create.*=1.7:3"
+// Note: default throttle for each service will be cleared if any override is set for that service.
+type ServiceOperationsThrottleConfig struct {
+	// service:operationRegex:config
+	value map[string][]throttleConfig
+}
+
+func (c *ServiceOperationsThrottleConfig) String() string {
+	if c == nil {
+		return ""
+	}
+
+	var configs []string
+	var serviceIDs []string
+	for serviceID := range c.value {
+		serviceIDs = append(serviceIDs, serviceID)
+	}
+	sort.Strings(serviceIDs)
+	for _, serviceID := range serviceIDs {
+		for _, operationsThrottleConfig := range c.value[serviceID] {
+			configs = append(configs, fmt.Sprintf("%s:%s=%v:%d",
+				serviceID,
+				operationsThrottleConfig.operationPtn.String(),
+				operationsThrottleConfig.r,
+				operationsThrottleConfig.burst,
+			))
+		}
+	}
+	return strings.Join(configs, ",")
+}
+
+func (c *ServiceOperationsThrottleConfig) Set(val string) error {
+	valueOverride := make(map[string][]throttleConfig)
+	configPairs := strings.Split(val, ",")
+	for _, pair := range configPairs {
+		kv := strings.Split(pair, "=")
+		if len(kv) != 2 {
+			return errors.Errorf("%s must be formatted as serviceID:operationRegex=rate:burst", pair)
+		}
+		serviceIDOperationRegexPair := strings.Split(kv[0], ":")
+		if len(serviceIDOperationRegexPair) != 2 {
+			return errors.Errorf("%s must be formatted as serviceID:operationRegex", kv[0])
+		}
+		rateBurstPair := strings.Split(kv[1], ":")
+		if len(rateBurstPair) != 2 {
+			return errors.Errorf("%s must be formatted as rate:burst", kv[1])
+		}
+		serviceID := serviceIDOperationRegexPair[0]
+		operationPtn, err := regexp.Compile(serviceIDOperationRegexPair[1])
+		if err != nil {
+			return errors.Errorf("%s must be valid regex expression for operation", serviceIDOperationRegexPair[1])
+		}
+		r, err := strconv.ParseFloat(rateBurstPair[0], 64)
+		if err != nil {
+			return errors.Errorf("%s must be valid float number as rate for operations per second", rateBurstPair[0])
+		}
+		burst, err := strconv.Atoi(rateBurstPair[1])
+		if err != nil {
+			return errors.Errorf("%s must be valid integer as burst for operations", rateBurstPair[1])
+		}
+		valueOverride[serviceID] = append(valueOverride[serviceID], throttleConfig{
+			operationPtn: operationPtn,
+			r:            rate.Limit(r),
+			burst:        burst,
+		})
+	}
+
+	if c.value == nil {
+		c.value = make(map[string][]throttleConfig)
+	}
+	for k, v := range valueOverride {
+		c.value[k] = v
+	}
+	return nil
+}
+
+func (c *ServiceOperationsThrottleConfig) Type() string {
+	return "serviceOperationsThrottleConfig"
+}

--- a/pkg/aws/throttle/config_test.go
+++ b/pkg/aws/throttle/config_test.go
@@ -1,0 +1,259 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func TestServiceOperationsThrottleConfig_String(t *testing.T) {
+	type fields struct {
+		value map[string][]throttleConfig
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "non-empty value",
+			fields: fields{
+				value: map[string][]throttleConfig{
+					appmesh.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        5,
+						},
+						{
+							operationPtn: regexp.MustCompile("CreateMesh"),
+							r:            4.2,
+							burst:        5,
+						},
+					},
+					servicediscovery.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        5,
+						},
+					},
+				},
+			},
+			want: "App Mesh:^Describe=4.2:5,App Mesh:CreateMesh=4.2:5,ServiceDiscovery:^Describe=4.2:5",
+		},
+		{
+			name: "nil value",
+			fields: fields{
+				value: nil,
+			},
+			want: "",
+		},
+		{
+			name: "empty value",
+			fields: fields{
+				value: nil,
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ServiceOperationsThrottleConfig{
+				value: tt.fields.value,
+			}
+			got := c.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestServiceOperationsThrottleConfig_Set(t *testing.T) {
+	type fields struct {
+		value map[string][]throttleConfig
+	}
+	type args struct {
+		val string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    ServiceOperationsThrottleConfig
+		wantErr error
+	}{
+		{
+			name: "when default value is nil",
+			fields: fields{
+				value: nil,
+			},
+			args: args{
+				val: "App Mesh:^Describe=4.2:5,App Mesh:CreateMesh=4.2:6,ServiceDiscovery:^Describe=4.2:7",
+			},
+			want: ServiceOperationsThrottleConfig{
+				value: map[string][]throttleConfig{
+					appmesh.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        5,
+						},
+						{
+							operationPtn: regexp.MustCompile("CreateMesh"),
+							r:            4.2,
+							burst:        6,
+						},
+					},
+					servicediscovery.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        7,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "when default value contains non-empty defaults",
+			fields: fields{
+				value: map[string][]throttleConfig{
+					elbv2.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Create"),
+							r:            4.2,
+							burst:        4,
+						},
+					},
+				},
+			},
+			args: args{
+				val: "App Mesh:^Describe=4.2:5,App Mesh:CreateMesh=4.2:6,ServiceDiscovery:^Describe=4.2:7",
+			},
+			want: ServiceOperationsThrottleConfig{
+				value: map[string][]throttleConfig{
+					elbv2.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Create"),
+							r:            4.2,
+							burst:        4,
+						},
+					},
+					appmesh.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        5,
+						},
+						{
+							operationPtn: regexp.MustCompile("CreateMesh"),
+							r:            4.2,
+							burst:        6,
+						},
+					},
+					servicediscovery.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        7,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "when val is empty",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "",
+			},
+			wantErr: errors.Errorf(" must be formatted as serviceID:operationRegex=rate:burst"),
+		},
+		{
+			name: "when val is not valid format - case 1",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a=b=c",
+			},
+			wantErr: errors.Errorf("a=b=c must be formatted as serviceID:operationRegex=rate:burst"),
+		},
+		{
+			name: "when val is not valid format - case 2",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:b:c=4.2:5",
+			},
+			wantErr: errors.Errorf("a:b:c must be formatted as serviceID:operationRegex"),
+		},
+		{
+			name: "when val is not valid format - case 3",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:b=4.2:5:6",
+			},
+			wantErr: errors.Errorf("4.2:5:6 must be formatted as rate:burst"),
+		},
+		{
+			name: "when operationPtn is not valid regex",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:^[Describe=4.2:5",
+			},
+			wantErr: errors.Errorf("^[Describe must be valid regex expression for operation"),
+		},
+		{
+			name: "when rate is not valid float number",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:^Describe=4.x:5",
+			},
+			wantErr: errors.Errorf("4.x must be valid float number as rate for operations per second"),
+		},
+		{
+			name: "when burst is not valid integer",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:^Describe=4.2:5x",
+			},
+			wantErr: errors.Errorf("5x must be valid integer as burst for operations"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ServiceOperationsThrottleConfig{
+				value: tt.fields.value,
+			}
+			err := c.Set(tt.args.val)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, *c)
+			}
+		})
+	}
+}
+
+func TestServiceOperationsThrottleConfig_Type(t *testing.T) {
+	c := &ServiceOperationsThrottleConfig{}
+	got := c.Type()
+	assert.Equal(t, "serviceOperationsThrottleConfig", got)
+}

--- a/pkg/aws/throttle/defaults.go
+++ b/pkg/aws/throttle/defaults.go
@@ -1,0 +1,55 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"golang.org/x/time/rate"
+	"regexp"
+)
+
+// NewDefaultServiceOperationsThrottleConfig returns a ServiceOperationsThrottleConfig with default settings.
+func NewDefaultServiceOperationsThrottleConfig() *ServiceOperationsThrottleConfig {
+	return &ServiceOperationsThrottleConfig{
+		value: map[string][]throttleConfig{
+			appmesh.ServiceID: {
+				{
+					operationPtn: regexp.MustCompile("^Describe|List"),
+					r:            rate.Limit(40),
+					burst:        5,
+				},
+				{
+					operationPtn: regexp.MustCompile("^Create|Update|Delete"),
+					r:            rate.Limit(8),
+					burst:        5,
+				},
+			},
+			servicediscovery.ServiceID: {
+				{
+					operationPtn: regexp.MustCompile("^ListNamespaces"),
+					r:            rate.Limit(1),
+					burst:        8,
+				},
+				{
+					operationPtn: regexp.MustCompile("^ListServices"),
+					r:            rate.Limit(1),
+					burst:        8,
+				},
+				{
+					operationPtn: regexp.MustCompile("^CreateService"),
+					r:            rate.Limit(8),
+					burst:        80,
+				},
+				{
+					operationPtn: regexp.MustCompile("^ListInstances"),
+					r:            rate.Limit(40),
+					burst:        400,
+				},
+				{
+					operationPtn: regexp.MustCompile("^RegisterInstance|DeregisterInstance"),
+					r:            rate.Limit(4),
+					burst:        80,
+				},
+			},
+		},
+	}
+}

--- a/pkg/aws/throttle/throttler.go
+++ b/pkg/aws/throttle/throttler.go
@@ -1,0 +1,70 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/aws/request"
+	"golang.org/x/time/rate"
+	"regexp"
+)
+
+const sdkHandlerRequestThrottle = "requestThrottle"
+
+type conditionLimiter struct {
+	condition Condition
+	limiter   *rate.Limiter
+}
+
+type throttler struct {
+	conditionLimiters []conditionLimiter
+}
+
+// NewThrottler constructs new request throttler instance.
+func NewThrottler(config *ServiceOperationsThrottleConfig) *throttler {
+	throttler := &throttler{}
+	for serviceID, operationsThrottleConfigs := range config.value {
+		for _, operationsThrottleConfig := range operationsThrottleConfigs {
+			throttler = throttler.WithOperationPatternThrottle(
+				serviceID,
+				operationsThrottleConfig.operationPtn,
+				operationsThrottleConfig.r,
+				operationsThrottleConfig.burst)
+		}
+	}
+	return throttler
+}
+
+func (t *throttler) WithConditionThrottle(condition Condition, r rate.Limit, burst int) *throttler {
+	limiter := rate.NewLimiter(r, burst)
+	t.conditionLimiters = append(t.conditionLimiters, conditionLimiter{
+		condition: condition,
+		limiter:   limiter,
+	})
+	return t
+}
+
+func (t *throttler) WithServiceThrottle(serviceID string, r rate.Limit, burst int) *throttler {
+	return t.WithConditionThrottle(matchService(serviceID), r, burst)
+}
+
+func (t *throttler) WithOperationThrottle(serviceID string, operation string, r rate.Limit, burst int) *throttler {
+	return t.WithConditionThrottle(matchServiceOperation(serviceID, operation), r, burst)
+}
+
+func (t *throttler) WithOperationPatternThrottle(serviceID string, operationPtn *regexp.Regexp, r rate.Limit, burst int) *throttler {
+	return t.WithConditionThrottle(matchServiceOperationPattern(serviceID, operationPtn), r, burst)
+}
+
+func (t *throttler) InjectHandlers(handlers *request.Handlers) {
+	handlers.Sign.PushFrontNamed(request.NamedHandler{
+		Name: sdkHandlerRequestThrottle,
+		Fn:   t.beforeSign,
+	})
+}
+
+// beforeSign is added to the Sign chain; called before each request
+func (t *throttler) beforeSign(r *request.Request) {
+	for _, conditionLimiter := range t.conditionLimiters {
+		if conditionLimiter.condition(r) {
+			conditionLimiter.limiter.Wait(r.Context())
+		}
+	}
+}

--- a/pkg/aws/throttle/throttler_test.go
+++ b/pkg/aws/throttle/throttler_test.go
@@ -1,0 +1,203 @@
+package throttle
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func Test_throttler_InjectHandlers(t *testing.T) {
+	throttler := &throttler{}
+	handlers := request.Handlers{}
+	throttler.InjectHandlers(&handlers)
+	assert.Equal(t, 1, handlers.Sign.Len())
+}
+
+// Test beforeSign to check whether throttle applies correctly.
+// Note: the validCallsCount checks whether the observed calls falls into [ideal-1, ideal+1]
+// it shouldn't be too precious to avoid false alarms caused by CPU load when running tests.
+// structure your limits and testQPS, so that the expect QPS with/without throttle differs dramatically. (e.g. 10x)
+func Test_throttler_beforeSign(t *testing.T) {
+	type fields struct {
+		conditionLimiters []conditionLimiter
+	}
+	type args struct {
+		r *request.Request
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		testDuration    time.Duration
+		testQPS         int64
+		validCallsCount func(elapsedDuration time.Duration, observedCallsCount int64)
+	}{
+		{
+			name: "[single matching condition] throttle should applies",
+			fields: fields{
+				conditionLimiters: []conditionLimiter{
+					{
+						condition: func(r *request.Request) bool {
+							return true
+						},
+						limiter: rate.NewLimiter(10, 5),
+					},
+				},
+			},
+			args: args{
+				r: &request.Request{
+					HTTPRequest: &http.Request{},
+				},
+			},
+			testQPS: 100,
+			validCallsCount: func(elapsedDuration time.Duration, count int64) {
+				ideal := 5 + 10*elapsedDuration.Seconds()
+				// We should never get more requests than allowed.
+				if want := int64(ideal + 1); count > want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+				// We should get very close to the number of requests allowed.
+				if want := int64(ideal - 1); count < want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+			},
+		},
+		{
+			name: "[single non-matching condition] throttle shouldn't applies",
+			fields: fields{
+				conditionLimiters: []conditionLimiter{
+					{
+						condition: func(r *request.Request) bool {
+							return false
+						},
+						limiter: rate.NewLimiter(10, 5),
+					},
+				},
+			},
+			args: args{
+				r: &request.Request{
+					HTTPRequest: &http.Request{},
+				},
+			},
+			testQPS: 100,
+			validCallsCount: func(elapsedDuration time.Duration, count int64) {
+				ideal := 100 * elapsedDuration.Seconds()
+				// We should never get more requests than allowed.
+				if want := int64(ideal + 1); count > want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+				// We should get very close to the number of requests allowed.
+				if want := int64(ideal - 1); count < want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+			},
+		},
+		{
+			name: "[two condition, one matching and another non-matching] matching throttle should applies",
+			fields: fields{
+				conditionLimiters: []conditionLimiter{
+					{
+						condition: func(r *request.Request) bool {
+							return true
+						},
+						limiter: rate.NewLimiter(10, 5),
+					},
+					{
+						condition: func(r *request.Request) bool {
+							return false
+						},
+						limiter: rate.NewLimiter(1, 5),
+					},
+				},
+			},
+			args: args{
+				r: &request.Request{
+					HTTPRequest: &http.Request{},
+				},
+			},
+			testQPS: 100,
+			validCallsCount: func(elapsedDuration time.Duration, count int64) {
+				ideal := 5 + 10*elapsedDuration.Seconds()
+				// We should never get more requests than allowed.
+				if want := int64(ideal + 1); count > want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+				// We should get very close to the number of requests allowed.
+				if want := int64(ideal - 1); count < want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+			},
+		},
+		{
+			name: "[two condition, both matching] most restrictive throttle should applies",
+			fields: fields{
+				conditionLimiters: []conditionLimiter{
+					{
+						condition: func(r *request.Request) bool {
+							return true
+						},
+						limiter: rate.NewLimiter(10, 5),
+					},
+					{
+						condition: func(r *request.Request) bool {
+							return true
+						},
+						limiter: rate.NewLimiter(1, 5),
+					},
+				},
+			},
+			args: args{
+				r: &request.Request{
+					HTTPRequest: &http.Request{},
+				},
+			},
+			testQPS: 100,
+			validCallsCount: func(elapsedDuration time.Duration, count int64) {
+				ideal := 5 + 1*elapsedDuration.Seconds()
+				// We should never get more requests than allowed.
+				if want := int64(ideal + 1); count > want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+				// We should get very close to the number of requests allowed.
+				if want := int64(ideal - 1); count < want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t1 *testing.T) {
+			throttler := &throttler{
+				conditionLimiters: tt.fields.conditionLimiters,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			tt.args.r.SetContext(ctx)
+
+			observedCount := int64(0)
+			start := time.Now()
+			end := start.Add(time.Second * 1)
+			testQPSThrottle := time.Tick(time.Second / time.Duration(tt.testQPS))
+			var wg sync.WaitGroup
+			for time.Now().Before(end) {
+				wg.Add(1)
+				go func() {
+					throttler.beforeSign(tt.args.r)
+					atomic.AddInt64(&observedCount, 1)
+					wg.Done()
+				}()
+				<-testQPSThrottle
+			}
+			elapsed := time.Since(start)
+			tt.validCallsCount(elapsed, observedCount)
+			cancel()
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
Add default throttling for aws apis.
customer can override it via `--aws-api-throttle`.
the default value can be viewed:
```
      --aws-api-throttle serviceOperationsThrottleConfig   throttle settings for aws APIs, format: serviceID1:operationRegex1=rate:burst,serviceID2:operationRegex2=rate:burst (default App Mesh:^Describe|List=40:5,App Mesh:^Create|Update|Delete=8:5,ServiceDiscovery:^ListNamespaces=1:8,ServiceDiscovery:^ListServices=1:8,ServiceDiscovery:^CreateService=8:80,ServiceDiscovery:^ListInstances=40:400,ServiceDiscovery:^RegisterInstance|DeregisterInstance=4:80
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
