### PR TITLE
finalizer name change & vn resource owner change

### DIFF
--- a/controllers/appmesh/mesh_controller.go
+++ b/controllers/appmesh/mesh_controller.go
@@ -78,7 +78,7 @@ func (r *meshReconciler) reconcile(req ctrl.Request) error {
 }
 
 func (r *meshReconciler) reconcileMesh(ctx context.Context, ms *appmesh.Mesh) error {
-	if err := r.finalizerManager.AddFinalizers(ctx, ms, k8s.FinalizerMeshMembers, k8s.FinalizerAWSResources); err != nil {
+	if err := r.finalizerManager.AddFinalizers(ctx, ms, k8s.FinalizerMeshMembers, k8s.FinalizerAWSAppMeshResources); err != nil {
 		return err
 	}
 	if err := r.meshResManager.Reconcile(ctx, ms); err != nil {
@@ -97,11 +97,11 @@ func (r *meshReconciler) cleanupMesh(ctx context.Context, ms *appmesh.Mesh) erro
 		}
 	}
 
-	if k8s.HasFinalizer(ms, k8s.FinalizerAWSResources) {
+	if k8s.HasFinalizer(ms, k8s.FinalizerAWSAppMeshResources) {
 		if err := r.meshResManager.Cleanup(ctx, ms); err != nil {
 			return err
 		}
-		if err := r.finalizerManager.RemoveFinalizers(ctx, ms, k8s.FinalizerAWSResources); err != nil {
+		if err := r.finalizerManager.RemoveFinalizers(ctx, ms, k8s.FinalizerAWSAppMeshResources); err != nil {
 			return err
 		}
 	}

--- a/controllers/appmesh/virtualnode_controller.go
+++ b/controllers/appmesh/virtualnode_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -32,9 +31,10 @@ import (
 )
 
 // NewVirtualNodeReconciler constructs new virtualNodeReconciler
-func NewVirtualNodeReconciler(k8sClient client.Client, vnResManager virtualnode.ResourceManager, log logr.Logger) *virtualNodeReconciler {
+func NewVirtualNodeReconciler(k8sClient client.Client, finalizerManager k8s.FinalizerManager, vnResManager virtualnode.ResourceManager, log logr.Logger) *virtualNodeReconciler {
 	return &virtualNodeReconciler{
 		k8sClient:                    k8sClient,
+		finalizerManager:             finalizerManager,
 		vnResManager:                 vnResManager,
 		enqueueRequestsForMeshEvents: virtualnode.NewEnqueueRequestsForMeshEvents(k8sClient, log),
 		log:                          log,
@@ -43,8 +43,9 @@ func NewVirtualNodeReconciler(k8sClient client.Client, vnResManager virtualnode.
 
 // virtualNodeReconciler reconciles a VirtualNode object
 type virtualNodeReconciler struct {
-	k8sClient    client.Client
-	vnResManager virtualnode.ResourceManager
+	k8sClient        client.Client
+	finalizerManager k8s.FinalizerManager
+	vnResManager     virtualnode.ResourceManager
 
 	enqueueRequestsForMeshEvents handler.EventHandler
 	log                          logr.Logger
@@ -77,7 +78,7 @@ func (r *virtualNodeReconciler) reconcile(req ctrl.Request) error {
 }
 
 func (r *virtualNodeReconciler) reconcileVirtualNode(ctx context.Context, vn *appmesh.VirtualNode) error {
-	if err := r.addFinalizers(ctx, vn); err != nil {
+	if err := r.finalizerManager.AddFinalizers(ctx, vn, k8s.FinalizerAWSAppMeshResources); err != nil {
 		return err
 	}
 	if err := r.vnResManager.Reconcile(ctx, vn); err != nil {
@@ -87,35 +88,13 @@ func (r *virtualNodeReconciler) reconcileVirtualNode(ctx context.Context, vn *ap
 }
 
 func (r *virtualNodeReconciler) cleanupVirtualNode(ctx context.Context, vn *appmesh.VirtualNode) error {
-	if err := r.vnResManager.Cleanup(ctx, vn); err != nil {
-		return err
-	}
-	if err := r.removeFinalizers(ctx, vn); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (r *virtualNodeReconciler) addFinalizers(ctx context.Context, vn *appmesh.VirtualNode) error {
-	if k8s.HasFinalizer(vn, k8s.FinalizerAWSResources) {
-		return nil
-	}
-	oldVN := vn.DeepCopy()
-	controllerutil.AddFinalizer(vn, k8s.FinalizerAWSResources)
-	if err := r.k8sClient.Patch(ctx, vn, client.MergeFrom(oldVN)); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (r *virtualNodeReconciler) removeFinalizers(ctx context.Context, vn *appmesh.VirtualNode) error {
-	if !k8s.HasFinalizer(vn, k8s.FinalizerAWSResources) {
-		return nil
-	}
-	oldVN := vn.DeepCopy()
-	controllerutil.RemoveFinalizer(vn, k8s.FinalizerAWSResources)
-	if err := r.k8sClient.Patch(ctx, vn, client.MergeFrom(oldVN)); err != nil {
-		return err
+	if k8s.HasFinalizer(vn, k8s.FinalizerAWSAppMeshResources) {
+		if err := r.vnResManager.Cleanup(ctx, vn); err != nil {
+			return err
+		}
+		if err := r.finalizerManager.RemoveFinalizers(ctx, vn, k8s.FinalizerAWSAppMeshResources); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -98,9 +98,9 @@ func main() {
 	meshRefResolver := mesh.NewDefaultReferenceResolver(mgr.GetClient(), ctrl.Log)
 	meshResManager := mesh.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), cloud.AccountID(), ctrl.Log)
 	vsRefResolver := virtualservice.NewDefaultReferenceResolver(mgr.GetClient(), ctrl.Log)
-	vnResManager := virtualnode.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), meshRefResolver, vsRefResolver, ctrl.Log)
+	vnResManager := virtualnode.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), meshRefResolver, vsRefResolver, cloud.AccountID(), ctrl.Log)
 	msReconciler := appmeshcontroller.NewMeshReconciler(mgr.GetClient(), finalizerManager, meshMembersFinalizer, meshResManager, ctrl.Log.WithName("controllers").WithName("Mesh"))
-	vnReconciler := appmeshcontroller.NewVirtualNodeReconciler(mgr.GetClient(), vnResManager, ctrl.Log.WithName("controllers").WithName("VirtualNode"))
+	vnReconciler := appmeshcontroller.NewVirtualNodeReconciler(mgr.GetClient(), finalizerManager, vnResManager, ctrl.Log.WithName("controllers").WithName("VirtualNode"))
 
 	if err = msReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Mesh")

--- a/pkg/k8s/finalizers.go
+++ b/pkg/k8s/finalizers.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	FinalizerMeshMembers  = "finalizers.appmesh.k8s.aws/mesh-members"
-	FinalizerAWSResources = "finalizers.appmesh.k8s.aws/aws-resources"
+	FinalizerMeshMembers         = "finalizers.appmesh.k8s.aws/mesh-members"
+	FinalizerAWSAppMeshResources = "finalizers.appmesh.k8s.aws/aws-appmesh-resources"
 )
 
 type APIObject interface {

--- a/pkg/mesh/resource_manager.go
+++ b/pkg/mesh/resource_manager.go
@@ -140,7 +140,7 @@ func (m *defaultResourceManager) updateSDKMesh(ctx context.Context, sdkMS *appme
 		"diff", diff,
 	)
 	resp, err := m.appMeshSDK.UpdateMeshWithContext(ctx, &appmeshsdk.UpdateMeshInput{
-		MeshName: ms.Spec.AWSName,
+		MeshName: sdkMS.MeshName,
 		Spec:     desiredSDKMSSpec,
 	})
 	if err != nil {
@@ -159,7 +159,7 @@ func (m *defaultResourceManager) deleteSDKMesh(ctx context.Context, sdkMS *appme
 	}
 
 	_, err := m.appMeshSDK.DeleteMeshWithContext(ctx, &appmeshsdk.DeleteMeshInput{
-		MeshName: ms.Spec.AWSName,
+		MeshName: sdkMS.MeshName,
 	})
 	if err != nil {
 		return err

--- a/pkg/virtualnode/resource_manager_test.go
+++ b/pkg/virtualnode/resource_manager_test.go
@@ -241,3 +241,111 @@ func Test_defaultResourceManager_buildSDKVirtualServiceReferenceConvertFunc(t *t
 		})
 	}
 }
+
+func Test_defaultResourceManager_isSDKVirtualNodeControlledByCRDVirtualNode(t *testing.T) {
+	type fields struct {
+		accountID string
+	}
+	type args struct {
+		sdkVN *appmeshsdk.VirtualNodeData
+		vn    *appmesh.VirtualNode
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "sdkVN is controlled by crdVN",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVN: &appmeshsdk.VirtualNodeData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("222222222"),
+					},
+				},
+				vn: &appmesh.VirtualNode{},
+			},
+			want: true,
+		},
+		{
+			name:   "sdkVN isn't controlled by crdVN",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVN: &appmeshsdk.VirtualNodeData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("33333333"),
+					},
+				},
+				vn: &appmesh.VirtualNode{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := &defaultResourceManager{
+				accountID: tt.fields.accountID,
+				log:       &log.NullLogger{},
+			}
+			got := m.isSDKVirtualNodeControlledByCRDVirtualNode(ctx, tt.args.sdkVN, tt.args.vn)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_defaultResourceManager_isSDKVirtualNodeOwnedByCRDVirtualNode(t *testing.T) {
+	type fields struct {
+		accountID string
+	}
+	type args struct {
+		sdkVN *appmeshsdk.VirtualNodeData
+		vn    *appmesh.VirtualNode
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "sdkVN is owned by crdVN",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVN: &appmeshsdk.VirtualNodeData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("222222222"),
+					},
+				},
+				vn: &appmesh.VirtualNode{},
+			},
+			want: true,
+		},
+		{
+			name:   "sdkVN isn't owned by crdVN",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVN: &appmeshsdk.VirtualNodeData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("33333333"),
+					},
+				},
+				vn: &appmesh.VirtualNode{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := &defaultResourceManager{
+				accountID: tt.fields.accountID,
+				log:       &log.NullLogger{},
+			}
+			got := m.isSDKVirtualNodeOwnedByCRDVirtualNode(ctx, tt.args.sdkVN, tt.args.vn)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
1. add a separate `finalizers.appmesh.k8s.aws/aws-appmesh-resource` finalizer, so we can add a cloudmap later.
2. use the centralized finalizer handling component for virtualNode.
3. add support for resource owners for virtualNode(same logic as mesh)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
