### PR TITLE
Metrics show continuous calls to RegisterInstance

### DIFF
--- a/pkg/aws/cloudmap.go
+++ b/pkg/aws/cloudmap.go
@@ -29,7 +29,7 @@ const (
 	AttrK8sPod = "k8s.io/pod"
 	//AttrK8sNamespace is a custom attribute injected by app-mesh controller
 	AttrK8sNamespace = "k8s.io/namespace"
-	AttrK8sApp = "app"
+	AttrK8sApp       = "app"
 )
 
 //CloudMapAPI is wrapper util to invoke CloudMap API

--- a/pkg/aws/cloudmap.go
+++ b/pkg/aws/cloudmap.go
@@ -29,6 +29,7 @@ const (
 	AttrK8sPod = "k8s.io/pod"
 	//AttrK8sNamespace is a custom attribute injected by app-mesh controller
 	AttrK8sNamespace = "k8s.io/namespace"
+	AttrK8sApp = "app"
 )
 
 //CloudMapAPI is wrapper util to invoke CloudMap API
@@ -172,8 +173,7 @@ func (c *Cloud) RegisterInstance(ctx context.Context, instanceID string, pod *co
 	}()
 
 	if pod.Status.Phase != corev1.PodRunning {
-		klog.V(4).Infof("Pod is in %s phase, skipping", pod.Status.Phase)
-		return nil
+		return fmt.Errorf("Pod is in %s phase, skipping", pod.Status.Phase)
 	}
 
 	serviceSummary, err := c.getService(ctx, cloudmapConfig)
@@ -182,7 +182,7 @@ func (c *Cloud) RegisterInstance(ctx context.Context, instanceID string, pod *co
 			awssdk.StringValue(cloudmapConfig.ServiceName),
 			awssdk.StringValue(cloudmapConfig.NamespaceName),
 			err)
