### PR TITLE
add reference handling utilities for virtualnode and virtualrouter

### DIFF
--- a/pkg/virtualnode/reference_resolver.go
+++ b/pkg/virtualnode/reference_resolver.go
@@ -1,0 +1,46 @@
+package virtualnode
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReferenceResolver resolves references to virtualNode CR.
+type ReferenceResolver interface {
+	// Resolve returns a virtualNode CR based on vnRef
+	Resolve(ctx context.Context, obj metav1.Object, vnRef appmesh.VirtualNodeReference) (*appmesh.VirtualNode, error)
+}
+
+func NewDefaultReferenceResolver(k8sClient client.Client, log logr.Logger) ReferenceResolver {
+	return &defaultReferenceResolver{
+		k8sClient: k8sClient,
+		log:       log,
+	}
+}
+
+var _ ReferenceResolver = &defaultReferenceResolver{}
+
+// defaultReferenceResolver implements ReferenceResolver
+type defaultReferenceResolver struct {
+	k8sClient client.Client
+	log       logr.Logger
+}
+
+func (r *defaultReferenceResolver) Resolve(ctx context.Context, obj metav1.Object, vnRef appmesh.VirtualNodeReference) (*appmesh.VirtualNode, error) {
+	namespace := obj.GetNamespace()
+	if vnRef.Namespace != nil && len(*vnRef.Namespace) != 0 {
+		namespace = *vnRef.Namespace
+	}
+
+	vnKey := types.NamespacedName{Namespace: namespace, Name: vnRef.Name}
+	vn := &appmesh.VirtualNode{}
+	if err := r.k8sClient.Get(ctx, vnKey, vn); err != nil {
+		return nil, errors.Wrapf(err, "unable to fetch virtualNode: %v", vnKey)
+	}
+	return vn, nil
+}

--- a/pkg/virtualnode/reference_resolver_test.go
+++ b/pkg/virtualnode/reference_resolver_test.go
@@ -1,0 +1,130 @@
+package virtualnode
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_defaultReferenceResolver_Resolve(t *testing.T) {
+	vnInNS1 := &appmesh.VirtualNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "vn",
+		},
+	}
+	vnInNS2 := &appmesh.VirtualNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-2",
+			Name:      "vn",
+		},
+	}
+
+	type env struct {
+		virtualNodes []*appmesh.VirtualNode
+	}
+	type args struct {
+		obj   metav1.Object
+		vnRef appmesh.VirtualNodeReference
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		want    *appmesh.VirtualNode
+		wantErr error
+	}{
+		{
+			name: "when VirtualNodeReference contains both namespace and name",
+			env: env{
+				virtualNodes: []*appmesh.VirtualNode{vnInNS1, vnInNS2},
+			},
+			args: args{
+				obj: &appmesh.VirtualRouter{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "vr",
+					},
+				},
+				vnRef: appmesh.VirtualNodeReference{
+					Namespace: aws.String("ns-2"),
+					Name:      "vn",
+				},
+			},
+			want: vnInNS2,
+		},
+		{
+			name: "when VirtualNodeReference contains name only",
+			env: env{
+				virtualNodes: []*appmesh.VirtualNode{vnInNS1, vnInNS2},
+			},
+			args: args{
+				obj: &appmesh.VirtualRouter{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "vr",
+					},
+				},
+				vnRef: appmesh.VirtualNodeReference{
+					Name: "vn",
+				},
+			},
+			want: vnInNS1,
+		},
+		{
+			name: "when VirtualNodeReference didn't reference existing vs",
+			env: env{
+				virtualNodes: []*appmesh.VirtualNode{vnInNS1, vnInNS2},
+			},
+			args: args{
+				obj: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "vn",
+					},
+				},
+				vnRef: appmesh.VirtualNodeReference{
+					Namespace: aws.String("ns-3"),
+					Name:      "vn",
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("unable to fetch virtualNode: ns-3/vn: virtualnodes.appmesh.k8s.aws \"vn\" not found"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			r := NewDefaultReferenceResolver(k8sClient, &log.NullLogger{})
+
+			for _, vn := range tt.env.virtualNodes {
+				err := k8sClient.Create(ctx, vn.DeepCopy())
+				assert.NoError(t, err)
+			}
+
+			got, err := r.Resolve(ctx, tt.args.obj, tt.args.vnRef)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opt := equality.IgnoreFakeClientPopulatedFields()
+				assert.True(t, cmp.Equal(tt.want, got, opt),
+					"diff: %v", cmp.Diff(tt.want, got, opt))
+			}
+		})
+	}
+}

