### PR TITLE
Add controller for Mesh

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/metrics"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/services"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/throttle"
@@ -16,6 +17,11 @@ type Cloud interface {
 	AppMesh() services.AppMesh
 	// CloudMap provides API to AWS CloudMap
 	CloudMap() services.CloudMap
+	// STS provides API to AWS STS
+	STS() services.STS
+
+	// AccountID provides AccountID for the kubernetes cluster
+	AccountID() string
 }
 
 // NewCloud constructs new Cloud implementation.
@@ -44,10 +50,19 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 
 	awsCfg := aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)
 	sess = sess.Copy(awsCfg)
+	sts := services.NewSTS(sess)
+	if len(cfg.AccountID) == 0 {
+		accountID, err := sts.AccountID(context.Background())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to introspect accountID from STS, specify --aws-account-id instead if STS is unavailable")
+		}
+		cfg.AccountID = accountID
+	}
 	return &defaultCloud{
 		cfg:      cfg,
 		appMesh:  services.NewAppMesh(sess),
 		cloudMap: services.NewCloudMap(sess),
+		sts:      sts,
 	}, nil
 }
 
@@ -58,6 +73,7 @@ type defaultCloud struct {
 
 	appMesh  services.AppMesh
 	cloudMap services.CloudMap
+	sts      services.STS
 }
 
 func (c *defaultCloud) AppMesh() services.AppMesh {
@@ -66,4 +82,12 @@ func (c *defaultCloud) AppMesh() services.AppMesh {
 
 func (c *defaultCloud) CloudMap() services.CloudMap {
 	return c.cloudMap
+}
+
+func (c *defaultCloud) STS() services.STS {
+	return c.sts
+}
+
+func (c *defaultCloud) AccountID() string {
+	return c.cfg.AccountID
 }

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -17,8 +17,6 @@ type Cloud interface {
 	AppMesh() services.AppMesh
 	// CloudMap provides API to AWS CloudMap
 	CloudMap() services.CloudMap
-	// STS provides API to AWS STS
-	STS() services.STS
 
 	// AccountID provides AccountID for the kubernetes cluster
 	AccountID() string
@@ -50,8 +48,8 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 
 	awsCfg := aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)
 	sess = sess.Copy(awsCfg)
-	sts := services.NewSTS(sess)
 	if len(cfg.AccountID) == 0 {
+		sts := services.NewSTS(sess)
 		accountID, err := sts.AccountID(context.Background())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to introspect accountID from STS, specify --aws-account-id instead if STS is unavailable")
@@ -62,7 +60,6 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 		cfg:      cfg,
 		appMesh:  services.NewAppMesh(sess),
 		cloudMap: services.NewCloudMap(sess),
-		sts:      sts,
 	}, nil
 }
 
@@ -73,7 +70,6 @@ type defaultCloud struct {
 
 	appMesh  services.AppMesh
 	cloudMap services.CloudMap
-	sts      services.STS
 }
 
 func (c *defaultCloud) AppMesh() services.AppMesh {
@@ -82,10 +78,6 @@ func (c *defaultCloud) AppMesh() services.AppMesh {
 
 func (c *defaultCloud) CloudMap() services.CloudMap {
 	return c.cloudMap
-}
-
-func (c *defaultCloud) STS() services.STS {
-	return c.sts
 }
 
 func (c *defaultCloud) AccountID() string {

--- a/pkg/aws/cloud_config.go
+++ b/pkg/aws/cloud_config.go
@@ -7,17 +7,21 @@ import (
 
 const (
 	flagAWSRegion      = "aws-region"
+	flagAWSAccountID   = "aws-account-id"
 	flagAWSAPIThrottle = "aws-api-throttle"
 )
 
 type CloudConfig struct {
 	// AWS Region for the kubernetes cluster
 	Region string
+	// AccountID for the kubernetes cluster
+	AccountID string
 	// Throttle settings for aws APIs
 	ThrottleConfig *throttle.ServiceOperationsThrottleConfig
 }
 
 func (cfg *CloudConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.Region, flagAWSRegion, "", "AWS Region for the kubernetes cluster")
+	fs.StringVar(&cfg.Region, flagAWSAccountID, "", "AWS AccountID for the kubernetes cluster")
 	fs.Var(cfg.ThrottleConfig, flagAWSAPIThrottle, "throttle settings for AWS APIs, format: serviceID1:operationRegex1=rate:burst,serviceID2:operationRegex2=rate:burst")
 }

--- a/pkg/aws/services/sts.go
+++ b/pkg/aws/services/sts.go
@@ -1,0 +1,34 @@
+package services
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+)
+
+type STS interface {
+	stsiface.STSAPI
+	// AccountID returns AWS accountID for current IAM identity.
+	AccountID(ctx context.Context) (string, error)
+}
+
+// NewSTS constructs new STS implementation.
+func NewSTS(session *session.Session) STS {
+	return &defaultSTS{
+		STSAPI: sts.New(session),
+	}
+}
+
+type defaultSTS struct {
+	stsiface.STSAPI
+}
+
+func (c *defaultSTS) AccountID(ctx context.Context) (string, error) {
+	resp, err := c.GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+	return aws.StringValue(resp.Account), nil
+}

--- a/pkg/conversions/mesh_types_conversion.go
+++ b/pkg/conversions/mesh_types_conversion.go
@@ -1,0 +1,25 @@
+package conversions
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"k8s.io/apimachinery/pkg/conversion"
+)
+
+func Convert_CRD_EgressFilter_To_SDK_EgressFilter(crdObj *appmesh.EgressFilter, sdkObj *appmeshsdk.EgressFilter, scope conversion.Scope) error {
+	sdkObj.Type = aws.String((string)(crdObj.Type))
+	return nil
+}
+
+func Convert_CRD_MeshSpec_To_SDK_MeshSpec(crdObj *appmesh.MeshSpec, sdkObj *appmeshsdk.MeshSpec, scope conversion.Scope) error {
+	if crdObj.EgressFilter != nil {
+		sdkObj.EgressFilter = &appmeshsdk.EgressFilter{}
+		if err := Convert_CRD_EgressFilter_To_SDK_EgressFilter(crdObj.EgressFilter, sdkObj.EgressFilter, scope); err != nil {
+			return err
+		}
+	} else {
+		sdkObj.EgressFilter = nil
+	}
+	return nil
+}

--- a/pkg/conversions/mesh_types_conversion_test.go
+++ b/pkg/conversions/mesh_types_conversion_test.go
@@ -1,0 +1,118 @@
+package conversions
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/conversion"
+	"testing"
+)
+
+func TestConvert_CRD_EgressFilter_To_SDK_EgressFilter(t *testing.T) {
+	type args struct {
+		crdObj *appmesh.EgressFilter
+		sdkObj *appmeshsdk.EgressFilter
+		scope  conversion.Scope
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantSDKObj *appmeshsdk.EgressFilter
+		wantErr    error
+	}{
+		{
+			name: "allow all egress filter",
+			args: args{
+				crdObj: &appmesh.EgressFilter{
+					Type: appmesh.EgressFilterTypeAllowAll,
+				},
+				sdkObj: &appmeshsdk.EgressFilter{},
+				scope:  nil,
+			},
+			wantSDKObj: &appmeshsdk.EgressFilter{
+				Type: aws.String("ALLOW_ALL"),
+			},
+		},
+		{
+			name: "drop all egress filter",
+			args: args{
+				crdObj: &appmesh.EgressFilter{
+					Type: appmesh.EgressFilterTypeDropAll,
+				},
+				sdkObj: &appmeshsdk.EgressFilter{},
+				scope:  nil,
+			},
+			wantSDKObj: &appmeshsdk.EgressFilter{
+				Type: aws.String("DROP_ALL"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Convert_CRD_EgressFilter_To_SDK_EgressFilter(tt.args.crdObj, tt.args.sdkObj, tt.args.scope)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantSDKObj, tt.args.sdkObj)
+			}
+		})
+	}
+}
+
+func TestConvert_CRD_MeshSpec_To_SDK_MeshSpec(t *testing.T) {
+	type args struct {
+		crdObj *appmesh.MeshSpec
+		sdkObj *appmeshsdk.MeshSpec
+		scope  conversion.Scope
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantSDKObj *appmeshsdk.MeshSpec
+		wantErr    error
+	}{
+		{
+			name: "non-nil egress filter",
+			args: args{
+				crdObj: &appmesh.MeshSpec{
+					EgressFilter: &appmesh.EgressFilter{
+						Type: appmesh.EgressFilterTypeAllowAll,
+					},
+				},
+				sdkObj: &appmeshsdk.MeshSpec{},
+				scope:  nil,
+			},
+			wantSDKObj: &appmeshsdk.MeshSpec{
+				EgressFilter: &appmeshsdk.EgressFilter{
+					Type: aws.String("ALLOW_ALL"),
+				},
+			},
+		},
+		{
+			name: "nil egress filter",
+			args: args{
+				crdObj: &appmesh.MeshSpec{
+					EgressFilter: nil,
+				},
+				sdkObj: &appmeshsdk.MeshSpec{},
+				scope:  nil,
+			},
+			wantSDKObj: &appmeshsdk.MeshSpec{
+				EgressFilter: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Convert_CRD_MeshSpec_To_SDK_MeshSpec(tt.args.crdObj, tt.args.sdkObj, tt.args.scope)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantSDKObj, tt.args.sdkObj)
+			}
+		})
+	}
+}

