### PR TITLE
V1beta2 gateway

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -29,6 +29,24 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-appmesh-k8s-aws-v1beta2-virtualgateway
+  failurePolicy: Fail
+  name: mvirtualgateway.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - appmesh.k8s.aws
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualgateways
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-appmesh-k8s-aws-v1beta2-virtualnode
   failurePolicy: Fail
   name: mvirtualnode.appmesh.k8s.aws
@@ -121,6 +139,24 @@ webhooks:
     - UPDATE
     resources:
     - meshes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appmesh-k8s-aws-v1beta2-virtualgateway
+  failurePolicy: Fail
+  name: vvirtualgateway.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - appmesh.k8s.aws
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualgateways
 - clientConfig:
     caBundle: Cg==
     service:

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,11 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gomodules.xyz/jsonpatch/v2 v2.0.1
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.2

--- a/webhooks/appmesh/virtualgateway_mutator.go
+++ b/webhooks/appmesh/virtualgateway_mutator.go
@@ -1,0 +1,77 @@
+package appmesh
+
+import (
+	"context"
+	"fmt"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/mesh"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/webhook"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const apiPathMutateAppMeshVirtualGateway = "/mutate-appmesh-k8s-aws-v1beta2-virtualgateway"
+
+// NewVirtualGatewayMutator returns a mutator for VirtualGateway.
+func NewVirtualGatewayMutator(meshMembershipDesignator mesh.MembershipDesignator) *virtualGatewayMutator {
+	return &virtualGatewayMutator{
+		meshMembershipDesignator: meshMembershipDesignator,
+	}
+}
+
+var _ webhook.Mutator = &virtualGatewayMutator{}
+
+type virtualGatewayMutator struct {
+	meshMembershipDesignator mesh.MembershipDesignator
+}
+
+func (m *virtualGatewayMutator) Prototype(req admission.Request) (runtime.Object, error) {
+	return &appmesh.VirtualGateway{}, nil
+}
+
+func (m *virtualGatewayMutator) MutateCreate(ctx context.Context, obj runtime.Object) (runtime.Object, error) {
+	vg := obj.(*appmesh.VirtualGateway)
+	if err := m.designateMeshMembership(ctx, vg); err != nil {
+		return nil, err
+	}
+	if err := m.defaultingAWSName(vg); err != nil {
+		return nil, err
+	}
+
+	return vg, nil
+}
+
+func (m *virtualGatewayMutator) MutateUpdate(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
+	return obj, nil
+}
+
+func (m *virtualGatewayMutator) defaultingAWSName(vg *appmesh.VirtualGateway) error {
+	if vg.Spec.AWSName == nil || len(*vg.Spec.AWSName) == 0 {
+		awsName := fmt.Sprintf("%s_%s", vg.Name, vg.Namespace)
+		vg.Spec.AWSName = &awsName
+	}
+	return nil
+}
+
+func (m *virtualGatewayMutator) designateMeshMembership(ctx context.Context, vg *appmesh.VirtualGateway) error {
+	if vg.Spec.MeshRef != nil {
+		return errors.Errorf("%s create may not specify read-only field: %s", "VirtualGateway", "spec.meshRef")
+	}
+	mesh, err := m.meshMembershipDesignator.Designate(ctx, vg)
+	if err != nil {
+		return err
+	}
+	vg.Spec.MeshRef = &appmesh.MeshReference{
+		Name: mesh.Name,
+		UID:  mesh.UID,
+	}
+	return nil
+}
+
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=mvirtualgateway.appmesh.k8s.aws
+
+func (m *virtualGatewayMutator) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register(apiPathMutateAppMeshVirtualGateway, webhook.MutatingWebhookForMutator(m))
+}