-		return nil
+		return err
 	}
 
 	attr := make(map[string]*string)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -136,7 +136,7 @@ func NewController(
 		sq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		pq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		cloudMapInstanceCache:    cache.NewTTLStore(func(obj interface{}) (string, error) {
-			                                  return obj.(*CloudMapInstanceCacheItem).key, nil
+			                                  return obj.(*cloudMapInstanceCacheItem).key, nil
 		                                       }, 300*time.Second),
 		recorder:                recorder,
 		stats:                   stats,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -55,6 +55,7 @@ type Controller struct {
 	podsLister corev1listers.PodLister
 	podsSynced cache.InformerSynced
 
+
 	meshLister           meshlisters.MeshLister
 	meshIndex            cache.Indexer
 	meshSynced           cache.InformerSynced
@@ -74,6 +75,8 @@ type Controller struct {
 	nq workqueue.RateLimitingInterface
 	sq workqueue.RateLimitingInterface
 	pq workqueue.RateLimitingInterface
+
+	cloudMapInstanceCache   cache.Store
 
 	// recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
@@ -132,6 +135,9 @@ func NewController(
 		nq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		sq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		pq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		cloudMapInstanceCache:    cache.NewTTLStore(func(obj interface{}) (string, error) {
+			                                  return obj.(*CloudMapInstanceCacheItem).key, nil
+		                                       }, 300*time.Second),
 		recorder:                recorder,
 		stats:                   stats,
 		leaderElection:          leaderElection,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -55,7 +55,6 @@ type Controller struct {
 	podsLister corev1listers.PodLister
 	podsSynced cache.InformerSynced
 
-
 	meshLister           meshlisters.MeshLister
 	meshIndex            cache.Indexer
 	meshSynced           cache.InformerSynced
@@ -76,7 +75,7 @@ type Controller struct {
 	sq workqueue.RateLimitingInterface
 	pq workqueue.RateLimitingInterface
 
-	cloudMapInstanceCache   cache.Store
+	cloudMapInstanceCache cache.Store
 
 	// recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
@@ -119,25 +118,25 @@ func NewController(
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
 	controller := &Controller{
-		name:                    controllerAgentName,
-		cloud:                   cloud,
-		kubeclientset:           kubeclientset,
-		meshclientset:           meshclientset,
-		podsLister:              podInformer.Lister(),
-		podsSynced:              podInformer.Informer().HasSynced,
-		meshLister:              meshInformer.Lister(),
-		meshSynced:              meshInformer.Informer().HasSynced,
-		virtualNodeLister:       virtualNodeInformer.Lister(),
-		virtualNodeSynced:       virtualNodeInformer.Informer().HasSynced,
-		virtualServiceLister:    virtualServiceInformer.Lister(),
-		virtualServiceSynced:    virtualServiceInformer.Informer().HasSynced,
-		mq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		nq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		sq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		pq:                      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		cloudMapInstanceCache:    cache.NewTTLStore(func(obj interface{}) (string, error) {
-			                                  return obj.(*cloudMapInstanceCacheItem).key, nil
-		                                       }, 300*time.Second),
+		name:                 controllerAgentName,
+		cloud:                cloud,
+		kubeclientset:        kubeclientset,
+		meshclientset:        meshclientset,
+		podsLister:           podInformer.Lister(),
+		podsSynced:           podInformer.Informer().HasSynced,
+		meshLister:           meshInformer.Lister(),
+		meshSynced:           meshInformer.Informer().HasSynced,
+		virtualNodeLister:    virtualNodeInformer.Lister(),
+		virtualNodeSynced:    virtualNodeInformer.Informer().HasSynced,
+		virtualServiceLister: virtualServiceInformer.Lister(),
+		virtualServiceSynced: virtualServiceInformer.Informer().HasSynced,
+		mq:                   workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		nq:                   workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		sq:                   workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		pq:                   workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		cloudMapInstanceCache: cache.NewTTLStore(func(obj interface{}) (string, error) {
+			return obj.(*cloudMapInstanceCacheItem).key, nil
+		}, 300*time.Second),
 		recorder:                recorder,
 		stats:                   stats,
 		leaderElection:          leaderElection,

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -26,7 +26,7 @@ const (
 )
 
 
-type CloudMapInstanceCacheItem struct {
+type cloudMapInstanceCacheItem struct {
 	key             string
 	instanceSummary map[string]bool
 }
@@ -212,11 +212,11 @@ func (c *Controller) syncPod(ctx context.Context, pod *corev1.Pod) error {
 
 	cloudmapConfig := virtualNode.Data.Spec.ServiceDiscovery.AwsCloudMap
 
-	var serviceItem *CloudMapInstanceCacheItem
+	var serviceItem *cloudMapInstanceCacheItem
 	serviceInstanceSummary := make(map[string]bool)
 	cloudMapServiceKey := *cloudmapConfig.NamespaceName + "-" + *cloudmapConfig.ServiceName
 
-	existingItem, exists, _ := c.cloudMapInstanceCache.Get(&CloudMapInstanceCacheItem{
+	existingItem, exists, _ := c.cloudMapInstanceCache.Get(&cloudMapInstanceCacheItem{
 		key: cloudMapServiceKey,
 	})
 
@@ -228,13 +228,13 @@ func (c *Controller) syncPod(ctx context.Context, pod *corev1.Pod) error {
 		}
 		//Clear the instance from Cache.
 		if exists {
-			delete(existingItem.(*CloudMapInstanceCacheItem).instanceSummary, pod.Status.PodIP)
+			delete(existingItem.(*cloudMapInstanceCacheItem).instanceSummary, pod.Status.PodIP)
 		}
 		return nil
 	}
 
 	if exists {
-		serviceItem = existingItem.(*CloudMapInstanceCacheItem)
+		serviceItem = existingItem.(*cloudMapInstanceCacheItem)
 	} else {
 		//Retrieve CloudMap instances for this service
 		appmeshCloudMapConfig := &appmesh.AwsCloudMapServiceDiscovery{
@@ -252,7 +252,7 @@ func (c *Controller) syncPod(ctx context.Context, pod *corev1.Pod) error {
 				serviceInstanceSummary[instanceID] = true
 			}
 
-			serviceItem = &CloudMapInstanceCacheItem{
+			serviceItem = &cloudMapInstanceCacheItem{
 				key:             cloudMapServiceKey,
 				instanceSummary: serviceInstanceSummary,
 			}
@@ -280,7 +280,7 @@ func (c *Controller) syncPod(ctx context.Context, pod *corev1.Pod) error {
 		return err
 	}
 
-	serviceItem = &CloudMapInstanceCacheItem{
+	serviceItem = &cloudMapInstanceCacheItem{
 		key: cloudMapServiceKey,
 		instanceSummary: serviceInstanceSummary,
 	}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -24,7 +24,6 @@ const (
 	annotationAppMeshVirtualNodeName = "appmesh.k8s.aws/virtualNode"
 )
 
-
 type cloudMapInstanceCacheItem struct {
 	key             string
 	instanceSummary map[string]bool
@@ -261,15 +260,15 @@ func (c *Controller) syncPod(ctx context.Context, pod *corev1.Pod) error {
 	}
 
 	if serviceItem != nil {
-	   if _, ok := serviceItem.instanceSummary[pod.Status.PodIP]; !ok {
-		   //Right now we're not logging pod/instance health info to CloudMap. So, if it is in cache then it is
-		   //considered healthy. *TODO - v1.0* */
-		   serviceInstanceSummary = serviceItem.instanceSummary
-		   serviceInstanceSummary[pod.Status.PodIP] = true
-	   } else {
-		   klog.V(4).Info("Instance already %s registered under service  %s", pod.Name, *cloudmapConfig.ServiceName)
-		   return nil
-	   }
+		if _, ok := serviceItem.instanceSummary[pod.Status.PodIP]; !ok {
+			//Right now we're not logging pod/instance health info to CloudMap. So, if it is in cache then it is
+			//considered healthy. *TODO - v1.0* */
+			serviceInstanceSummary = serviceItem.instanceSummary
+			serviceInstanceSummary[pod.Status.PodIP] = true
+		} else {
+			klog.V(4).Info("Instance already %s registered under service  %s", pod.Name, *cloudmapConfig.ServiceName)
+			return nil
+		}
 	} else {
 		serviceInstanceSummary[pod.Status.PodIP] = true
 	}
@@ -281,7 +280,7 @@ func (c *Controller) syncPod(ctx context.Context, pod *corev1.Pod) error {
 	}
 
 	serviceItem = &cloudMapInstanceCacheItem{
-		key: cloudMapServiceKey,
+		key:             cloudMapServiceKey,
 		instanceSummary: serviceInstanceSummary,
 	}
 
@@ -291,7 +290,7 @@ func (c *Controller) syncPod(ctx context.Context, pod *corev1.Pod) error {
 }
 
 func (c *Controller) getServiceInstancesFromCloudMap(ctx context.Context,
-	           appmeshCloudMapConfig *appmesh.AwsCloudMapServiceDiscovery)([]*servicediscovery.InstanceSummary, error) {
+	appmeshCloudMapConfig *appmesh.AwsCloudMapServiceDiscovery) ([]*servicediscovery.InstanceSummary, error) {
 
 	instances, err := c.cloud.ListInstances(ctx, appmeshCloudMapConfig)
 	if err != nil {
@@ -299,8 +298,8 @@ func (c *Controller) getServiceInstancesFromCloudMap(ctx context.Context,
 		return instances, err
 	}
 
-	klog.V(4).Info(" Reach out to CloudMap for service: %s. Current Instance Count: ",
-		        *appmeshCloudMapConfig.ServiceName, len(instances))
+	klog.V(4).Info("Reach out to CloudMap for service: %s. Current Instance Count: ",
+		*appmeshCloudMapConfig.ServiceName, len(instances))
 	return instances, nil
 }
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"strings"
 	"time"
@@ -207,7 +206,8 @@ func (c *Controller) syncPod(ctx context.Context, pod *corev1.Pod) error {
 
 	if virtualNode.Data.Spec.ServiceDiscovery.AwsCloudMap.NamespaceName == nil ||
 		virtualNode.Data.Spec.ServiceDiscovery.AwsCloudMap.ServiceName == nil {
-		return fmt.Errorf("CloudMap NamespaceName or ServiceName is null")
+		klog.Errorf("CloudMap NamespaceName or ServiceName is null")
+		return nil
 	}
 
 	cloudmapConfig := virtualNode.Data.Spec.ServiceDiscovery.AwsCloudMap


### PR DESCRIPTION

*Issue #, if available:*
#160 

*Description of changes:*
Maintain a Cache of Registered instances in CloudMap per Service & NameSpace to avoid periodic registerinstace calls to CloudMap. Cache will be refreshed with CloudMap instance data every 5 mins.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