--- a/pkg/k8s/finalizers.go
+++ b/pkg/k8s/finalizers.go
@@ -1,13 +1,70 @@
 package k8s
 
 import (
+	"context"
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
 	FinalizerMeshMembers  = "finalizers.appmesh.k8s.aws/mesh-members"
 	FinalizerAWSResources = "finalizers.appmesh.k8s.aws/aws-resources"
 )
+
+type APIObject interface {
+	metav1.Object
+	runtime.Object
+}
+
+type FinalizerManager interface {
+	AddFinalizers(ctx context.Context, obj APIObject, finalizers ...string) error
+	RemoveFinalizers(ctx context.Context, obj APIObject, finalizers ...string) error
+}
+
+func NewDefaultFinalizerManager(k8sClient client.Client, log logr.Logger) FinalizerManager {
+	return &defaultFinalizerManager{
+		k8sClient: k8sClient,
+		log:       log,
+	}
+}
+
+type defaultFinalizerManager struct {
+	k8sClient client.Client
+	log       logr.Logger
+}
+
+func (m *defaultFinalizerManager) AddFinalizers(ctx context.Context, obj APIObject, finalizers ...string) error {
+	oldObj := obj.DeepCopyObject()
+	needsUpdate := false
+	for _, finalizer := range finalizers {
+		if !HasFinalizer(obj, finalizer) {
+			controllerutil.AddFinalizer(obj, finalizer)
+			needsUpdate = true
+		}
+	}
+	if !needsUpdate {
+		return nil
+	}
+	return m.k8sClient.Patch(ctx, obj, client.MergeFrom(oldObj))
+}
+
+func (m *defaultFinalizerManager) RemoveFinalizers(ctx context.Context, obj APIObject, finalizers ...string) error {
+	oldObj := obj.DeepCopyObject()
+	needsUpdate := false
+	for _, finalizer := range finalizers {
+		if HasFinalizer(obj, finalizer) {
+			controllerutil.RemoveFinalizer(obj, finalizer)
+			needsUpdate = true
+		}
+	}
+	if !needsUpdate {
+		return nil
+	}
+	return m.k8sClient.Patch(ctx, obj, client.MergeFrom(oldObj))
+}
 
 // HasFinalizer tests whether k8s object has specified finalizer
 func HasFinalizer(obj metav1.Object, finalizer string) bool {

--- a/pkg/k8s/finalizers_test.go
+++ b/pkg/k8s/finalizers_test.go
@@ -1,9 +1,16 @@
 package k8s
 
 import (
+	"context"
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"testing"
 )
 
@@ -49,6 +56,281 @@ func TestHasFinalizer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := HasFinalizer(tt.obj, tt.finalizer)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_defaultFinalizerManager_AddFinalizers(t *testing.T) {
+	type args struct {
+		obj        *appmesh.Mesh
+		finalizers []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantObj *appmesh.Mesh
+		wantErr error
+	}{
+		{
+			name: "add one finalizer",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-mesh",
+					},
+				},
+				finalizers: []string{"finalizer-1"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: []string{"finalizer-1"},
+				},
+			},
+		},
+		{
+			name: "add one finalizer + added finalizer already exists",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "my-ns",
+						Name:       "my-mesh",
+						Finalizers: []string{"finalizer-1"},
+					},
+				},
+				finalizers: []string{"finalizer-1"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: []string{"finalizer-1"},
+				},
+			},
+		},
+		{
+			name: "add one finalizer + other finalizer already exists",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "my-ns",
+						Name:       "my-mesh",
+						Finalizers: []string{"finalizer-2"},
+					},
+				},
+				finalizers: []string{"finalizer-1"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: []string{"finalizer-2", "finalizer-1"},
+				},
+			},
+		},
+		{
+			name: "add two finalizer",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-mesh",
+					},
+				},
+				finalizers: []string{"finalizer-1", "finalizer-2"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: []string{"finalizer-1", "finalizer-2"},
+				},
+			},
+		},
+		{
+			name: "add two finalizer + one added finalizer already exists",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "my-ns",
+						Name:       "my-mesh",
+						Finalizers: []string{"finalizer-2"},
+					},
+				},
+				finalizers: []string{"finalizer-1", "finalizer-2"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: []string{"finalizer-2", "finalizer-1"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			m := NewDefaultFinalizerManager(k8sClient, &log.NullLogger{})
+
+			err := k8sClient.Create(ctx, tt.args.obj.DeepCopy())
+			assert.NoError(t, err)
+
+			err = m.AddFinalizers(ctx, tt.args.obj, tt.args.finalizers...)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				gotObj := &appmesh.Mesh{}
+				err = k8sClient.Get(ctx, NamespacedName(tt.args.obj), gotObj)
+				assert.NoError(t, err)
+				opts := equality.IgnoreFakeClientPopulatedFields()
+				assert.True(t, cmp.Equal(tt.wantObj, gotObj, opts), "diff", cmp.Diff(tt.wantObj, gotObj, opts))
+			}
+		})
+	}
+}
+
+func Test_defaultFinalizerManager_RemoveFinalizers(t *testing.T) {
+	type args struct {
+		obj        *appmesh.Mesh
+		finalizers []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantObj *appmesh.Mesh
+		wantErr error
+	}{
+		{
+			name: "remove one finalizer",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "my-ns",
+						Name:       "my-mesh",
+						Finalizers: []string{"finalizer-1"},
+					},
+				},
+				finalizers: []string{"finalizer-1"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: nil,
+				},
+			},
+		},
+		{
+			name: "remove one finalizer + removed finalizer didn't exists",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-mesh",
+					},
+				},
+				finalizers: []string{"finalizer-1"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: nil,
+				},
+			},
+		},
+		{
+			name: "remove one finalizer + other finalizer already exists",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "my-ns",
+						Name:       "my-mesh",
+						Finalizers: []string{"finalizer-1", "finalizer-2"},
+					},
+				},
+				finalizers: []string{"finalizer-1"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: []string{"finalizer-2"},
+				},
+			},
+		},
+		{
+			name: "remove two finalizer",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "my-ns",
+						Name:       "my-mesh",
+						Finalizers: []string{"finalizer-1", "finalizer-2"},
+					},
+				},
+				finalizers: []string{"finalizer-1", "finalizer-2"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: nil,
+				},
+			},
+		},
+		{
+			name: "remove two finalizer + one removed finalizer already exists",
+			args: args{
+				obj: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "my-ns",
+						Name:       "my-mesh",
+						Finalizers: []string{"finalizer-2", "finalizer-3"},
+					},
+				},
+				finalizers: []string{"finalizer-1", "finalizer-2"},
+			},
+			wantObj: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "my-ns",
+					Name:       "my-mesh",
+					Finalizers: []string{"finalizer-3"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			m := NewDefaultFinalizerManager(k8sClient, &log.NullLogger{})
+
+			err := k8sClient.Create(ctx, tt.args.obj.DeepCopy())
+			assert.NoError(t, err)
+
+			err = m.RemoveFinalizers(ctx, tt.args.obj, tt.args.finalizers...)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				gotObj := &appmesh.Mesh{}
+				err = k8sClient.Get(ctx, NamespacedName(tt.args.obj), gotObj)
+				assert.NoError(t, err)
+				opts := equality.IgnoreFakeClientPopulatedFields()
+				assert.True(t, cmp.Equal(tt.wantObj, gotObj, opts), "diff", cmp.Diff(tt.wantObj, gotObj, opts))
+			}
 		})
 	}
 }

