### PR TITLE
initialize aws package

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/metrics"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/services"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/throttle"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Cloud interface {
+	// AppMesh provides API to AWS AppMesh
+	AppMesh() services.AppMesh
+	// CloudMap provides API to AWS CloudMap
+	CloudMap() services.CloudMap
+}
+
+// NewCloud constructs new Cloud implementation.
+func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, error) {
+	sess := session.Must(session.NewSession(aws.NewConfig()))
+	if cfg.ThrottleConfig != nil {
+		throttler := throttle.NewThrottler(cfg.ThrottleConfig)
+		throttler.InjectHandlers(&sess.Handlers)
+	}
+	if metricsRegisterer != nil {
+		metricsCollector, err := metrics.NewCollector(metricsRegisterer)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to initialize sdk metrics collector")
+		}
+		metricsCollector.InjectHandlers(&sess.Handlers)
+	}
+
+	if len(cfg.Region) == 0 {
+		metadata := services.NewEC2Metadata(sess)
+		region, err := metadata.Region()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to introspect region from EC2Metadata, specify --aws-region instead if EC2Metadata is unavailable")
+		}
+		cfg.Region = region
+	}
+
+	awsCfg := aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)
+	sess = sess.Copy(awsCfg)
+	return &defaultCloud{
+		cfg:      cfg,
+		appMesh:  services.NewAppMesh(sess),
+		cloudMap: services.NewCloudMap(sess),
+	}, nil
+}
+
+var _ Cloud = &defaultCloud{}
+
+type defaultCloud struct {
+	cfg CloudConfig
+
+	appMesh  services.AppMesh
+	cloudMap services.CloudMap
+}
+
+func (c *defaultCloud) AppMesh() services.AppMesh {
+	return c.appMesh
+}
+
+func (c *defaultCloud) CloudMap() services.CloudMap {
+	return c.cloudMap
+}

--- a/pkg/aws/cloud_config.go
+++ b/pkg/aws/cloud_config.go
@@ -1,0 +1,23 @@
+package aws
+
+import (
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/throttle"
+	"github.com/spf13/pflag"
+)
+
+const (
+	flagAWSRegion      = "aws-region"
+	flagAWSAPIThrottle = "aws-api-throttle"
+)
+
+type CloudConfig struct {
+	// AWS Region for the kubernetes cluster
+	Region string
+	// Throttle settings for aws APIs
+	ThrottleConfig *throttle.ServiceOperationsThrottleConfig
+}
+
+func (cfg *CloudConfig) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&cfg.Region, flagAWSRegion, "", "AWS Region for the kubernetes cluster")
+	fs.Var(cfg.ThrottleConfig, flagAWSAPIThrottle, "throttle settings for AWS APIs, format: serviceID1:operationRegex1=rate:burst,serviceID2:operationRegex2=rate:burst")
+}