--- a/pkg/virtualnode/utils.go
+++ b/pkg/virtualnode/utils.go
@@ -1,0 +1,17 @@
+package virtualnode
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// IsVirtualNodeActive checks whether given virtualNode is active.
+// virtualNode is active when its VirtualNodeActive condition equals true.
+func IsVirtualNodeActive(vn *appmesh.VirtualNode) bool {
+	for _, condition := range vn.Status.Conditions {
+		if condition.Type == appmesh.VirtualNodeActive {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/virtualnode/utils_test.go
+++ b/pkg/virtualnode/utils_test.go
@@ -1,0 +1,85 @@
+package virtualnode
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestIsVirtualNodeActive(t *testing.T) {
+	type args struct {
+		vn *appmesh.VirtualNode
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "virtualNode have true VirtualNodeActive condition",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					Status: appmesh.VirtualNodeStatus{
+						Conditions: []appmesh.VirtualNodeCondition{
+							{
+								Type:   appmesh.VirtualNodeActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "virtualNode have false VirtualNodeActive condition",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					Status: appmesh.VirtualNodeStatus{
+						Conditions: []appmesh.VirtualNodeCondition{
+							{
+								Type:   appmesh.VirtualNodeActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "virtualNode have unknown VirtualNodeActive condition",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					Status: appmesh.VirtualNodeStatus{
+						Conditions: []appmesh.VirtualNodeCondition{
+							{
+								Type:   appmesh.VirtualNodeActive,
+								Status: corev1.ConditionUnknown,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "virtualNode doesn't have VirtualNodeActive condition",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					Status: appmesh.VirtualNodeStatus{
+						Conditions: []appmesh.VirtualNodeCondition{},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsVirtualNodeActive(tt.args.vn)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/virtualrouter/reference_resolver.go
+++ b/pkg/virtualrouter/reference_resolver.go
@@ -1,0 +1,46 @@
+package virtualrouter
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReferenceResolver resolves references to virtualRouter CR.
+type ReferenceResolver interface {
+	// Resolve returns a virtualRouter CR based on vrRef
+	Resolve(ctx context.Context, obj metav1.Object, vrRef appmesh.VirtualRouterReference) (*appmesh.VirtualRouter, error)
+}
+
+func NewDefaultReferenceResolver(k8sClient client.Client, log logr.Logger) ReferenceResolver {
+	return &defaultReferenceResolver{
+		k8sClient: k8sClient,
+		log:       log,
+	}
+}
+
+var _ ReferenceResolver = &defaultReferenceResolver{}
+
+// defaultReferenceResolver implements ReferenceResolver
+type defaultReferenceResolver struct {
+	k8sClient client.Client
+	log       logr.Logger
+}
+
+func (r *defaultReferenceResolver) Resolve(ctx context.Context, obj metav1.Object, vrRef appmesh.VirtualRouterReference) (*appmesh.VirtualRouter, error) {
+	namespace := obj.GetNamespace()
+	if vrRef.Namespace != nil && len(*vrRef.Namespace) != 0 {
+		namespace = *vrRef.Namespace
+	}
+
+	vrKey := types.NamespacedName{Namespace: namespace, Name: vrRef.Name}
+	vr := &appmesh.VirtualRouter{}
+	if err := r.k8sClient.Get(ctx, vrKey, vr); err != nil {
+		return nil, errors.Wrapf(err, "unable to fetch virtualRouter: %v", vrKey)
+	}
+	return vr, nil
+}

--- a/pkg/virtualrouter/reference_resolver_test.go
+++ b/pkg/virtualrouter/reference_resolver_test.go
@@ -1,0 +1,130 @@
+package virtualrouter
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_defaultReferenceResolver_Resolve(t *testing.T) {
+	vrInNS1 := &appmesh.VirtualRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-1",
+			Name:      "vr",
+		},
+	}
+	vrInNS2 := &appmesh.VirtualRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns-2",
+			Name:      "vr",
+		},
+	}
+
+	type env struct {
+		virtualRouters []*appmesh.VirtualRouter
+	}
+	type args struct {
+		obj   metav1.Object
+		vrRef appmesh.VirtualRouterReference
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		want    *appmesh.VirtualRouter
+		wantErr error
+	}{
+		{
+			name: "when VirtualRouterReference contains both namespace and name",
+			env: env{
+				virtualRouters: []*appmesh.VirtualRouter{vrInNS1, vrInNS2},
+			},
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "vs",
+					},
+				},
+				vrRef: appmesh.VirtualRouterReference{
+					Namespace: aws.String("ns-2"),
+					Name:      "vr",
+				},
+			},
+			want: vrInNS2,
+		},
+		{
+			name: "when VirtualRouterReference contains name only",
+			env: env{
+				virtualRouters: []*appmesh.VirtualRouter{vrInNS1, vrInNS2},
+			},
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "vs",
+					},
+				},
+				vrRef: appmesh.VirtualRouterReference{
+					Name: "vr",
+				},
+			},
+			want: vrInNS1,
+		},
+		{
+			name: "when VirtualRouterReference didn't reference existing vs",
+			env: env{
+				virtualRouters: []*appmesh.VirtualRouter{vrInNS1, vrInNS2},
+			},
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "vs",
+					},
+				},
+				vrRef: appmesh.VirtualRouterReference{
+					Namespace: aws.String("ns-3"),
+					Name:      "vr",
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("unable to fetch virtualRouter: ns-3/vr: virtualrouters.appmesh.k8s.aws \"vr\" not found"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			r := NewDefaultReferenceResolver(k8sClient, &log.NullLogger{})
+
+			for _, vr := range tt.env.virtualRouters {
+				err := k8sClient.Create(ctx, vr.DeepCopy())
+				assert.NoError(t, err)
+			}
+
+			got, err := r.Resolve(ctx, tt.args.obj, tt.args.vrRef)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opt := equality.IgnoreFakeClientPopulatedFields()
+				assert.True(t, cmp.Equal(tt.want, got, opt),
+					"diff: %v", cmp.Diff(tt.want, got, opt))
+			}
+		})
+	}
+}

--- a/pkg/virtualrouter/utils.go
+++ b/pkg/virtualrouter/utils.go
@@ -1,0 +1,17 @@
+package virtualrouter
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// IsVirtualRouterActive checks whether given virtualRouter is active.
+// virtualRouter is active when its VirtualRouterActive condition equals true.
+func IsVirtualRouterActive(vr *appmesh.VirtualRouter) bool {
+	for _, condition := range vr.Status.Conditions {
+		if condition.Type == appmesh.VirtualRouterActive {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/virtualrouter/utils_test.go
+++ b/pkg/virtualrouter/utils_test.go
@@ -1,0 +1,85 @@
+package virtualrouter
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestIsVirtualRouterActive(t *testing.T) {
+	type args struct {
+		vr *appmesh.VirtualRouter
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "virtualRouter have true VirtualRouterActive condition",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "virtualRouter have false VirtualRouterActive condition",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "virtualRouter have unknown VirtualRouterActive condition",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionUnknown,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "virtualRouter doesn't have VirtualRouterActive condition",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsVirtualRouterActive(tt.args.vr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Add reference handling utilities for virtualnode and virtualrouter.

It's a clone of existing reference handling utilities for virtualService.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
