### PR TITLE
make virtualService provider optional to match awsSDK

### DIFF
--- a/apis/appmesh/v1beta2/virtualservice_types.go
+++ b/apis/appmesh/v1beta2/virtualservice_types.go
@@ -74,7 +74,8 @@ type VirtualServiceSpec struct {
 	AWSName *string `json:"awsName,omitempty"`
 
 	// The provider for virtual services. You can specify a single virtual node or virtual router.
-	Provider VirtualServiceProvider `json:"provider"`
+	// +optional
+	Provider *VirtualServiceProvider `json:"provider,omitempty"`
 
 	// A reference to k8s Mesh CR that this VirtualService belongs to.
 	// The admission controller populates it using Meshes's selector, and prevents users from setting this field.

--- a/apis/appmesh/v1beta2/zz_generated.deepcopy.go
+++ b/apis/appmesh/v1beta2/zz_generated.deepcopy.go
@@ -2559,7 +2559,11 @@ func (in *VirtualServiceSpec) DeepCopyInto(out *VirtualServiceSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	in.Provider.DeepCopyInto(&out.Provider)
+	if in.Provider != nil {
+		in, out := &in.Provider, &out.Provider
+		*out = new(VirtualServiceProvider)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MeshRef != nil {
 		in, out := &in.MeshRef, &out.MeshRef
 		*out = new(MeshReference)

--- a/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
@@ -100,8 +100,6 @@ spec:
                   - virtualRouterRef
                   type: object
               type: object
-          required:
-          - provider
           type: object
         status:
           description: VirtualServiceStatus defines the observed state of VirtualService


### PR DESCRIPTION
make virtualService provider optional to match awsSDK

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