--- a/pkg/aws/metrics/collector.go
+++ b/pkg/aws/metrics/collector.go
@@ -1,0 +1,110 @@
+package metrics
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/prometheus/client_golang/prometheus"
+	"strconv"
+	"time"
+)
+
+const (
+	sdkHandlerCollectAPICallMetric    = "collectAPICallMetric"
+	sdkHandlerCollectAPIRequestMetric = "collectAPIRequestMetric"
+)
+
+type collector struct {
+	instruments *instruments
+}
+
+func NewCollector(registerer prometheus.Registerer) (*collector, error) {
+	instruments, err := newInstruments(registerer)
+	if err != nil {
+		return nil, err
+	}
+	return &collector{
+		instruments: instruments,
+	}, nil
+}
+
+func (c *collector) InjectHandlers(handlers *request.Handlers) {
+	handlers.Complete.PushFrontNamed(request.NamedHandler{
+		Name: sdkHandlerCollectAPIRequestMetric,
+		Fn:   c.collectAPIRequestMetric,
+	})
+	handlers.Complete.PushFrontNamed(request.NamedHandler{
+		Name: sdkHandlerCollectAPICallMetric,
+		Fn:   c.collectAPICallMetric,
+	})
+}
+
+func (c *collector) collectAPIRequestMetric(r *request.Request) {
+	service := r.ClientInfo.ServiceID
+	operation := r.Operation.Name
+	statusCode := statusCodeForRequest(r)
+	errorCode := errorCodeForRequest(r)
+	duration := time.Since(r.AttemptTime)
+
+	c.instruments.apiRequestsTotal.With(map[string]string{
+		labelService:    service,
+		labelOperation:  operation,
+		labelStatusCode: statusCode,
+		labelErrorCode:  errorCode,
+	}).Inc()
+	c.instruments.apiRequestDurationSecond.With(map[string]string{
+		labelService:   service,
+		labelOperation: operation,
+	}).Observe(duration.Seconds())
+}
+
+func (c *collector) collectAPICallMetric(r *request.Request) {
+	service := r.ClientInfo.ServiceID
+	operation := r.Operation.Name
+	statusCode := statusCodeForRequest(r)
+	errorCode := errorCodeForRequest(r)
+	duration := time.Since(r.Time)
+
+	c.instruments.apiCallsTotal.With(map[string]string{
+		labelService:    service,
+		labelOperation:  operation,
+		labelStatusCode: statusCode,
+		labelErrorCode:  errorCode,
+	}).Inc()
+	c.instruments.apiCallDurationSeconds.With(map[string]string{
+		labelService:   service,
+		labelOperation: operation,
+	}).Observe(duration.Seconds())
+	c.instruments.apiCallRetries.With(map[string]string{
+		labelService:   service,
+		labelOperation: operation,
+	}).Observe(float64(r.RetryCount))
+}
+
+// statusCodeForRequest returns the http status code for request.
+// if there is no http response, returns "0".
+func statusCodeForRequest(r *request.Request) string {
+	if r.HTTPResponse != nil {
+		return strconv.Itoa(r.HTTPResponse.StatusCode)
+	}
+	return "0"
+}
+
+// errorCodeForRequest returns the error code for request.
+// if no error happened, returns "".
+func errorCodeForRequest(r *request.Request) string {
+	if r.Error != nil {
+		if awserr, ok := r.Error.(awserr.Error); ok {
+			return awserr.Code()
+		}
+		return "internal"
+	}
+	return ""
+}
+
+// operationForRequest returns the operation for request.
+func operationForRequest(r *request.Request) string {
+	if r.Operation != nil {
+		return r.Operation.Name
+	}
+	return "?"
+}

--- a/pkg/aws/metrics/collector_test.go
+++ b/pkg/aws/metrics/collector_test.go
@@ -1,0 +1,125 @@
+package metrics
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func Test_statusCodeForRequest(t *testing.T) {
+	type args struct {
+		r *request.Request
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "requests without http response",
+			args: args{
+				r: &request.Request{},
+			},
+			want: "0",
+		},
+		{
+			name: "requests with http response",
+			args: args{
+				r: &request.Request{
+					HTTPResponse: &http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			want: "200",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statusCodeForRequest(tt.args.r)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_errorCodeForRequest(t *testing.T) {
+	type args struct {
+		r *request.Request
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "requests without error",
+			args: args{
+				r: &request.Request{},
+			},
+			want: "",
+		},
+		{
+			name: "requests with internal error",
+			args: args{
+				r: &request.Request{
+					Error: errors.New("oops, some internal error"),
+				},
+			},
+			want: "internal",
+		},
+		{
+			name: "requests with aws error",
+			args: args{
+				r: &request.Request{
+					Error: awserr.New("NotFoundException", "", nil),
+				},
+			},
+			want: "NotFoundException",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := errorCodeForRequest(tt.args.r)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_operationForRequest(t *testing.T) {
+	type args struct {
+		r *request.Request
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "requests without operation",
+			args: args{
+				r: &request.Request{},
+			},
+			want: "?",
+		},
+		{
+			name: "requests with operation",
+			args: args{
+				r: &request.Request{
+					Operation: &request.Operation{
+						Name: "DescribeMesh",
+					},
+				},
+			},
+			want: "DescribeMesh",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := operationForRequest(tt.args.r)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/aws/metrics/instruments.go
+++ b/pkg/aws/metrics/instruments.go
@@ -1,0 +1,85 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricSubsystemAWS = "aws"
+
+	metricAPICallsTotal          = "api_calls_total"
+	metricAPICallDurationSeconds = "api_call_duration_seconds"
+	metricAPICallRetries         = "api_call_retries"
+
+	metricAPIRequestsTotal          = "api_requests_total"
+	metricAPIRequestDurationSeconds = "api_request_duration_seconds"
+)
+
+const (
+	labelService    = "service"
+	labelOperation  = "operation"
+	labelStatusCode = "status_code"
+	labelErrorCode  = "error_code"
+)
+
+type instruments struct {
+	apiCallsTotal            *prometheus.CounterVec
+	apiCallDurationSeconds   *prometheus.HistogramVec
+	apiCallRetries           *prometheus.HistogramVec
+	apiRequestsTotal         *prometheus.CounterVec
+	apiRequestDurationSecond *prometheus.HistogramVec
+}
+
+// newInstruments allocates and register new metrics to registerer
+func newInstruments(registerer prometheus.Registerer) (*instruments, error) {
+	apiCallsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: metricSubsystemAWS,
+		Name:      metricAPICallsTotal,
+		Help:      "Total number of SDK API calls from the customer's code to AWS services",
+	}, []string{labelService, labelOperation, labelStatusCode, labelErrorCode})
+	apiCallDurationSeconds := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: metricSubsystemAWS,
+		Name:      metricAPICallDurationSeconds,
+		Help:      "Perceived latency from when your code makes an SDK call, includes retries",
+	}, []string{labelService, labelOperation})
+	apiCallRetries := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: metricSubsystemAWS,
+		Name:      metricAPICallRetries,
+		Help:      "Number of times the SDK retried requests to AWS services for SDK API calls",
+		Buckets:   []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+	}, []string{labelService, labelOperation})
+
+	apiRequestsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: metricSubsystemAWS,
+		Name:      metricAPIRequestsTotal,
+		Help:      "Total number of HTTP requests that the SDK made",
+	}, []string{labelService, labelOperation, labelStatusCode, labelErrorCode})
+	apiRequestDurationSecond := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: metricSubsystemAWS,
+		Name:      metricAPIRequestDurationSeconds,
+		Help:      "Latency of an individual HTTP request to the service endpoint",
+	}, []string{labelService, labelOperation})
+
+	if err := registerer.Register(apiCallsTotal); err != nil {
+		return nil, err
+	}
+	if err := registerer.Register(apiCallDurationSeconds); err != nil {
+		return nil, err
+	}
+	if err := registerer.Register(apiCallRetries); err != nil {
+		return nil, err
+	}
+	if err := registerer.Register(apiRequestsTotal); err != nil {
+		return nil, err
+	}
+	if err := registerer.Register(apiRequestDurationSecond); err != nil {
+		return nil, err
+	}
+	return &instruments{
+		apiCallsTotal:            apiCallsTotal,
+		apiCallDurationSeconds:   apiCallDurationSeconds,
+		apiCallRetries:           apiCallRetries,
+		apiRequestsTotal:         apiRequestsTotal,
+		apiRequestDurationSecond: apiRequestDurationSecond,
+	}, nil
+}