--- a/pkg/mesh/conditions.go
+++ b/pkg/mesh/conditions.go
@@ -1,0 +1,51 @@
+package mesh
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// getCondition will get pointer to mesh's existing condition.
+func getCondition(ms *appmesh.Mesh, conditionType appmesh.MeshConditionType) *appmesh.MeshCondition {
+	for i := range ms.Status.Conditions {
+		if ms.Status.Conditions[i].Type == conditionType {
+			return &ms.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// updateCondition will update mesh's condition. returns whether it's updated.
+func updateCondition(ms *appmesh.Mesh, conditionType appmesh.MeshConditionType, status corev1.ConditionStatus, reason *string, message *string) bool {
+	now := metav1.Now()
+	existingCondition := getCondition(ms, conditionType)
+	if existingCondition == nil {
+		newCondition := appmesh.MeshCondition{
+			Type:               conditionType,
+			Status:             status,
+			LastTransitionTime: &now,
+			Reason:             reason,
+			Message:            message,
+		}
+		ms.Status.Conditions = append(ms.Status.Conditions, newCondition)
+		return true
+	}
+
+	hasChanged := false
+	if existingCondition.Status != status {
+		existingCondition.Status = status
+		existingCondition.LastTransitionTime = &now
+		hasChanged = true
+	}
+	if aws.StringValue(existingCondition.Reason) != aws.StringValue(reason) {
+		existingCondition.Reason = reason
+		hasChanged = true
+	}
+	if aws.StringValue(existingCondition.Message) != aws.StringValue(message) {
+		existingCondition.Message = message
+		hasChanged = true
+	}
+	return hasChanged
+}

--- a/pkg/mesh/conditions_test.go
+++ b/pkg/mesh/conditions_test.go
@@ -1,0 +1,269 @@
+package mesh
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_getCondition(t *testing.T) {
+	type args struct {
+		ms            *appmesh.Mesh
+		conditionType appmesh.MeshConditionType
+	}
+	tests := []struct {
+		name string
+		args args
+		want *appmesh.MeshCondition
+	}{
+		{
+			name: "condition found",
+			args: args{
+				ms: &appmesh.Mesh{
+					Status: appmesh.MeshStatus{
+						Conditions: []appmesh.MeshCondition{
+							{
+								Type:   appmesh.MeshActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.MeshActive,
+			},
+			want: &appmesh.MeshCondition{
+				Type:   appmesh.MeshActive,
+				Status: corev1.ConditionFalse,
+			},
+		},
+		{
+			name: "condition not found",
+			args: args{
+				ms: &appmesh.Mesh{
+					Status: appmesh.MeshStatus{
+						Conditions: []appmesh.MeshCondition{},
+					},
+				},
+				conditionType: appmesh.MeshActive,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getCondition(tt.args.ms, tt.args.conditionType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_updateCondition(t *testing.T) {
+	type args struct {
+		ms            *appmesh.Mesh
+		conditionType appmesh.MeshConditionType
+		status        corev1.ConditionStatus
+		reason        *string
+		message       *string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantMS      *appmesh.Mesh
+		wantChanged bool
+	}{
+		{
+			name: "condition updated by modify condition status",
+			args: args{
+				ms: &appmesh.Mesh{
+					Status: appmesh.MeshStatus{
+						Conditions: []appmesh.MeshCondition{
+							{
+								Type:   appmesh.MeshActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.MeshActive,
+				status:        corev1.ConditionTrue,
+			},
+			wantMS: &appmesh.Mesh{
+				Status: appmesh.MeshStatus{
+					Conditions: []appmesh.MeshCondition{
+						{
+							Type:   appmesh.MeshActive,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition reason",
+			args: args{
+				ms: &appmesh.Mesh{
+					Status: appmesh.MeshStatus{
+						Conditions: []appmesh.MeshCondition{
+							{
+								Type:   appmesh.MeshActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.MeshActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+			},
+			wantMS: &appmesh.Mesh{
+				Status: appmesh.MeshStatus{
+					Conditions: []appmesh.MeshCondition{
+						{
+							Type:   appmesh.MeshActive,
+							Status: corev1.ConditionTrue,
+							Reason: aws.String("reason"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition message",
+			args: args{
+				ms: &appmesh.Mesh{
+					Status: appmesh.MeshStatus{
+						Conditions: []appmesh.MeshCondition{
+							{
+								Type:   appmesh.MeshActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.MeshActive,
+				status:        corev1.ConditionTrue,
+				message:       aws.String("message"),
+			},
+			wantMS: &appmesh.Mesh{
+				Status: appmesh.MeshStatus{
+					Conditions: []appmesh.MeshCondition{
+						{
+							Type:    appmesh.MeshActive,
+							Status:  corev1.ConditionTrue,
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition status/reason/message",
+			args: args{
+				ms: &appmesh.Mesh{
+					Status: appmesh.MeshStatus{
+						Conditions: []appmesh.MeshCondition{
+							{
+								Type:   appmesh.MeshActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.MeshActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantMS: &appmesh.Mesh{
+				Status: appmesh.MeshStatus{
+					Conditions: []appmesh.MeshCondition{
+						{
+							Type:    appmesh.MeshActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by new condition",
+			args: args{
+				ms: &appmesh.Mesh{
+					Status: appmesh.MeshStatus{
+						Conditions: nil,
+					},
+				},
+				conditionType: appmesh.MeshActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantMS: &appmesh.Mesh{
+				Status: appmesh.MeshStatus{
+					Conditions: []appmesh.MeshCondition{
+						{
+							Type:    appmesh.MeshActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition unmodified",
+			args: args{
+				ms: &appmesh.Mesh{
+					Status: appmesh.MeshStatus{
+						Conditions: []appmesh.MeshCondition{
+							{
+								Type:    appmesh.MeshActive,
+								Status:  corev1.ConditionTrue,
+								Reason:  aws.String("reason"),
+								Message: aws.String("message"),
+							},
+						},
+					},
+				},
+				conditionType: appmesh.MeshActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantMS: &appmesh.Mesh{
+				Status: appmesh.MeshStatus{
+					Conditions: []appmesh.MeshCondition{
+						{
+							Type:    appmesh.MeshActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChanged := updateCondition(tt.args.ms, tt.args.conditionType, tt.args.status, tt.args.reason, tt.args.message)
+			opts := cmpopts.IgnoreTypes((*metav1.Time)(nil))
+			assert.True(t, cmp.Equal(tt.wantMS, tt.args.ms, opts), "diff", cmp.Diff(tt.wantMS, tt.args.ms, opts))
+			assert.Equal(t, tt.wantChanged, gotChanged)
+		})
+	}
+}

--- a/pkg/mesh/members_finalizer.go
+++ b/pkg/mesh/members_finalizer.go
@@ -1,0 +1,135 @@
+package mesh
+
+import (
+	"context"
+	"fmt"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/runtime"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"time"
+)
+
+const (
+	pendingMembersFinalizerEvaluateInterval = 60 * time.Second
+)
+
+type MembersFinalizer interface {
+	Finalize(ctx context.Context, ms *appmesh.Mesh) error
+}
+
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
+
+func NewPendingMembersFinalizer(k8sClient client.Client, eventRecorder record.EventRecorder, log logr.Logger) MembersFinalizer {
+	return &pendingMembersFinalizer{
+		k8sClient:        k8sClient,
+		eventRecorder:    eventRecorder,
+		log:              log,
+		evaluateInterval: pendingMembersFinalizerEvaluateInterval,
+	}
+}
+
+// pendingMembersFinalizer is a MembersFinalizer that will pend mesh deletion until all mesh members are deleted.
+type pendingMembersFinalizer struct {
+	k8sClient     client.Client
+	eventRecorder record.EventRecorder
+	log           logr.Logger
+
+	evaluateInterval time.Duration
+}
+
+func (m *pendingMembersFinalizer) Finalize(ctx context.Context, ms *appmesh.Mesh) error {
+	vsMembers, err := m.findVirtualServiceMembers(ctx, ms)
+	if err != nil {
+		return err
+	}
+	vrMembers, err := m.findVirtualRouterMembers(ctx, ms)
+	if err != nil {
+		return err
+	}
+	vnMembers, err := m.findVirtualNodeMembers(ctx, ms)
+	if err != nil {
+		return err
+	}
+	if len(vsMembers) == 0 && len(vrMembers) == 0 && len(vnMembers) == 0 {
+		return nil
+	}
+
+	message := m.buildPendingMembersEventMessage(ctx, vsMembers, vrMembers, vnMembers)
+	m.eventRecorder.Eventf(ms, corev1.EventTypeWarning, "PendingMembersDeletion", message)
+	return runtime.NewRequeueAfterError(errors.New("pending members deletion"), m.evaluateInterval)
+}
+
+// findVirtualServiceMembers find the VirtualService members for this mesh.
+func (m *pendingMembersFinalizer) findVirtualServiceMembers(ctx context.Context, ms *appmesh.Mesh) ([]*appmesh.VirtualService, error) {
+	vsList := &appmesh.VirtualServiceList{}
+	if err := m.k8sClient.List(ctx, vsList); err != nil {
+		return nil, err
+	}
+	members := make([]*appmesh.VirtualService, 0, len(vsList.Items))
+	for i := range vsList.Items {
+		vs := &vsList.Items[i]
+		if vs.Spec.MeshRef == nil || !IsMeshReferenced(ms, *vs.Spec.MeshRef) {
+			continue
+		}
+		members = append(members, vs)
+	}
+	return members, nil
+}
+
+// findVirtualRouterMembers find the VirtualRouter members for this mesh.
+func (m *pendingMembersFinalizer) findVirtualRouterMembers(ctx context.Context, ms *appmesh.Mesh) ([]*appmesh.VirtualRouter, error) {
+	vrList := &appmesh.VirtualRouterList{}
+	if err := m.k8sClient.List(ctx, vrList); err != nil {
+		return nil, err
+	}
+	members := make([]*appmesh.VirtualRouter, 0, len(vrList.Items))
+	for i := range vrList.Items {
+		vr := &vrList.Items[i]
+		if vr.Spec.MeshRef == nil || !IsMeshReferenced(ms, *vr.Spec.MeshRef) {
+			continue
+		}
+		members = append(members, vr)
+	}
+	return members, nil
+}
+
+// findVirtualNodeMembers find the VirtualNode members for this mesh.
+func (m *pendingMembersFinalizer) findVirtualNodeMembers(ctx context.Context, ms *appmesh.Mesh) ([]*appmesh.VirtualNode, error) {
+	vnList := &appmesh.VirtualNodeList{}
+	if err := m.k8sClient.List(ctx, vnList); err != nil {
+		return nil, err
+	}
+	members := make([]*appmesh.VirtualNode, 0, len(vnList.Items))
+	for i := range vnList.Items {
+		vn := &vnList.Items[i]
+		if vn.Spec.MeshRef == nil || !IsMeshReferenced(ms, *vn.Spec.MeshRef) {
+			continue
+		}
+		members = append(members, vn)
+	}
+	return members, nil
+}
+
+func (m *pendingMembersFinalizer) buildPendingMembersEventMessage(ctx context.Context,
+	vsMembers []*appmesh.VirtualService, vrMembers []*appmesh.VirtualRouter, vnMembers []*appmesh.VirtualNode) string {
+	var messagePerObjectTypes []string
+	if len(vsMembers) != 0 {
+		message := fmt.Sprintf("virtualService: %v", len(vsMembers))
+		messagePerObjectTypes = append(messagePerObjectTypes, message)
+	}
+	if len(vrMembers) != 0 {
+		message := fmt.Sprintf("virtualRouter: %v", len(vrMembers))
+		messagePerObjectTypes = append(messagePerObjectTypes, message)
+	}
+	if len(vnMembers) != 0 {
+		message := fmt.Sprintf("virtualNode: %v", len(vnMembers))
+		messagePerObjectTypes = append(messagePerObjectTypes, message)
+	}
+
+	return "objects belong to this mesh exists, please delete them to proceed. " + strings.Join(messagePerObjectTypes, ", ")
+}

--- a/pkg/mesh/members_finalizer_test.go
+++ b/pkg/mesh/members_finalizer_test.go
@@ -1,0 +1,653 @@
+package mesh
+
+import (
+	"context"
+	"errors"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_pendingMembersFinalizer_buildPendingMembersEventMessage(t *testing.T) {
+	type args struct {
+		vsMembers []*appmesh.VirtualService
+		vrMembers []*appmesh.VirtualRouter
+		vnMembers []*appmesh.VirtualNode
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "two virtualService pending",
+			args: args{
+				vsMembers: []*appmesh.VirtualService{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-1",
+							Name:      "vs-1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-2",
+							Name:      "vs-2",
+						},
+					},
+				},
+			},
+			want: "objects belong to this mesh exists, please delete them to proceed. virtualService: 2",
+		},
+		{
+			name: "two virtualRouter pending",
+			args: args{
+				vrMembers: []*appmesh.VirtualRouter{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-1",
+							Name:      "vr-1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-2",
+							Name:      "vr-2",
+						},
+					},
+				},
+			},
+			want: "objects belong to this mesh exists, please delete them to proceed. virtualRouter: 2",
+		},
+		{
+			name: "two virtualNode pending",
+			args: args{
+				vnMembers: []*appmesh.VirtualNode{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-1",
+							Name:      "vn-1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-2",
+							Name:      "vn-2",
+						},
+					},
+				},
+			},
+			want: "objects belong to this mesh exists, please delete them to proceed. virtualNode: 2",
+		},
+		{
+			name: "1 virtualService and 1 virtualNode pending",
+			args: args{
+				vsMembers: []*appmesh.VirtualService{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-1",
+							Name:      "vs-1",
+						},
+					},
+				},
+				vnMembers: []*appmesh.VirtualNode{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-1",
+							Name:      "vn-1",
+						},
+					},
+				},
+			},
+			want: "objects belong to this mesh exists, please delete them to proceed. virtualService: 1, virtualNode: 1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			eventRecorder := record.NewFakeRecorder(1)
+			m := &pendingMembersFinalizer{
+				k8sClient:     k8sClient,
+				eventRecorder: eventRecorder,
+				log:           &log.NullLogger{},
+			}
+			got := m.buildPendingMembersEventMessage(ctx, tt.args.vsMembers, tt.args.vrMembers, tt.args.vnMembers)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_pendingMembersFinalizer_findVirtualServiceMembers(t *testing.T) {
+	ms := &appmesh.Mesh{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mesh-1",
+			UID:  "uid-1",
+		},
+	}
+	vsInMesh_1 := &appmesh.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "vs-1",
+		},
+		Spec: appmesh.VirtualServiceSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-1",
+			},
+		},
+	}
+	vsInMesh_2 := &appmesh.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-2",
+			Name:      "vs-2",
+		},
+		Spec: appmesh.VirtualServiceSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-1",
+			},
+		},
+	}
+	vsNotInMesh_1 := &appmesh.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-3",
+			Name:      "vs-3",
+		},
+		Spec: appmesh.VirtualServiceSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-2",
+				UID:  "uid-2",
+			},
+		},
+	}
+	vsNotInMesh_2 := &appmesh.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-4",
+			Name:      "vs-4",
+		},
+		Spec: appmesh.VirtualServiceSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-2",
+			},
+		},
+	}
+
+	type env struct {
+		virtualServices []*appmesh.VirtualService
+	}
+	type args struct {
+		ms *appmesh.Mesh
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		want    []*appmesh.VirtualService
+		wantErr error
+	}{
+		{
+			name: "found no virtualService",
+			env: env{
+				virtualServices: []*appmesh.VirtualService{},
+			},
+			args: args{
+				ms: ms,
+			},
+			want: []*appmesh.VirtualService{},
+		},
+		{
+			name: "found virtualServices that matches",
+			env: env{
+				virtualServices: []*appmesh.VirtualService{
+					vsInMesh_1, vsInMesh_2, vsNotInMesh_1, vsNotInMesh_2,
+				},
+			},
+			args: args{
+				ms: ms,
+			},
+			want: []*appmesh.VirtualService{vsInMesh_1, vsInMesh_2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			eventRecorder := record.NewFakeRecorder(1)
+			m := &pendingMembersFinalizer{
+				k8sClient:        k8sClient,
+				eventRecorder:    eventRecorder,
+				log:              &log.NullLogger{},
+				evaluateInterval: pendingMembersFinalizerEvaluateInterval,
+			}
+
+			for _, vs := range tt.env.virtualServices {
+				err := k8sClient.Create(ctx, vs.DeepCopy())
+				assert.NoError(t, err)
+			}
+
+			got, err := m.findVirtualServiceMembers(ctx, tt.args.ms)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opts := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+					cmpopts.SortSlices(compareVirtualService),
+				}
+				assert.True(t, cmp.Equal(tt.want, got, opts), "diff", cmp.Diff(tt.want, got, opts))
+			}
+		})
+	}
+}
+
+func Test_pendingMembersFinalizer_findVirtualNodeMembers(t *testing.T) {
+	ms := &appmesh.Mesh{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mesh-1",
+			UID:  "uid-1",
+		},
+	}
+	vnInMesh_1 := &appmesh.VirtualNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "vn-1",
+		},
+		Spec: appmesh.VirtualNodeSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-1",
+			},
+		},
+	}
+	vnInMesh_2 := &appmesh.VirtualNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-2",
+			Name:      "vn-2",
+		},
+		Spec: appmesh.VirtualNodeSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-1",
+			},
+		},
+	}
+	vnNotInMesh_1 := &appmesh.VirtualNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-3",
+			Name:      "vn-3",
+		},
+		Spec: appmesh.VirtualNodeSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-2",
+				UID:  "uid-2",
+			},
+		},
+	}
+	vnNotInMesh_2 := &appmesh.VirtualNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-4",
+			Name:      "vn-4",
+		},
+		Spec: appmesh.VirtualNodeSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-2",
+			},
+		},
+	}
+
+	type env struct {
+		virtualNodes []*appmesh.VirtualNode
+	}
+	type args struct {
+		ms *appmesh.Mesh
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		want    []*appmesh.VirtualNode
+		wantErr error
+	}{
+		{
+			name: "found no virtualNode",
+			env: env{
+				virtualNodes: []*appmesh.VirtualNode{},
+			},
+			args: args{
+				ms: ms,
+			},
+			want: []*appmesh.VirtualNode{},
+		},
+		{
+			name: "found virtualNodes that matches",
+			env: env{
+				virtualNodes: []*appmesh.VirtualNode{
+					vnInMesh_1, vnInMesh_2, vnNotInMesh_1, vnNotInMesh_2,
+				},
+			},
+			args: args{
+				ms: ms,
+			},
+			want: []*appmesh.VirtualNode{vnInMesh_1, vnInMesh_2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			eventRecorder := record.NewFakeRecorder(1)
+			m := &pendingMembersFinalizer{
+				k8sClient:        k8sClient,
+				eventRecorder:    eventRecorder,
+				log:              &log.NullLogger{},
+				evaluateInterval: pendingMembersFinalizerEvaluateInterval,
+			}
+
+			for _, vn := range tt.env.virtualNodes {
+				err := k8sClient.Create(ctx, vn.DeepCopy())
+				assert.NoError(t, err)
+			}
+
+			got, err := m.findVirtualNodeMembers(ctx, tt.args.ms)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opts := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+					cmpopts.SortSlices(compareVirtualNode),
+				}
+				assert.True(t, cmp.Equal(tt.want, got, opts), "diff", cmp.Diff(tt.want, got, opts))
+			}
+		})
+	}
+}
+
+func Test_pendingMembersFinalizer_findVirtualRouterMembers(t *testing.T) {
+	ms := &appmesh.Mesh{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mesh-1",
+			UID:  "uid-1",
+		},
+	}
+	vrInMesh_1 := &appmesh.VirtualRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "vr-1",
+		},
+		Spec: appmesh.VirtualRouterSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-1",
+			},
+		},
+	}
+	vrInMesh_2 := &appmesh.VirtualRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-2",
+			Name:      "vr-2",
+		},
+		Spec: appmesh.VirtualRouterSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-1",
+			},
+		},
+	}
+	vrNotInMesh_1 := &appmesh.VirtualRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-3",
+			Name:      "vr-3",
+		},
+		Spec: appmesh.VirtualRouterSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-2",
+				UID:  "uid-2",
+			},
+		},
+	}
+	vrNotInMesh_2 := &appmesh.VirtualRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-4",
+			Name:      "vr-4",
+		},
+		Spec: appmesh.VirtualRouterSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "mesh-1",
+				UID:  "uid-2",
+			},
+		},
+	}
+
+	type env struct {
+		virtualRouters []*appmesh.VirtualRouter
+	}
+	type args struct {
+		ms *appmesh.Mesh
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		want    []*appmesh.VirtualRouter
+		wantErr error
+	}{
+		{
+			name: "found no virtualRouter",
+			env: env{
+				virtualRouters: []*appmesh.VirtualRouter{},
+			},
+			args: args{
+				ms: ms,
+			},
+			want: []*appmesh.VirtualRouter{},
+		},
+		{
+			name: "found virtualRouters that matches",
+			env: env{
+				virtualRouters: []*appmesh.VirtualRouter{
+					vrInMesh_1, vrInMesh_2, vrNotInMesh_1, vrNotInMesh_2,
+				},
+			},
+			args: args{
+				ms: ms,
+			},
+			want: []*appmesh.VirtualRouter{vrInMesh_1, vrInMesh_2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			eventRecorder := record.NewFakeRecorder(1)
+			m := &pendingMembersFinalizer{
+				k8sClient:        k8sClient,
+				eventRecorder:    eventRecorder,
+				log:              &log.NullLogger{},
+				evaluateInterval: pendingMembersFinalizerEvaluateInterval,
+			}
+
+			for _, vr := range tt.env.virtualRouters {
+				err := k8sClient.Create(ctx, vr.DeepCopy())
+				assert.NoError(t, err)
+			}
+
+			got, err := m.findVirtualRouterMembers(ctx, tt.args.ms)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opts := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+					cmpopts.SortSlices(compareVirtualRouter),
+				}
+				assert.True(t, cmp.Equal(tt.want, got, opts), "diff", cmp.Diff(tt.want, got, opts))
+			}
+		})
+	}
+}
+
+func Test_pendingMembersFinalizer_Finalize(t *testing.T) {
+	ms := &appmesh.Mesh{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-mesh",
+			UID:  "uid-1",
+		},
+	}
+	vs := &appmesh.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "vs-1",
+		},
+		Spec: appmesh.VirtualServiceSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "my-mesh",
+				UID:  "uid-1",
+			},
+		},
+	}
+	vn := &appmesh.VirtualNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "vn-1",
+		},
+		Spec: appmesh.VirtualNodeSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "my-mesh",
+				UID:  "uid-1",
+			},
+		},
+	}
+	vr := &appmesh.VirtualRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "vr-1",
+		},
+		Spec: appmesh.VirtualRouterSpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "my-mesh",
+				UID:  "uid-1",
+			},
+		},
+	}
+	_ = vn
+	_ = vr
+
+	type env struct {
+		virtualServices []*appmesh.VirtualService
+		virtualNodes    []*appmesh.VirtualNode
+		virtualRouters  []*appmesh.VirtualRouter
+	}
+	type args struct {
+		ms *appmesh.Mesh
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		wantErr error
+	}{
+		{
+			name: "when pending virtualService deletion",
+			env: env{
+				virtualServices: []*appmesh.VirtualService{vs},
+			},
+			args:    args{ms: ms},
+			wantErr: errors.New("pending members deletion"),
+		},
+		{
+			name: "when pending virtualRouter deletion",
+			env: env{
+				virtualRouters: []*appmesh.VirtualRouter{vr},
+			},
+			args:    args{ms: ms},
+			wantErr: errors.New("pending members deletion"),
+		},
+		{
+			name: "when pending virtualService deletion",
+			env: env{
+				virtualNodes: []*appmesh.VirtualNode{vn},
+			},
+			args:    args{ms: ms},
+			wantErr: errors.New("pending members deletion"),
+		},
+		{
+			name:    "when pending no member deletion",
+			env:     env{},
+			args:    args{ms: ms},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			eventRecorder := record.NewFakeRecorder(1)
+			m := &pendingMembersFinalizer{
+				k8sClient:        k8sClient,
+				eventRecorder:    eventRecorder,
+				log:              &log.NullLogger{},
+				evaluateInterval: pendingMembersFinalizerEvaluateInterval,
+			}
+			for _, vs := range tt.env.virtualServices {
+				err := k8sClient.Create(ctx, vs)
+				assert.NoError(t, err)
+			}
+			for _, vr := range tt.env.virtualRouters {
+				err := k8sClient.Create(ctx, vr)
+				assert.NoError(t, err)
+			}
+			for _, vn := range tt.env.virtualNodes {
+				err := k8sClient.Create(ctx, vn)
+				assert.NoError(t, err)
+			}
+
+			err := m.Finalize(ctx, tt.args.ms)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func compareVirtualService(a *appmesh.VirtualService, b *appmesh.VirtualService) bool {
+	return k8s.NamespacedName(a).String() < k8s.NamespacedName(b).String()
+}
+
+func compareVirtualNode(a *appmesh.VirtualNode, b *appmesh.VirtualNode) bool {
+	return k8s.NamespacedName(a).String() < k8s.NamespacedName(b).String()
+}
+
+func compareVirtualRouter(a *appmesh.VirtualRouter, b *appmesh.VirtualRouter) bool {
+	return k8s.NamespacedName(a).String() < k8s.NamespacedName(b).String()
+}

--- a/pkg/mesh/resource_manager.go
+++ b/pkg/mesh/resource_manager.go
@@ -1,0 +1,224 @@
+package mesh
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/services"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/conversions"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ResourceManager is dedicated to manage AppMesh Mesh resources for k8s Mesh CRs.
+type ResourceManager interface {
+	// Reconcile will create/update AppMesh Mesh to match ms.spec, and update ms.status
+	Reconcile(ctx context.Context, ms *appmesh.Mesh) error
+
+	// Cleanup will delete AppMesh Mesh created for ms.
+	Cleanup(ctx context.Context, ms *appmesh.Mesh) error
+}
+
+func NewDefaultResourceManager(
+	k8sClient client.Client,
+	appMeshSDK services.AppMesh,
+	accountID string,
+	log logr.Logger) ResourceManager {
+
+	return &defaultResourceManager{
+		k8sClient:  k8sClient,
+		appMeshSDK: appMeshSDK,
+		accountID:  accountID,
+		log:        log,
+	}
+}
+
+// defaultResourceManager implements ResourceManager
+type defaultResourceManager struct {
+	k8sClient  client.Client
+	appMeshSDK services.AppMesh
+	// current iam identity's aws accountID, used to differentiate mesh ownership.
+	accountID string
+	log       logr.Logger
+}
+
+func (m *defaultResourceManager) Reconcile(ctx context.Context, ms *appmesh.Mesh) error {
+	sdkMS, err := m.findSDKMesh(ctx, ms)
+	if err != nil {
+		return err
+	}
+	if sdkMS == nil {
+		sdkMS, err = m.createSDKMesh(ctx, ms)
+		if err != nil {
+			return err
+		}
+	} else {
+		sdkMS, err = m.updateSDKMesh(ctx, sdkMS, ms)
+		if err != nil {
+			return err
+		}
+	}
+	return m.updateCRDMesh(ctx, ms, sdkMS)
+}
+
+func (m *defaultResourceManager) Cleanup(ctx context.Context, ms *appmesh.Mesh) error {
+	sdkMS, err := m.findSDKMesh(ctx, ms)
+	if err != nil {
+		return err
+	}
+	if sdkMS == nil {
+		return nil
+	}
+
+	return m.deleteSDKMesh(ctx, sdkMS, ms)
+}
+
+func (m *defaultResourceManager) findSDKMesh(ctx context.Context, ms *appmesh.Mesh) (*appmeshsdk.MeshData, error) {
+	resp, err := m.appMeshSDK.DescribeMeshWithContext(ctx, &appmeshsdk.DescribeMeshInput{
+		MeshName:  ms.Spec.AWSName,
+		MeshOwner: ms.Spec.MeshOwner,
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return resp.Mesh, nil
+}
+
+func (m *defaultResourceManager) createSDKMesh(ctx context.Context, ms *appmesh.Mesh) (*appmeshsdk.MeshData, error) {
+	sdkMSSpec, err := m.buildSDKMeshSpec(ctx, ms)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := m.appMeshSDK.CreateMeshWithContext(ctx, &appmeshsdk.CreateMeshInput{
+		MeshName: ms.Spec.AWSName,
+		Spec:     sdkMSSpec,
+		Tags:     nil,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Mesh, nil
+}
+
+func (m *defaultResourceManager) updateSDKMesh(ctx context.Context, sdkMS *appmeshsdk.MeshData, ms *appmesh.Mesh) (*appmeshsdk.MeshData, error) {
+	actualSDKMSSpec := sdkMS.Spec
+	desiredSDKMSSpec, err := m.buildSDKMeshSpec(ctx, ms)
+	if err != nil {
+		return nil, err
+	}
+
+	// If an optional field is not set, AWS will provide default settings that will be in actualSDKMSSpec.
+	// We use IgnoreLeftHandUnset when doing the equality check here to allow AWS sever-side to provide default settings.
+	opts := equality.IgnoreLeftHandUnset()
+	if cmp.Equal(desiredSDKMSSpec, actualSDKMSSpec, opts) {
+		return sdkMS, nil
+	}
+	if !m.isSDKMeshControlledByCRDMesh(ctx, sdkMS, ms) {
+		m.log.V(2).Info("skip mesh update since it's not controlled",
+			"mesh", k8s.NamespacedName(ms),
+			"meshARN", aws.StringValue(sdkMS.Metadata.Arn),
+		)
+		return sdkMS, nil
+	}
+
+	diff := cmp.Diff(desiredSDKMSSpec, actualSDKMSSpec, opts)
+	m.log.V(2).Info("meshSpec changed",
+		"mesh", k8s.NamespacedName(ms),
+		"actualSDKMSSpec", actualSDKMSSpec,
+		"desiredSDKMSSpec", desiredSDKMSSpec,
+		"diff", diff,
+	)
+	resp, err := m.appMeshSDK.UpdateMeshWithContext(ctx, &appmeshsdk.UpdateMeshInput{
+		MeshName: ms.Spec.AWSName,
+		Spec:     desiredSDKMSSpec,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Mesh, nil
+}
+
+func (m *defaultResourceManager) deleteSDKMesh(ctx context.Context, sdkMS *appmeshsdk.MeshData, ms *appmesh.Mesh) error {
+	if !m.isSDKMeshOwnedByCRDMesh(ctx, sdkMS, ms) {
+		m.log.V(2).Info("skip mesh deletion since its not owned",
+			"mesh", k8s.NamespacedName(ms),
+			"meshARN", aws.StringValue(sdkMS.Metadata.Arn),
+		)
+		return nil
+	}
+
+	_, err := m.appMeshSDK.DeleteMeshWithContext(ctx, &appmeshsdk.DeleteMeshInput{
+		MeshName: ms.Spec.AWSName,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *defaultResourceManager) buildSDKMeshSpec(ctx context.Context, ms *appmesh.Mesh) (*appmeshsdk.MeshSpec, error) {
+	converter := conversion.NewConverter(conversion.DefaultNameFunc)
+	converter.RegisterUntypedConversionFunc((*appmesh.MeshSpec)(nil), (*appmeshsdk.MeshSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return conversions.Convert_CRD_MeshSpec_To_SDK_MeshSpec(a.(*appmesh.MeshSpec), b.(*appmeshsdk.MeshSpec), scope)
+	})
+	sdkMSSpec := &appmeshsdk.MeshSpec{}
+	if err := converter.Convert(&ms.Spec, sdkMSSpec, conversion.DestFromSource, nil); err != nil {
+		return nil, err
+	}
+	return sdkMSSpec, nil
+}
+
+func (m *defaultResourceManager) updateCRDMesh(ctx context.Context, ms *appmesh.Mesh, sdkMS *appmeshsdk.MeshData) error {
+	oldMS := ms.DeepCopy()
+	needsUpdate := false
+
+	if aws.StringValue(ms.Status.MeshARN) != aws.StringValue(sdkMS.Metadata.Arn) {
+		ms.Status.MeshARN = sdkMS.Metadata.Arn
+		needsUpdate = true
+	}
+
+	msActiveConditionStatus := corev1.ConditionFalse
+	if sdkMS.Status != nil && aws.StringValue(sdkMS.Status.Status) == appmeshsdk.MeshStatusCodeActive {
+		msActiveConditionStatus = corev1.ConditionTrue
+	}
+	if updateCondition(ms, appmesh.MeshActive, msActiveConditionStatus, nil, nil) {
+		needsUpdate = true
+	}
+
+	if !needsUpdate {
+		return nil
+	}
+	return m.k8sClient.Patch(ctx, ms, client.MergeFrom(oldMS))
+}
+
+// isSDKMeshControlledByCRDMesh checks whether an AppMesh mesh is controlled by CRDMesh
+// if it's controlled, CRDMesh update is responsible for update AppMesh mesh.
+func (m *defaultResourceManager) isSDKMeshControlledByCRDMesh(ctx context.Context, sdkMS *appmeshsdk.MeshData, ms *appmesh.Mesh) bool {
+	if aws.StringValue(sdkMS.Metadata.ResourceOwner) != m.accountID {
+		return false
+	}
+	return true
+}
+
+// isSDKMeshOwnedByCRDMesh checks whether an AppMesh mesh is owned by CRDMesh.
+// if it's owned, CRDMesh deletion is responsible for delete AppMesh mesh.
+func (m *defaultResourceManager) isSDKMeshOwnedByCRDMesh(ctx context.Context, sdkMS *appmeshsdk.MeshData, ms *appmesh.Mesh) bool {
+	if !m.isSDKMeshControlledByCRDMesh(ctx, sdkMS, ms) {
+		return false
+	}
+
+	// TODO: Adding tagging support, so a existing mesh in owner account but not ownership can be support.
+	// currently, mesh controllership == ownership, but it don't have to be so once we add tagging support.
+	return true
+}

--- a/pkg/mesh/resource_manager_test.go
+++ b/pkg/mesh/resource_manager_test.go
@@ -1,0 +1,247 @@
+package mesh
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-sdk-go/aws"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_defaultResourceManager_updateCRDMesh(t *testing.T) {
+	type args struct {
+		ms    *appmesh.Mesh
+		sdkMS *appmeshsdk.MeshData
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantMS  *appmesh.Mesh
+		wantErr error
+	}{
+		{
+			name: "mesh needs patch both arn and condition",
+			args: args{
+				ms: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mesh-1",
+					},
+					Status: appmesh.MeshStatus{},
+				},
+				sdkMS: &appmeshsdk.MeshData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						Arn: aws.String("arn-1"),
+					},
+					Status: &appmeshsdk.MeshStatus{
+						Status: aws.String(appmeshsdk.MeshStatusCodeActive),
+					},
+				},
+			},
+			wantMS: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mesh-1",
+				},
+				Status: appmesh.MeshStatus{
+					MeshARN: aws.String("arn-1"),
+					Conditions: []appmesh.MeshCondition{
+						{
+							Type:   appmesh.MeshActive,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mesh needs patch condition only",
+			args: args{
+				ms: &appmesh.Mesh{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mesh-1",
+					},
+					Status: appmesh.MeshStatus{
+						MeshARN: aws.String("arn-1"),
+						Conditions: []appmesh.MeshCondition{
+							{
+								Type:   appmesh.MeshActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				sdkMS: &appmeshsdk.MeshData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						Arn: aws.String("arn-1"),
+					},
+					Status: &appmeshsdk.MeshStatus{
+						Status: aws.String(appmeshsdk.MeshStatusCodeInactive),
+					},
+				},
+			},
+			wantMS: &appmesh.Mesh{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mesh-1",
+				},
+				Status: appmesh.MeshStatus{
+					MeshARN: aws.String("arn-1"),
+					Conditions: []appmesh.MeshCondition{
+						{
+							Type:   appmesh.MeshActive,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+
+			m := &defaultResourceManager{
+				k8sClient: k8sClient,
+				log:       &log.NullLogger{},
+			}
+
+			err := k8sClient.Create(ctx, tt.args.ms.DeepCopy())
+			assert.NoError(t, err)
+			err = m.updateCRDMesh(ctx, tt.args.ms, tt.args.sdkMS)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				gotMS := &appmesh.Mesh{}
+				err = k8sClient.Get(ctx, k8s.NamespacedName(tt.args.ms), gotMS)
+				assert.NoError(t, err)
+				opts := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+					cmpopts.IgnoreTypes((*metav1.Time)(nil)),
+				}
+				assert.True(t, cmp.Equal(tt.wantMS, gotMS, opts), "diff", cmp.Diff(tt.wantMS, gotMS, opts))
+			}
+		})
+	}
+}
+
+func Test_defaultResourceManager_isSDKMeshControlledByCRDMesh(t *testing.T) {
+	type fields struct {
+		accountID string
+	}
+	type args struct {
+		sdkMS *appmeshsdk.MeshData
+		ms    *appmesh.Mesh
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "sdkMesh is controlled crdMesh",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkMS: &appmeshsdk.MeshData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("222222222"),
+					},
+				},
+				ms: &appmesh.Mesh{},
+			},
+			want: true,
+		},
+		{
+			name:   "sdkMesh isn't controlled crdMesh",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkMS: &appmeshsdk.MeshData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("33333333"),
+					},
+				},
+				ms: &appmesh.Mesh{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := &defaultResourceManager{
+				accountID: tt.fields.accountID,
+				log:       &log.NullLogger{},
+			}
+			got := m.isSDKMeshControlledByCRDMesh(ctx, tt.args.sdkMS, tt.args.ms)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_defaultResourceManager_isSDKMeshOwnedByCRDMesh(t *testing.T) {
+	type fields struct {
+		accountID string
+	}
+	type args struct {
+		sdkMS *appmeshsdk.MeshData
+		ms    *appmesh.Mesh
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "sdkMesh is controlled crdMesh",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkMS: &appmeshsdk.MeshData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("222222222"),
+					},
+				},
+				ms: &appmesh.Mesh{},
+			},
+			want: true,
+		},
+		{
+			name:   "sdkMesh isn't controlled crdMesh",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkMS: &appmeshsdk.MeshData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("33333333"),
+					},
+				},
+				ms: &appmesh.Mesh{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := &defaultResourceManager{
+				accountID: tt.fields.accountID,
+				log:       &log.NullLogger{},
+			}
+			got := m.isSDKMeshOwnedByCRDMesh(ctx, tt.args.sdkMS, tt.args.ms)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Add controller for Mesh.

This PR is separated into 6 commits:
1. `add accountID and STS API`: used to discover current accountID from STS, and provide AWS flags to avoid STS dependency.
2. `add finalizer manager`: add a component to centralize finalizer handling.
3. `add mesh types conversions`: add conversion functions for mesh types
4. `add mesh members finalizer` add a component to block mesh deletion if there is members belong to mesh
5. `add mesh resource manager` add a resource manager to manage AWS resource for mesh
6. `add mesh controller` hook all piece together to add a controller for mesh

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