--- a/webhooks/appmesh/virtualgateway_mutator_test.go
+++ b/webhooks/appmesh/virtualgateway_mutator_test.go
@@ -1,0 +1,216 @@
+package appmesh
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	mock_mesh "github.com/aws/aws-app-mesh-controller-for-k8s/mocks/aws-app-mesh-controller-for-k8s/pkg/mesh"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_virtualGatewayMutator_defaultingAWSName(t *testing.T) {
+	type args struct {
+		vGateway *appmesh.VirtualGateway
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *appmesh.VirtualGateway
+		wantErr error
+	}{
+		{
+			name: "VirtualGateway didn't specify awsName",
+			args: args{
+				vGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{},
+				},
+			},
+			want: &appmesh.VirtualGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-vg",
+				},
+				Spec: appmesh.VirtualGatewaySpec{
+					AWSName: aws.String("my-vg_my-ns"),
+				},
+			},
+		},
+		{
+			name: "VirtualGateway specified empty awsName",
+			args: args{
+				vGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String(""),
+					},
+				},
+			},
+			want: &appmesh.VirtualGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-vg",
+				},
+				Spec: appmesh.VirtualGatewaySpec{
+					AWSName: aws.String("my-vg_my-ns"),
+				},
+			},
+		},
+		{
+			name: "VirtualGateway specified non-empty awsName",
+			args: args{
+				vGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_my-ns_my-cluster"),
+					},
+				},
+			},
+			want: &appmesh.VirtualGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-vg",
+				},
+				Spec: appmesh.VirtualGatewaySpec{
+					AWSName: aws.String("my-vg_my-ns_my-cluster"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &virtualGatewayMutator{}
+			err := m.defaultingAWSName(tt.args.vGateway)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, tt.args.vGateway)
+			}
+		})
+	}
+}
+
+func Test_virtualGatewayMutator_designateMeshMembership(t *testing.T) {
+	type fields struct {
+		meshMembershipDesignatorDesignate func(ctx context.Context, obj metav1.Object) (*appmesh.Mesh, error)
+	}
+	type args struct {
+		vGateway *appmesh.VirtualGateway
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *appmesh.VirtualGateway
+		wantErr error
+	}{
+		{
+			name: "successfully designate mesh membership",
+			fields: fields{
+				meshMembershipDesignatorDesignate: func(ctx context.Context, obj metav1.Object) (*appmesh.Mesh, error) {
+					return &appmesh.Mesh{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					}, nil
+				},
+			},
+			args: args{
+				vGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{},
+				},
+			},
+			want: &appmesh.VirtualGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-vg",
+				},
+				Spec: appmesh.VirtualGatewaySpec{
+					MeshRef: &appmesh.MeshReference{
+						Name: "my-mesh",
+						UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+					},
+				},
+			},
+		},
+		{
+			name: "failed to designate mesh membership",
+			fields: fields{
+				meshMembershipDesignatorDesignate: func(ctx context.Context, obj metav1.Object) (*appmesh.Mesh, error) {
+					return nil, errors.New("oops, some error happened")
+				},
+			},
+			args: args{
+				vGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{},
+				},
+			},
+			wantErr: errors.New("oops, some error happened"),
+		},
+		{
+			name:   "meshRef already specified",
+			fields: fields{},
+			args: args{
+				vGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+			},
+			wantErr: errors.New("VirtualGateway create may not specify read-only field: spec.meshRef"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			designator := mock_mesh.NewMockMembershipDesignator(ctrl)
+			if tt.fields.meshMembershipDesignatorDesignate != nil {
+				designator.EXPECT().Designate(gomock.Any(), gomock.Any()).DoAndReturn(tt.fields.meshMembershipDesignatorDesignate)
+			}
+
+			m := &virtualGatewayMutator{
+				meshMembershipDesignator: designator,
+			}
+			err := m.designateMeshMembership(ctx, tt.args.vGateway)
+
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, tt.args.vGateway)
+			}
+		})
+	}
+}