--- a/pkg/aws/services/appmesh.go
+++ b/pkg/aws/services/appmesh.go
@@ -1,0 +1,22 @@
+package services
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/aws/aws-sdk-go/service/appmesh/appmeshiface"
+)
+
+type AppMesh interface {
+	appmeshiface.AppMeshAPI
+}
+
+// NewAppMesh constructs new AppMesh implementation.
+func NewAppMesh(session *session.Session) AppMesh {
+	return &defaultAppMesh{
+		AppMeshAPI: appmesh.New(session),
+	}
+}
+
+type defaultAppMesh struct {
+	appmeshiface.AppMeshAPI
+}

--- a/pkg/aws/services/cloudmap.go
+++ b/pkg/aws/services/cloudmap.go
@@ -1,0 +1,22 @@
+package services
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/aws/aws-sdk-go/service/servicediscovery/servicediscoveryiface"
+)
+
+type CloudMap interface {
+	servicediscoveryiface.ServiceDiscoveryAPI
+}
+
+// NewCloudMap constructs new CloudMap implementation.
+func NewCloudMap(session *session.Session) CloudMap {
+	return &defaultCloudMap{
+		ServiceDiscoveryAPI: servicediscovery.New(session),
+	}
+}
+
+type defaultCloudMap struct {
+	servicediscoveryiface.ServiceDiscoveryAPI
+}

--- a/pkg/aws/services/ec2_metadata.go
+++ b/pkg/aws/services/ec2_metadata.go
@@ -1,0 +1,21 @@
+package services
+
+import (
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+type EC2Metadata interface {
+	Region() (string, error)
+}
+
+// NewEC2Metadata constructs new EC2Metadata implementation.
+func NewEC2Metadata(session *session.Session) EC2Metadata {
+	return &defaultEC2Metadata{
+		EC2Metadata: ec2metadata.New(session),
+	}
+}
+
+type defaultEC2Metadata struct {
+	*ec2metadata.EC2Metadata
+}

--- a/pkg/aws/throttle/condition.go
+++ b/pkg/aws/throttle/condition.go
@@ -1,0 +1,32 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/aws/request"
+	"regexp"
+)
+
+type Condition func(r *request.Request) bool
+
+func matchService(serviceID string) Condition {
+	return func(r *request.Request) bool {
+		return r.ClientInfo.ServiceID == serviceID
+	}
+}
+
+func matchServiceOperation(serviceID string, operation string) Condition {
+	return func(r *request.Request) bool {
+		if r.Operation == nil {
+			return false
+		}
+		return r.ClientInfo.ServiceID == serviceID && r.Operation.Name == operation
+	}
+}
+
+func matchServiceOperationPattern(serviceID string, operationPtn *regexp.Regexp) Condition {
+	return func(r *request.Request) bool {
+		if r.Operation == nil {
+			return false
+		}
+		return r.ClientInfo.ServiceID == serviceID && operationPtn.Match([]byte(r.Operation.Name))
+	}
+}

--- a/pkg/aws/throttle/condition_test.go
+++ b/pkg/aws/throttle/condition_test.go
@@ -1,0 +1,207 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/aws/client/metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func Test_matchService(t *testing.T) {
+	type args struct {
+		serviceID string
+	}
+	tests := []struct {
+		name string
+		args args
+		req  *request.Request
+		want bool
+	}{
+		{
+			name: "service matches",
+			args: args{
+				serviceID: "App Mesh",
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "service mismatches",
+			args: args{
+				serviceID: "App Mesh",
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "S3",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predict := matchService(tt.args.serviceID)
+			got := predict(tt.req)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_matchServiceOperation(t *testing.T) {
+	type args struct {
+		serviceID string
+		operation string
+	}
+	tests := []struct {
+		name string
+		args args
+		req  *request.Request
+		want bool
+	}{
+		{
+			name: "operation matches",
+			args: args{
+				serviceID: "App Mesh",
+				operation: "CreateMesh",
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operation mismatches",
+			args: args{
+				serviceID: "App Mesh",
+				operation: "CreateMesh",
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "DescribeMesh",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predict := matchServiceOperation(tt.args.serviceID, tt.args.operation)
+			got := predict(tt.req)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_matchServiceOperationPattern(t *testing.T) {
+	type args struct {
+		serviceID    string
+		operationPtn *regexp.Regexp
+	}
+	tests := []struct {
+		name string
+		args args
+		req  *request.Request
+		want bool
+	}{
+		{
+			name: "operationPtn matches - case 1",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("Create"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operationPtn matches - case 2",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("Create.*"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operationPtn matches - case 3",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("^Create"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operationPtn matches - case 4",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("Mesh"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "operationPtn mismatches",
+			args: args{
+				serviceID:    "App Mesh",
+				operationPtn: regexp.MustCompile("Describe"),
+			},
+			req: &request.Request{
+				ClientInfo: metadata.ClientInfo{
+					ServiceID: "App Mesh",
+				},
+				Operation: &request.Operation{
+					Name: "CreateMesh",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predict := matchServiceOperationPattern(tt.args.serviceID, tt.args.operationPtn)
+			got := predict(tt.req)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/aws/throttle/config.go
+++ b/pkg/aws/throttle/config.go
@@ -1,0 +1,102 @@
+package throttle
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"golang.org/x/time/rate"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type throttleConfig struct {
+	operationPtn *regexp.Regexp
+	r            rate.Limit
+	burst        int
+}
+
+var _ pflag.Value = &ServiceOperationsThrottleConfig{}
+
+// serviceOperationsThrottleConfig is throttleConfig for each service's operations.
+// It supports to be configured using flags with format like "${serviceID}:${operationRegex}={rate}:{burst}"
+// e.g. "appmesh:DescribeMesh=1.3:5,appmesh:Create.*=1.7:3"
+// Note: default throttle for each service will be cleared if any override is set for that service.
+type ServiceOperationsThrottleConfig struct {
+	// service:operationRegex:config
+	value map[string][]throttleConfig
+}
+
+func (c *ServiceOperationsThrottleConfig) String() string {
+	if c == nil {
+		return ""
+	}
+
+	var configs []string
+	var serviceIDs []string
+	for serviceID := range c.value {
+		serviceIDs = append(serviceIDs, serviceID)
+	}
+	sort.Strings(serviceIDs)
+	for _, serviceID := range serviceIDs {
+		for _, operationsThrottleConfig := range c.value[serviceID] {
+			configs = append(configs, fmt.Sprintf("%s:%s=%v:%d",
+				serviceID,
+				operationsThrottleConfig.operationPtn.String(),
+				operationsThrottleConfig.r,
+				operationsThrottleConfig.burst,
+			))
+		}
+	}
+	return strings.Join(configs, ",")
+}
+
+func (c *ServiceOperationsThrottleConfig) Set(val string) error {
+	valueOverride := make(map[string][]throttleConfig)
+	configPairs := strings.Split(val, ",")
+	for _, pair := range configPairs {
+		kv := strings.Split(pair, "=")
+		if len(kv) != 2 {
+			return errors.Errorf("%s must be formatted as serviceID:operationRegex=rate:burst", pair)
+		}
+		serviceIDOperationRegexPair := strings.Split(kv[0], ":")
+		if len(serviceIDOperationRegexPair) != 2 {
+			return errors.Errorf("%s must be formatted as serviceID:operationRegex", kv[0])
+		}
+		rateBurstPair := strings.Split(kv[1], ":")
+		if len(rateBurstPair) != 2 {
+			return errors.Errorf("%s must be formatted as rate:burst", kv[1])
+		}
+		serviceID := serviceIDOperationRegexPair[0]
+		operationPtn, err := regexp.Compile(serviceIDOperationRegexPair[1])
+		if err != nil {
+			return errors.Errorf("%s must be valid regex expression for operation", serviceIDOperationRegexPair[1])
+		}
+		r, err := strconv.ParseFloat(rateBurstPair[0], 64)
+		if err != nil {
+			return errors.Errorf("%s must be valid float number as rate for operations per second", rateBurstPair[0])
+		}
+		burst, err := strconv.Atoi(rateBurstPair[1])
+		if err != nil {
+			return errors.Errorf("%s must be valid integer as burst for operations", rateBurstPair[1])
+		}
+		valueOverride[serviceID] = append(valueOverride[serviceID], throttleConfig{
+			operationPtn: operationPtn,
+			r:            rate.Limit(r),
+			burst:        burst,
+		})
+	}
+
+	if c.value == nil {
+		c.value = make(map[string][]throttleConfig)
+	}
+	for k, v := range valueOverride {
+		c.value[k] = v
+	}
+	return nil
+}
+
+func (c *ServiceOperationsThrottleConfig) Type() string {
+	return "serviceOperationsThrottleConfig"
+}

--- a/pkg/aws/throttle/config_test.go
+++ b/pkg/aws/throttle/config_test.go
@@ -1,0 +1,259 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func TestServiceOperationsThrottleConfig_String(t *testing.T) {
+	type fields struct {
+		value map[string][]throttleConfig
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "non-empty value",
+			fields: fields{
+				value: map[string][]throttleConfig{
+					appmesh.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        5,
+						},
+						{
+							operationPtn: regexp.MustCompile("CreateMesh"),
+							r:            4.2,
+							burst:        5,
+						},
+					},
+					servicediscovery.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        5,
+						},
+					},
+				},
+			},
+			want: "App Mesh:^Describe=4.2:5,App Mesh:CreateMesh=4.2:5,ServiceDiscovery:^Describe=4.2:5",
+		},
+		{
+			name: "nil value",
+			fields: fields{
+				value: nil,
+			},
+			want: "",
+		},
+		{
+			name: "empty value",
+			fields: fields{
+				value: nil,
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ServiceOperationsThrottleConfig{
+				value: tt.fields.value,
+			}
+			got := c.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestServiceOperationsThrottleConfig_Set(t *testing.T) {
+	type fields struct {
+		value map[string][]throttleConfig
+	}
+	type args struct {
+		val string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    ServiceOperationsThrottleConfig
+		wantErr error
+	}{
+		{
+			name: "when default value is nil",
+			fields: fields{
+				value: nil,
+			},
+			args: args{
+				val: "App Mesh:^Describe=4.2:5,App Mesh:CreateMesh=4.2:6,ServiceDiscovery:^Describe=4.2:7",
+			},
+			want: ServiceOperationsThrottleConfig{
+				value: map[string][]throttleConfig{
+					appmesh.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        5,
+						},
+						{
+							operationPtn: regexp.MustCompile("CreateMesh"),
+							r:            4.2,
+							burst:        6,
+						},
+					},
+					servicediscovery.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        7,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "when default value contains non-empty defaults",
+			fields: fields{
+				value: map[string][]throttleConfig{
+					elbv2.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Create"),
+							r:            4.2,
+							burst:        4,
+						},
+					},
+				},
+			},
+			args: args{
+				val: "App Mesh:^Describe=4.2:5,App Mesh:CreateMesh=4.2:6,ServiceDiscovery:^Describe=4.2:7",
+			},
+			want: ServiceOperationsThrottleConfig{
+				value: map[string][]throttleConfig{
+					elbv2.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Create"),
+							r:            4.2,
+							burst:        4,
+						},
+					},
+					appmesh.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        5,
+						},
+						{
+							operationPtn: regexp.MustCompile("CreateMesh"),
+							r:            4.2,
+							burst:        6,
+						},
+					},
+					servicediscovery.ServiceID: {
+						{
+							operationPtn: regexp.MustCompile("^Describe"),
+							r:            4.2,
+							burst:        7,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "when val is empty",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "",
+			},
+			wantErr: errors.Errorf(" must be formatted as serviceID:operationRegex=rate:burst"),
+		},
+		{
+			name: "when val is not valid format - case 1",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a=b=c",
+			},
+			wantErr: errors.Errorf("a=b=c must be formatted as serviceID:operationRegex=rate:burst"),
+		},
+		{
+			name: "when val is not valid format - case 2",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:b:c=4.2:5",
+			},
+			wantErr: errors.Errorf("a:b:c must be formatted as serviceID:operationRegex"),
+		},
+		{
+			name: "when val is not valid format - case 3",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:b=4.2:5:6",
+			},
+			wantErr: errors.Errorf("4.2:5:6 must be formatted as rate:burst"),
+		},
+		{
+			name: "when operationPtn is not valid regex",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:^[Describe=4.2:5",
+			},
+			wantErr: errors.Errorf("^[Describe must be valid regex expression for operation"),
+		},
+		{
+			name: "when rate is not valid float number",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:^Describe=4.x:5",
+			},
+			wantErr: errors.Errorf("4.x must be valid float number as rate for operations per second"),
+		},
+		{
+			name: "when burst is not valid integer",
+			fields: fields{
+				value: map[string][]throttleConfig{},
+			},
+			args: args{
+				val: "a:^Describe=4.2:5x",
+			},
+			wantErr: errors.Errorf("5x must be valid integer as burst for operations"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ServiceOperationsThrottleConfig{
+				value: tt.fields.value,
+			}
+			err := c.Set(tt.args.val)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, *c)
+			}
+		})
+	}
+}
+
+func TestServiceOperationsThrottleConfig_Type(t *testing.T) {
+	c := &ServiceOperationsThrottleConfig{}
+	got := c.Type()
+	assert.Equal(t, "serviceOperationsThrottleConfig", got)
+}

--- a/pkg/aws/throttle/defaults.go
+++ b/pkg/aws/throttle/defaults.go
@@ -1,0 +1,55 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"golang.org/x/time/rate"
+	"regexp"
+)
+
+// NewDefaultServiceOperationsThrottleConfig returns a ServiceOperationsThrottleConfig with default settings.
+func NewDefaultServiceOperationsThrottleConfig() *ServiceOperationsThrottleConfig {
+	return &ServiceOperationsThrottleConfig{
+		value: map[string][]throttleConfig{
+			appmesh.ServiceID: {
+				{
+					operationPtn: regexp.MustCompile("^Describe|List"),
+					r:            rate.Limit(40),
+					burst:        5,
+				},
+				{
+					operationPtn: regexp.MustCompile("^Create|Update|Delete"),
+					r:            rate.Limit(8),
+					burst:        5,
+				},
+			},
+			servicediscovery.ServiceID: {
+				{
+					operationPtn: regexp.MustCompile("^ListNamespaces"),
+					r:            rate.Limit(1),
+					burst:        8,
+				},
+				{
+					operationPtn: regexp.MustCompile("^ListServices"),
+					r:            rate.Limit(1),
+					burst:        8,
+				},
+				{
+					operationPtn: regexp.MustCompile("^CreateService"),
+					r:            rate.Limit(8),
+					burst:        80,
+				},
+				{
+					operationPtn: regexp.MustCompile("^ListInstances"),
+					r:            rate.Limit(40),
+					burst:        400,
+				},
+				{
+					operationPtn: regexp.MustCompile("^RegisterInstance|DeregisterInstance"),
+					r:            rate.Limit(4),
+					burst:        80,
+				},
+			},
+		},
+	}
+}

--- a/pkg/aws/throttle/throttler.go
+++ b/pkg/aws/throttle/throttler.go
@@ -1,0 +1,70 @@
+package throttle
+
+import (
+	"github.com/aws/aws-sdk-go/aws/request"
+	"golang.org/x/time/rate"
+	"regexp"
+)
+
+const sdkHandlerRequestThrottle = "requestThrottle"
+
+type conditionLimiter struct {
+	condition Condition
+	limiter   *rate.Limiter
+}
+
+type throttler struct {
+	conditionLimiters []conditionLimiter
+}
+
+// NewThrottler constructs new request throttler instance.
+func NewThrottler(config *ServiceOperationsThrottleConfig) *throttler {
+	throttler := &throttler{}
+	for serviceID, operationsThrottleConfigs := range config.value {
+		for _, operationsThrottleConfig := range operationsThrottleConfigs {
+			throttler = throttler.WithOperationPatternThrottle(
+				serviceID,
+				operationsThrottleConfig.operationPtn,
+				operationsThrottleConfig.r,
+				operationsThrottleConfig.burst)
+		}
+	}
+	return throttler
+}
+
+func (t *throttler) WithConditionThrottle(condition Condition, r rate.Limit, burst int) *throttler {
+	limiter := rate.NewLimiter(r, burst)
+	t.conditionLimiters = append(t.conditionLimiters, conditionLimiter{
+		condition: condition,
+		limiter:   limiter,
+	})
+	return t
+}
+
+func (t *throttler) WithServiceThrottle(serviceID string, r rate.Limit, burst int) *throttler {
+	return t.WithConditionThrottle(matchService(serviceID), r, burst)
+}
+
+func (t *throttler) WithOperationThrottle(serviceID string, operation string, r rate.Limit, burst int) *throttler {
+	return t.WithConditionThrottle(matchServiceOperation(serviceID, operation), r, burst)
+}
+
+func (t *throttler) WithOperationPatternThrottle(serviceID string, operationPtn *regexp.Regexp, r rate.Limit, burst int) *throttler {
+	return t.WithConditionThrottle(matchServiceOperationPattern(serviceID, operationPtn), r, burst)
+}
+
+func (t *throttler) InjectHandlers(handlers *request.Handlers) {
+	handlers.Sign.PushFrontNamed(request.NamedHandler{
+		Name: sdkHandlerRequestThrottle,
+		Fn:   t.beforeSign,
+	})
+}
+
+// beforeSign is added to the Sign chain; called before each request
+func (t *throttler) beforeSign(r *request.Request) {
+	for _, conditionLimiter := range t.conditionLimiters {
+		if conditionLimiter.condition(r) {
+			conditionLimiter.limiter.Wait(r.Context())
+		}
+	}
+}

--- a/pkg/aws/throttle/throttler_test.go
+++ b/pkg/aws/throttle/throttler_test.go
@@ -1,0 +1,203 @@
+package throttle
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func Test_throttler_InjectHandlers(t *testing.T) {
+	throttler := &throttler{}
+	handlers := request.Handlers{}
+	throttler.InjectHandlers(&handlers)
+	assert.Equal(t, 1, handlers.Sign.Len())
+}
+
+// Test beforeSign to check whether throttle applies correctly.
+// Note: the validCallsCount checks whether the observed calls falls into [ideal-1, ideal+1]
+// it shouldn't be too precisely to avoid false alarms caused by CPU load when running tests.
+// structure your limits and testQPS, so that the expect QPS with/without throttle differs dramatically. (e.g. 10x)
+func Test_throttler_beforeSign(t *testing.T) {
+	type fields struct {
+		conditionLimiters []conditionLimiter
+	}
+	type args struct {
+		r *request.Request
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		testDuration    time.Duration
+		testQPS         int64
+		validCallsCount func(elapsedDuration time.Duration, observedCallsCount int64)
+	}{
+		{
+			name: "[single matching condition] throttle should applies",
+			fields: fields{
+				conditionLimiters: []conditionLimiter{
+					{
+						condition: func(r *request.Request) bool {
+							return true
+						},
+						limiter: rate.NewLimiter(10, 5),
+					},
+				},
+			},
+			args: args{
+				r: &request.Request{
+					HTTPRequest: &http.Request{},
+				},
+			},
+			testQPS: 100,
+			validCallsCount: func(elapsedDuration time.Duration, count int64) {
+				ideal := 5 + 10*elapsedDuration.Seconds()
+				// We should never get more requests than allowed.
+				if want := int64(ideal + 1); count > want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+				// We should get very close to the number of requests allowed.
+				if want := int64(ideal - 1); count < want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+			},
+		},
+		{
+			name: "[single non-matching condition] throttle shouldn't applies",
+			fields: fields{
+				conditionLimiters: []conditionLimiter{
+					{
+						condition: func(r *request.Request) bool {
+							return false
+						},
+						limiter: rate.NewLimiter(10, 5),
+					},
+				},
+			},
+			args: args{
+				r: &request.Request{
+					HTTPRequest: &http.Request{},
+				},
+			},
+			testQPS: 100,
+			validCallsCount: func(elapsedDuration time.Duration, count int64) {
+				ideal := 100 * elapsedDuration.Seconds()
+				// We should never get more requests than allowed.
+				if want := int64(ideal + 1); count > want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+				// We should get very close to the number of requests allowed.
+				if want := int64(ideal - 1); count < want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+			},
+		},
+		{
+			name: "[two condition, one matching and another non-matching] matching throttle should applies",
+			fields: fields{
+				conditionLimiters: []conditionLimiter{
+					{
+						condition: func(r *request.Request) bool {
+							return true
+						},
+						limiter: rate.NewLimiter(10, 5),
+					},
+					{
+						condition: func(r *request.Request) bool {
+							return false
+						},
+						limiter: rate.NewLimiter(1, 5),
+					},
+				},
+			},
+			args: args{
+				r: &request.Request{
+					HTTPRequest: &http.Request{},
+				},
+			},
+			testQPS: 100,
+			validCallsCount: func(elapsedDuration time.Duration, count int64) {
+				ideal := 5 + 10*elapsedDuration.Seconds()
+				// We should never get more requests than allowed.
+				if want := int64(ideal + 1); count > want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+				// We should get very close to the number of requests allowed.
+				if want := int64(ideal - 1); count < want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+			},
+		},
+		{
+			name: "[two condition, both matching] most restrictive throttle should applies",
+			fields: fields{
+				conditionLimiters: []conditionLimiter{
+					{
+						condition: func(r *request.Request) bool {
+							return true
+						},
+						limiter: rate.NewLimiter(10, 5),
+					},
+					{
+						condition: func(r *request.Request) bool {
+							return true
+						},
+						limiter: rate.NewLimiter(1, 5),
+					},
+				},
+			},
+			args: args{
+				r: &request.Request{
+					HTTPRequest: &http.Request{},
+				},
+			},
+			testQPS: 100,
+			validCallsCount: func(elapsedDuration time.Duration, count int64) {
+				ideal := 5 + 1*elapsedDuration.Seconds()
+				// We should never get more requests than allowed.
+				if want := int64(ideal + 1); count > want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+				// We should get very close to the number of requests allowed.
+				if want := int64(ideal - 1); count < want {
+					t.Errorf("count = %d, want %d (ideal %f", count, want, ideal)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t1 *testing.T) {
+			throttler := &throttler{
+				conditionLimiters: tt.fields.conditionLimiters,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			tt.args.r.SetContext(ctx)
+
+			observedCount := int64(0)
+			start := time.Now()
+			end := start.Add(time.Second * 1)
+			testQPSThrottle := time.Tick(time.Second / time.Duration(tt.testQPS))
+			var wg sync.WaitGroup
+			for time.Now().Before(end) {
+				wg.Add(1)
+				go func() {
+					throttler.beforeSign(tt.args.r)
+					atomic.AddInt64(&observedCount, 1)
+					wg.Done()
+				}()
+				<-testQPSThrottle
+			}
+			elapsed := time.Since(start)
+			tt.validCallsCount(elapsed, observedCount)
+			cancel()
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
# changes done
1. "add aws sdk throttle support" same change as https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/163. (already approve for master branch)
2. "add aws sdk metrics support"
     1. supports collect below metrics:
        * `aws_api_calls_total` (Total number of SDK API calls from the customer's code to AWS services)
        * `aws_api_call_duration_seconds` (Perceived latency from when your code makes an SDK call, includes retries)
        * `aws_api_call_retries` (Number of times the SDK retried requests to AWS services for SDK API calls)
        * `aws_api_requests_total` (Total number of HTTP requests that the SDK made)
        * `aws_api_request_duration_seconds` (Latency of an individual HTTP request to the service endpoint)
     2. difference than current metrics implementation used in master branch:
        1. more accurate, it now reports both latency/count from SDKClient's perspective and awsAPI's perspective. (a single SDK client apis call may result in multiple aws API calls)
       2. there isn't a separate `aws_api_errors` metric, error code are now models as a label per prometheus best practice.
       3. rely on session handler, so less intrusive into SDK wrapper.
3. "add thin sdk wrapper":
      1. the aws.cloud is meant as thin wrappers around aws SDK and aws related settings.
      2. the wrapper interface around sdk's api-iface is to allow us add helper method like `DescribeMeshesAsList` to handle pagination.
      3. the aws.cloud  have method to return interface to different services instead of embed them(there could be method conflict among services if embed them)
          