--- a/webhooks/appmesh/virtualgateway_validator.go
+++ b/webhooks/appmesh/virtualgateway_validator.go
@@ -1,0 +1,67 @@
+package appmesh
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/webhook"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"strings"
+)
+
+const apiPathValidateAppMeshVirtualGateway = "/validate-appmesh-k8s-aws-v1beta2-virtualgateway"
+
+// NewVirtualGatewayValidator returns a validator for VirtualGateway.
+func NewVirtualGatewayValidator() *virtualGatewayValidator {
+	return &virtualGatewayValidator{}
+}
+
+var _ webhook.Validator = &virtualGatewayValidator{}
+
+type virtualGatewayValidator struct {
+}
+
+func (v *virtualGatewayValidator) Prototype(req admission.Request) (runtime.Object, error) {
+	return &appmesh.VirtualGateway{}, nil
+}
+
+func (v *virtualGatewayValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func (v *virtualGatewayValidator) ValidateUpdate(ctx context.Context, obj runtime.Object, oldObj runtime.Object) error {
+	newVGateway := obj.(*appmesh.VirtualGateway)
+	oldVGateway := oldObj.(*appmesh.VirtualGateway)
+	if err := v.enforceFieldsImmutability(newVGateway, oldVGateway); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *virtualGatewayValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+// enforceFieldsImmutability will enforce immutable fields are not changed.
+func (v *virtualGatewayValidator) enforceFieldsImmutability(newVGateway *appmesh.VirtualGateway, oldVGateway *appmesh.VirtualGateway) error {
+	var changedImmutableFields []string
+	if !reflect.DeepEqual(newVGateway.Spec.AWSName, oldVGateway.Spec.AWSName) {
+		changedImmutableFields = append(changedImmutableFields, "spec.awsName")
+	}
+	if !reflect.DeepEqual(newVGateway.Spec.MeshRef, oldVGateway.Spec.MeshRef) {
+		changedImmutableFields = append(changedImmutableFields, "spec.meshRef")
+	}
+	if len(changedImmutableFields) != 0 {
+		return errors.Errorf("%s update may not change these fields: %s", "VirtualGateway", strings.Join(changedImmutableFields, ","))
+	}
+	return nil
+}
+
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=vvirtualgateway.appmesh.k8s.aws
+
+func (v *virtualGatewayValidator) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register(apiPathValidateAppMeshVirtualGateway, webhook.ValidatingWebhookForValidator(v))
+}

--- a/webhooks/appmesh/virtualgateway_validator_test.go
+++ b/webhooks/appmesh/virtualgateway_validator_test.go
@@ -1,0 +1,162 @@
+package appmesh
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_virtualGatewayValidator_enforceFieldsImmutability(t *testing.T) {
+	type args struct {
+		newVGateway *appmesh.VirtualGateway
+		oldVGateway *appmesh.VirtualGateway
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "VirtualGateway immutable fields didn't change",
+			args: args{
+				newVGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "app-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_app-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+				oldVGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "app-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_app-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "VirtualGateway field awsName changed",
+			args: args{
+				newVGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "app-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_app-ns_my-cluster"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+				oldVGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "app-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_app-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+			},
+			wantErr: errors.New("VirtualGateway update may not change these fields: spec.awsName"),
+		},
+		{
+			name: "VirtualGateway field meshRef changed",
+			args: args{
+				newVGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "app-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_app-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "another-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+				oldVGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "app-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_app-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+			},
+			wantErr: errors.New("VirtualGateway update may not change these fields: spec.meshRef"),
+		},
+		{
+			name: "VirtualGateway fields awsName and meshRef changed",
+			args: args{
+				newVGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "app-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_app-ns_my-cluster"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "another-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+				oldVGateway: &appmesh.VirtualGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "app-ns",
+						Name:      "my-vg",
+					},
+					Spec: appmesh.VirtualGatewaySpec{
+						AWSName: aws.String("my-vg_app-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+			},
+			wantErr: errors.New("VirtualGateway update may not change these fields: spec.awsName,spec.meshRef"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &virtualGatewayValidator{}
+			err := v.enforceFieldsImmutability(tt.args.newVGateway, tt.args.oldVGateway)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
[aws-app-mesh-roadmap #37](https://github.com/aws/aws-app-mesh-roadmap/issues/37)

*Description of changes:*
Adding mutator and validator for Virtual Gateway API. The mutator adds the immutable fields (awsName and meshId) whereas the validator validates that the immutable fields are not changed between updates.

Note for reviewer:
The PR is separated into 2 commits, only the 1st one needs to be reviewed while the second one is auto-generated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
