### PR TITLE
Add resource manager for virtualRouter and virtualService

### DIFF
--- a/pkg/conversions/virtualrouter_types_conversion.go
+++ b/pkg/conversions/virtualrouter_types_conversion.go
@@ -374,3 +374,16 @@ func Convert_CRD_Route_To_SDK_RouteSpec(crdObj *appmesh.Route, sdkObj *appmeshsd
 	sdkObj.Priority = crdObj.Priority
 	return nil
 }
+
+func Convert_CRD_VirtualRouterSpec_To_SDK__VirtualRouterSpec(crdObj *appmesh.VirtualRouterSpec, sdkObj *appmeshsdk.VirtualRouterSpec, scope conversion.Scope) error {
+	var sdkListeners []*appmeshsdk.VirtualRouterListener
+	for _, crdListener := range crdObj.Listeners {
+		sdkListener := &appmeshsdk.VirtualRouterListener{}
+		if err := Convert_CRD_VirtualRouterListener_To_SDK_VirtualRouterListener(&crdListener, sdkListener, scope); err != nil {
+			return err
+		}
+		sdkListeners = append(sdkListeners, sdkListener)
+	}
+	sdkObj.Listeners = sdkListeners
+	return nil
+}

--- a/pkg/conversions/virtualrouter_types_conversion_test.go
+++ b/pkg/conversions/virtualrouter_types_conversion_test.go
@@ -1751,3 +1751,68 @@ func TestConvert_CRD_Route_To_SDK_RouteSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestConvert_CRD_VirtualRouterSpec_To_SDK__VirtualRouterSpec(t *testing.T) {
+	type args struct {
+		crdObj *appmesh.VirtualRouterSpec
+		sdkObj *appmeshsdk.VirtualRouterSpec
+		scope  conversion.Scope
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantSDKObj *appmeshsdk.VirtualRouterSpec
+		wantErr    error
+	}{
+		{
+			name: "normal case",
+			args: args{
+				crdObj: &appmesh.VirtualRouterSpec{
+					Listeners: []appmesh.VirtualRouterListener{
+						{
+							PortMapping: appmesh.PortMapping{
+								Port:     80,
+								Protocol: "http",
+							},
+						},
+						{
+							PortMapping: appmesh.PortMapping{
+								Port:     443,
+								Protocol: "http",
+							},
+						},
+					},
+				},
+				sdkObj: &appmeshsdk.VirtualRouterSpec{},
+				scope:  nil,
+			},
+			wantSDKObj: &appmeshsdk.VirtualRouterSpec{
+				Listeners: []*appmeshsdk.VirtualRouterListener{
+					{
+						PortMapping: &appmeshsdk.PortMapping{
+							Port:     aws.Int64(80),
+							Protocol: aws.String("http"),
+						},
+					},
+					{
+						PortMapping: &appmeshsdk.PortMapping{
+							Port:     aws.Int64(443),
+							Protocol: aws.String("http"),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Convert_CRD_VirtualRouterSpec_To_SDK__VirtualRouterSpec(tt.args.crdObj, tt.args.sdkObj, tt.args.scope)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantSDKObj, tt.args.sdkObj)
+			}
+		})
+	}
+}

--- a/pkg/references/conversions.go
+++ b/pkg/references/conversions.go
@@ -1,0 +1,58 @@
+package references
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// SDKVirtualNodeReferenceConvertFunc is func that can convert VirtualNodeReference to its AppMesh VirtualNode name.
+type SDKVirtualNodeReferenceConvertFunc func(vnRef *appmesh.VirtualNodeReference, vnAWSName *string, scope conversion.Scope) error
+
+// SDKVirtualServiceReferenceConvertFunc is func that can convert VirtualServiceReference to its AppMesh VirtualService name.
+type SDKVirtualServiceReferenceConvertFunc func(vsRef *appmesh.VirtualServiceReference, vsAWSName *string, scope conversion.Scope) error
+
+// SDKVirtualRouterReferenceConvertFunc is func that can convert VirtualRouterReference to its AppMesh VirtualRouter name.
+type SDKVirtualRouterReferenceConvertFunc func(vrRef *appmesh.VirtualRouterReference, vrAWSName *string, scope conversion.Scope) error
+
+// BuildSDKVirtualNodeReferenceConvertFunc constructs new SDKVirtualNodeReferenceConvertFunc by given referencing object and VirtualNode mapping.
+func BuildSDKVirtualNodeReferenceConvertFunc(obj metav1.Object, vnByKey map[types.NamespacedName]*appmesh.VirtualNode) SDKVirtualNodeReferenceConvertFunc {
+	return func(vnRef *appmesh.VirtualNodeReference, vnAWSName *string, scope conversion.Scope) error {
+		vnKey := ObjectKeyForVirtualNodeReference(obj, *vnRef)
+		vn, ok := vnByKey[vnKey]
+		if !ok {
+			return errors.Errorf("unexpected VirtualNodeReference: %v", vnKey)
+		}
+		*vnAWSName = aws.StringValue(vn.Spec.AWSName)
+		return nil
+	}
+}
+
+// BuildSDKVirtualServiceReferenceConvertFunc constructs new SDKVirtualServiceReferenceConvertFunc by given referencing object and VirtualService mapping.
+func BuildSDKVirtualServiceReferenceConvertFunc(obj metav1.Object, vsByKey map[types.NamespacedName]*appmesh.VirtualService) SDKVirtualServiceReferenceConvertFunc {
+	return func(vsRef *appmesh.VirtualServiceReference, vsAWSName *string, scope conversion.Scope) error {
+		vsKey := ObjectKeyForVirtualServiceReference(obj, *vsRef)
+		vs, ok := vsByKey[vsKey]
+		if !ok {
+			return errors.Errorf("unexpected VirtualServiceReference: %v", vsKey)
+		}
+		*vsAWSName = aws.StringValue(vs.Spec.AWSName)
+		return nil
+	}
+}
+
+// BuildSDKVirtualRouterReferenceConvertFunc constructs new SDKVirtualRouterReferenceConvertFunc by given referencing object and VirtualRouter mapping.
+func BuildSDKVirtualRouterReferenceConvertFunc(obj metav1.Object, vrByKey map[types.NamespacedName]*appmesh.VirtualRouter) SDKVirtualRouterReferenceConvertFunc {
+	return func(vrRef *appmesh.VirtualRouterReference, vrAWSName *string, scope conversion.Scope) error {
+		vrKey := ObjectKeyForVirtualRouterReference(obj, *vrRef)
+		vr, ok := vrByKey[vrKey]
+		if !ok {
+			return errors.Errorf("unexpected VirtualRouterReference: %v", vrKey)
+		}
+		*vrAWSName = aws.StringValue(vr.Spec.AWSName)
+		return nil
+	}
+}

--- a/pkg/references/conversions_test.go
+++ b/pkg/references/conversions_test.go
@@ -1,0 +1,401 @@
+package references
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+func TestBuildSDKVirtualNodeReferenceConvertFunc(t *testing.T) {
+	vs := &appmesh.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "vs",
+		},
+	}
+	vnRefWithNamespace := appmesh.VirtualNodeReference{
+		Namespace: aws.String("my-ns"),
+		Name:      "vn-1",
+	}
+	vnRefWithoutNamespace := appmesh.VirtualNodeReference{
+		Namespace: nil,
+		Name:      "vn-2",
+	}
+	vnRefInAnotherNamespace := appmesh.VirtualNodeReference{
+		Namespace: aws.String("my-other-ns"),
+		Name:      "vn-3",
+	}
+
+	type args struct {
+		obj     metav1.Object
+		vnByKey map[types.NamespacedName]*appmesh.VirtualNode
+	}
+	tests := []struct {
+		name                  string
+		args                  args
+		wantAWSNameOrErrByRef map[appmesh.VirtualNodeReference]struct {
+			awsName string
+			err     error
+		}
+	}{
+		{
+			name: "when all VirtualNodeReference resolve correctly",
+			args: args{
+				obj: vs,
+				vnByKey: map[types.NamespacedName]*appmesh.VirtualNode{
+					types.NamespacedName{Namespace: "my-ns", Name: "vn-1"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vn-1",
+						},
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-1_my-ns"),
+						},
+					},
+					types.NamespacedName{Namespace: "my-ns", Name: "vn-2"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vn-2",
+						},
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-2_my-ns"),
+						},
+					},
+					types.NamespacedName{Namespace: "my-other-ns", Name: "vn-3"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-other-ns",
+							Name:      "vn-3",
+						},
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-3_my-other-ns"),
+						},
+					},
+				},
+			},
+			wantAWSNameOrErrByRef: map[appmesh.VirtualNodeReference]struct {
+				awsName string
+				err     error
+			}{
+				vnRefWithNamespace: {
+					awsName: "vn-1_my-ns",
+				},
+				vnRefWithoutNamespace: {
+					awsName: "vn-2_my-ns",
+				},
+				vnRefInAnotherNamespace: {
+					awsName: "vn-3_my-other-ns",
+				},
+			},
+		},
+		{
+			name: "when some VirtualNodeReference cannot resolve correctly",
+			args: args{
+				obj: vs,
+				vnByKey: map[types.NamespacedName]*appmesh.VirtualNode{
+					types.NamespacedName{Namespace: "my-ns", Name: "vn-1"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vn-1",
+						},
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-1_my-ns"),
+						},
+					},
+				},
+			},
+			wantAWSNameOrErrByRef: map[appmesh.VirtualNodeReference]struct {
+				awsName string
+				err     error
+			}{
+				vnRefWithNamespace: {
+					awsName: "vn-1_my-ns",
+				},
+				vnRefWithoutNamespace: {
+					err: errors.New("unexpected VirtualNodeReference: my-ns/vn-2"),
+				},
+				vnRefInAnotherNamespace: {
+					err: errors.New("unexpected VirtualNodeReference: my-other-ns/vn-3"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			convertFunc := BuildSDKVirtualNodeReferenceConvertFunc(tt.args.obj, tt.args.vnByKey)
+			for vnRef, wantAWSNameOrErr := range tt.wantAWSNameOrErrByRef {
+				var gotAWSName = ""
+				gotErr := convertFunc(&vnRef, &gotAWSName, nil)
+				if wantAWSNameOrErr.err != nil {
+					assert.EqualError(t, gotErr, wantAWSNameOrErr.err.Error())
+				} else {
+					assert.NoError(t, gotErr)
+					assert.Equal(t, wantAWSNameOrErr.awsName, gotAWSName)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSDKVirtualServiceReferenceConvertFunc(t *testing.T) {
+	vn := &appmesh.VirtualNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "vn",
+		},
+	}
+	vsRefWithNamespace := appmesh.VirtualServiceReference{
+		Namespace: aws.String("my-ns"),
+		Name:      "vs-1",
+	}
+	vsRefWithoutNamespace := appmesh.VirtualServiceReference{
+		Namespace: nil,
+		Name:      "vs-2",
+	}
+	vsRefInAnotherNamespace := appmesh.VirtualServiceReference{
+		Namespace: aws.String("my-other-ns"),
+		Name:      "vs-3",
+	}
+
+	type args struct {
+		obj     metav1.Object
+		vsByKey map[types.NamespacedName]*appmesh.VirtualService
+	}
+	tests := []struct {
+		name                  string
+		args                  args
+		wantAWSNameOrErrByRef map[appmesh.VirtualServiceReference]struct {
+			awsName string
+			err     error
+		}
+	}{
+		{
+			name: "when all VirtualServiceReference resolve correctly",
+			args: args{
+				obj: vn,
+				vsByKey: map[types.NamespacedName]*appmesh.VirtualService{
+					types.NamespacedName{Namespace: "my-ns", Name: "vs-1"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vs-1",
+						},
+						Spec: appmesh.VirtualServiceSpec{
+							AWSName: aws.String("vs-1.my-ns"),
+						},
+					},
+					types.NamespacedName{Namespace: "my-ns", Name: "vs-2"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vs-2",
+						},
+						Spec: appmesh.VirtualServiceSpec{
+							AWSName: aws.String("vs-2.my-ns"),
+						},
+					},
+					types.NamespacedName{Namespace: "my-other-ns", Name: "vs-3"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-other-ns",
+							Name:      "vs-3",
+						},
+						Spec: appmesh.VirtualServiceSpec{
+							AWSName: aws.String("vs-3.my-other-ns"),
+						},
+					},
+				},
+			},
+			wantAWSNameOrErrByRef: map[appmesh.VirtualServiceReference]struct {
+				awsName string
+				err     error
+			}{
+				vsRefWithNamespace: {
+					awsName: "vs-1.my-ns",
+				},
+				vsRefWithoutNamespace: {
+					awsName: "vs-2.my-ns",
+				},
+				vsRefInAnotherNamespace: {
+					awsName: "vs-3.my-other-ns",
+				},
+			},
+		},
+		{
+			name: "when some VirtualServiceReference cannot resolve correctly",
+			args: args{
+				obj: vn,
+				vsByKey: map[types.NamespacedName]*appmesh.VirtualService{
+					types.NamespacedName{Namespace: "my-ns", Name: "vs-1"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vs-1",
+						},
+						Spec: appmesh.VirtualServiceSpec{
+							AWSName: aws.String("vs-1.my-ns"),
+						},
+					},
+				},
+			},
+			wantAWSNameOrErrByRef: map[appmesh.VirtualServiceReference]struct {
+				awsName string
+				err     error
+			}{
+				vsRefWithNamespace: {
+					awsName: "vs-1.my-ns",
+				},
+				vsRefWithoutNamespace: {
+					err: errors.New("unexpected VirtualServiceReference: my-ns/vs-2"),
+				},
+				vsRefInAnotherNamespace: {
+					err: errors.New("unexpected VirtualServiceReference: my-other-ns/vs-3"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			convertFunc := BuildSDKVirtualServiceReferenceConvertFunc(tt.args.obj, tt.args.vsByKey)
+			for vsRef, wantAWSNameOrErr := range tt.wantAWSNameOrErrByRef {
+				var gotAWSName = ""
+				gotErr := convertFunc(&vsRef, &gotAWSName, nil)
+				if wantAWSNameOrErr.err != nil {
+					assert.EqualError(t, gotErr, wantAWSNameOrErr.err.Error())
+				} else {
+					assert.NoError(t, gotErr)
+					assert.Equal(t, wantAWSNameOrErr.awsName, gotAWSName)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSDKVirtualRouterReferenceConvertFunc(t *testing.T) {
+	vs := &appmesh.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "vs",
+		},
+	}
+	vrRefWithNamespace := appmesh.VirtualRouterReference{
+		Namespace: aws.String("my-ns"),
+		Name:      "vr-1",
+	}
+	vrRefWithoutNamespace := appmesh.VirtualRouterReference{
+		Namespace: nil,
+		Name:      "vr-2",
+	}
+	vrRefInAnotherNamespace := appmesh.VirtualRouterReference{
+		Namespace: aws.String("my-other-ns"),
+		Name:      "vr-3",
+	}
+
+	type args struct {
+		obj     metav1.Object
+		vrByKey map[types.NamespacedName]*appmesh.VirtualRouter
+	}
+	tests := []struct {
+		name                  string
+		args                  args
+		wantAWSNameOrErrByRef map[appmesh.VirtualRouterReference]struct {
+			awsName string
+			err     error
+		}
+	}{
+		{
+			name: "when all VirtualRouterReference resolve correctly",
+			args: args{
+				obj: vs,
+				vrByKey: map[types.NamespacedName]*appmesh.VirtualRouter{
+					types.NamespacedName{Namespace: "my-ns", Name: "vr-1"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vr-1",
+						},
+						Spec: appmesh.VirtualRouterSpec{
+							AWSName: aws.String("vr-1_my-ns"),
+						},
+					},
+					types.NamespacedName{Namespace: "my-ns", Name: "vr-2"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vr-2",
+						},
+						Spec: appmesh.VirtualRouterSpec{
+							AWSName: aws.String("vr-2_my-ns"),
+						},
+					},
+					types.NamespacedName{Namespace: "my-other-ns", Name: "vr-3"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-other-ns",
+							Name:      "vr-3",
+						},
+						Spec: appmesh.VirtualRouterSpec{
+							AWSName: aws.String("vr-3_my-other-ns"),
+						},
+					},
+				},
+			},
+			wantAWSNameOrErrByRef: map[appmesh.VirtualRouterReference]struct {
+				awsName string
+				err     error
+			}{
+				vrRefWithNamespace: {
+					awsName: "vr-1_my-ns",
+				},
+				vrRefWithoutNamespace: {
+					awsName: "vr-2_my-ns",
+				},
+				vrRefInAnotherNamespace: {
+					awsName: "vr-3_my-other-ns",
+				},
+			},
+		},
+		{
+			name: "when some VirtualRouterReference cannot resolve correctly",
+			args: args{
+				obj: vs,
+				vrByKey: map[types.NamespacedName]*appmesh.VirtualRouter{
+					types.NamespacedName{Namespace: "my-ns", Name: "vr-1"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "vr-1",
+						},
+						Spec: appmesh.VirtualRouterSpec{
+							AWSName: aws.String("vr-1_my-ns"),
+						},
+					},
+				},
+			},
+			wantAWSNameOrErrByRef: map[appmesh.VirtualRouterReference]struct {
+				awsName string
+				err     error
+			}{
+				vrRefWithNamespace: {
+					awsName: "vr-1_my-ns",
+				},
+				vrRefWithoutNamespace: {
+					err: errors.New("unexpected VirtualRouterReference: my-ns/vr-2"),
+				},
+				vrRefInAnotherNamespace: {
+					err: errors.New("unexpected VirtualRouterReference: my-other-ns/vr-3"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			convertFunc := BuildSDKVirtualRouterReferenceConvertFunc(tt.args.obj, tt.args.vrByKey)
+			for vrRef, wantAWSNameOrErr := range tt.wantAWSNameOrErrByRef {
+				var gotAWSName = ""
+				gotErr := convertFunc(&vrRef, &gotAWSName, nil)
+				if wantAWSNameOrErr.err != nil {
+					assert.EqualError(t, gotErr, wantAWSNameOrErr.err.Error())
+				} else {
+					assert.NoError(t, gotErr)
+					assert.Equal(t, wantAWSNameOrErr.awsName, gotAWSName)
+				}
+			}
+		})
+	}
+}

--- a/pkg/references/object_key.go
+++ b/pkg/references/object_key.go
@@ -1,0 +1,34 @@
+package references
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ObjectKeyForVirtualNodeReference returns the key of referenced VirtualNode CR.
+func ObjectKeyForVirtualNodeReference(obj metav1.Object, vnRef appmesh.VirtualNodeReference) types.NamespacedName {
+	namespace := obj.GetNamespace()
+	if vnRef.Namespace != nil && len(*vnRef.Namespace) != 0 {
+		namespace = *vnRef.Namespace
+	}
+	return types.NamespacedName{Namespace: namespace, Name: vnRef.Name}
+}
+
+// ObjectKeyForVirtualServiceReference returns the key of referenced VirtualService CR.
+func ObjectKeyForVirtualServiceReference(obj metav1.Object, vsRef appmesh.VirtualServiceReference) types.NamespacedName {
+	namespace := obj.GetNamespace()
+	if vsRef.Namespace != nil && len(*vsRef.Namespace) != 0 {
+		namespace = *vsRef.Namespace
+	}
+	return types.NamespacedName{Namespace: namespace, Name: vsRef.Name}
+}
+
+// ObjectKeyForVirtualRouterReference returns the key of referenced VirtualRouter CR.
+func ObjectKeyForVirtualRouterReference(obj metav1.Object, vrRef appmesh.VirtualRouterReference) types.NamespacedName {
+	namespace := obj.GetNamespace()
+	if vrRef.Namespace != nil && len(*vrRef.Namespace) != 0 {
+		namespace = *vrRef.Namespace
+	}
+	return types.NamespacedName{Namespace: namespace, Name: vrRef.Name}
+}

--- a/pkg/references/object_key_test.go
+++ b/pkg/references/object_key_test.go
@@ -1,0 +1,160 @@
+package references
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+func TestObjectKeyForVirtualNodeReference(t *testing.T) {
+	type args struct {
+		obj   metav1.Object
+		vnRef appmesh.VirtualNodeReference
+	}
+	tests := []struct {
+		name string
+		args args
+		want types.NamespacedName
+	}{
+		{
+			name: "namespace un-specified",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "vs-ns",
+						Name:      "vs",
+					},
+				},
+				vnRef: appmesh.VirtualNodeReference{
+					Name: "vn",
+				},
+			},
+			want: types.NamespacedName{Namespace: "vs-ns", Name: "vn"},
+		},
+		{
+			name: "namespace specified",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "vs-ns",
+						Name:      "vs",
+					},
+				},
+				vnRef: appmesh.VirtualNodeReference{
+					Namespace: aws.String("vn-ns"),
+					Name:      "vn",
+				},
+			},
+			want: types.NamespacedName{Namespace: "vn-ns", Name: "vn"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ObjectKeyForVirtualNodeReference(tt.args.obj, tt.args.vnRef)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestObjectKeyForVirtualServiceReference(t *testing.T) {
+	type args struct {
+		obj   metav1.Object
+		vsRef appmesh.VirtualServiceReference
+	}
+	tests := []struct {
+		name string
+		args args
+		want types.NamespacedName
+	}{
+		{
+			name: "namespace un-specified",
+			args: args{
+				obj: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "vn-ns",
+						Name:      "vn",
+					},
+				},
+				vsRef: appmesh.VirtualServiceReference{
+					Name: "vs",
+				},
+			},
+			want: types.NamespacedName{Namespace: "vn-ns", Name: "vs"},
+		},
+		{
+			name: "namespace specified",
+			args: args{
+				obj: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "vn-ns",
+						Name:      "vn",
+					},
+				},
+				vsRef: appmesh.VirtualServiceReference{
+					Namespace: aws.String("vs-ns"),
+					Name:      "vs",
+				},
+			},
+			want: types.NamespacedName{Namespace: "vs-ns", Name: "vs"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ObjectKeyForVirtualServiceReference(tt.args.obj, tt.args.vsRef)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestObjectKeyForVirtualRouterReference(t *testing.T) {
+	type args struct {
+		obj   metav1.Object
+		vrRef appmesh.VirtualRouterReference
+	}
+	tests := []struct {
+		name string
+		args args
+		want types.NamespacedName
+	}{
+		{
+			name: "namespace un-specified",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "vs-ns",
+						Name:      "vs",
+					},
+				},
+				vrRef: appmesh.VirtualRouterReference{
+					Name: "vr",
+				},
+			},
+			want: types.NamespacedName{Namespace: "vs-ns", Name: "vr"},
+		},
+		{
+			name: "namespace specified",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "vs-ns",
+						Name:      "vs",
+					},
+				},
+				vrRef: appmesh.VirtualRouterReference{
+					Namespace: aws.String("vr-ns"),
+					Name:      "vr",
+				},
+			},
+			want: types.NamespacedName{Namespace: "vr-ns", Name: "vr"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ObjectKeyForVirtualRouterReference(tt.args.obj, tt.args.vrRef)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/references/resolver.go
+++ b/pkg/references/resolver.go
@@ -53,12 +53,7 @@ func (r *defaultResolver) ResolveMeshReference(ctx context.Context, ref appmesh.
 }
 
 func (r *defaultResolver) ResolveVirtualNodeReference(ctx context.Context, obj metav1.Object, ref appmesh.VirtualNodeReference) (*appmesh.VirtualNode, error) {
-	namespace := obj.GetNamespace()
-	if ref.Namespace != nil && len(*ref.Namespace) != 0 {
-		namespace = *ref.Namespace
-	}
-
-	vnKey := types.NamespacedName{Namespace: namespace, Name: ref.Name}
+	vnKey := ObjectKeyForVirtualNodeReference(obj, ref)
 	vn := &appmesh.VirtualNode{}
 	if err := r.k8sClient.Get(ctx, vnKey, vn); err != nil {
 		return nil, errors.Wrapf(err, "unable to fetch virtualNode: %v", vnKey)
@@ -67,11 +62,7 @@ func (r *defaultResolver) ResolveVirtualNodeReference(ctx context.Context, obj m
 }
 
 func (r *defaultResolver) ResolveVirtualServiceReference(ctx context.Context, obj metav1.Object, ref appmesh.VirtualServiceReference) (*appmesh.VirtualService, error) {
-	namespace := obj.GetNamespace()
-	if ref.Namespace != nil && len(*ref.Namespace) != 0 {
-		namespace = *ref.Namespace
-	}
-	vsKey := types.NamespacedName{Namespace: namespace, Name: ref.Name}
+	vsKey := ObjectKeyForVirtualServiceReference(obj, ref)
 	vs := &appmesh.VirtualService{}
 	if err := r.k8sClient.Get(ctx, vsKey, vs); err != nil {
 		return nil, errors.Wrapf(err, "unable to fetch virtualService: %v", vsKey)
@@ -80,12 +71,7 @@ func (r *defaultResolver) ResolveVirtualServiceReference(ctx context.Context, ob
 }
 
 func (r *defaultResolver) ResolveVirtualRouterReference(ctx context.Context, obj metav1.Object, ref appmesh.VirtualRouterReference) (*appmesh.VirtualRouter, error) {
-	namespace := obj.GetNamespace()
-	if ref.Namespace != nil && len(*ref.Namespace) != 0 {
-		namespace = *ref.Namespace
-	}
-
-	vrKey := types.NamespacedName{Namespace: namespace, Name: ref.Name}
+	vrKey := ObjectKeyForVirtualRouterReference(obj, ref)
 	vr := &appmesh.VirtualRouter{}
 	if err := r.k8sClient.Get(ctx, vrKey, vr); err != nil {
 		return nil, errors.Wrapf(err, "unable to fetch virtualRouter: %v", vrKey)

--- a/pkg/virtualnode/resource_manager.go
+++ b/pkg/virtualnode/resource_manager.go
@@ -270,11 +270,11 @@ func (m *defaultResourceManager) updateCRDVirtualNode(ctx context.Context, vn *a
 }
 
 func (m *defaultResourceManager) buildSDKVirtualNodeSpec(ctx context.Context, vn *appmesh.VirtualNode, vsByRef map[appmesh.VirtualServiceReference]*appmesh.VirtualService) (*appmeshsdk.VirtualNodeSpec, error) {
-	sdkVSRefConvertFunc := m.buildSDKVirtualServiceReferenceConvertFunc(ctx, vsByRef)
 	converter := conversion.NewConverter(conversion.DefaultNameFunc)
 	converter.RegisterUntypedConversionFunc((*appmesh.VirtualNodeSpec)(nil), (*appmeshsdk.VirtualNodeSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return conversions.Convert_CRD_VirtualNodeSpec_To_SDK_VirtualNodeSpec(a.(*appmesh.VirtualNodeSpec), b.(*appmeshsdk.VirtualNodeSpec), scope)
 	})
+	sdkVSRefConvertFunc := m.buildSDKVirtualServiceReferenceConvertFunc(ctx, vsByRef)
 	converter.RegisterUntypedConversionFunc((*appmesh.VirtualServiceReference)(nil), (*string)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return sdkVSRefConvertFunc(a.(*appmesh.VirtualServiceReference), b.(*string), scope)
 	})
@@ -304,16 +304,13 @@ func (m *defaultResourceManager) buildSDKVirtualServiceReferenceConvertFunc(ctx 
 }
 
 // isSDKVirtualNodeControlledByCRDVirtualNode checks whether an AppMesh virtualNode is controlled by CRD virtualNode
-// if it's controlled, CRD virtualNode update is responsible for update AppMesh virtualNode.
+// if it's controlled, CRD virtualNode update is responsible for updating the AppMesh virtualNode.
 func (m *defaultResourceManager) isSDKVirtualNodeControlledByCRDVirtualNode(ctx context.Context, sdkVN *appmeshsdk.VirtualNodeData, vn *appmesh.VirtualNode) bool {
-	if aws.StringValue(sdkVN.Metadata.ResourceOwner) != m.accountID {
-		return false
-	}
-	return true
+	return aws.StringValue(sdkVN.Metadata.ResourceOwner) == m.accountID
 }
 
 // isSDKVirtualNodeOwnedByCRDVirtualNode checks whether an AppMesh virtualNode is owned by CRD virtualNode.
-// if it's owned, CRD virtualNode deletion is responsible for delete AppMesh virtualNode.
+// if it's owned, CRD virtualNode deletion is responsible for deleting the AppMesh virtualNode.
 func (m *defaultResourceManager) isSDKVirtualNodeOwnedByCRDVirtualNode(ctx context.Context, sdkVN *appmeshsdk.VirtualNodeData, vn *appmesh.VirtualNode) bool {
 	if !m.isSDKVirtualNodeControlledByCRDVirtualNode(ctx, sdkVN, vn) {
 		return false

--- a/pkg/virtualrouter/conditions.go
+++ b/pkg/virtualrouter/conditions.go
@@ -1,0 +1,51 @@
+package virtualrouter
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// getCondition will get pointer to virtualRouter's existing condition.
+func getCondition(vr *appmesh.VirtualRouter, conditionType appmesh.VirtualRouterConditionType) *appmesh.VirtualRouterCondition {
+	for i := range vr.Status.Conditions {
+		if vr.Status.Conditions[i].Type == conditionType {
+			return &vr.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// updateCondition will update virtualRouter's condition. returns whether it's updated.
+func updateCondition(vr *appmesh.VirtualRouter, conditionType appmesh.VirtualRouterConditionType, status corev1.ConditionStatus, reason *string, message *string) bool {
+	now := metav1.Now()
+	existingCondition := getCondition(vr, conditionType)
+	if existingCondition == nil {
+		newCondition := appmesh.VirtualRouterCondition{
+			Type:               conditionType,
+			Status:             status,
+			LastTransitionTime: &now,
+			Reason:             reason,
+			Message:            message,
+		}
+		vr.Status.Conditions = append(vr.Status.Conditions, newCondition)
+		return true
+	}
+
+	hasChanged := false
+	if existingCondition.Status != status {
+		existingCondition.Status = status
+		existingCondition.LastTransitionTime = &now
+		hasChanged = true
+	}
+	if aws.StringValue(existingCondition.Reason) != aws.StringValue(reason) {
+		existingCondition.Reason = reason
+		hasChanged = true
+	}
+	if aws.StringValue(existingCondition.Message) != aws.StringValue(message) {
+		existingCondition.Message = message
+		hasChanged = true
+	}
+	return hasChanged
+}

--- a/pkg/virtualrouter/conditions_test.go
+++ b/pkg/virtualrouter/conditions_test.go
@@ -1,0 +1,269 @@
+package virtualrouter
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_getCondition(t *testing.T) {
+	type args struct {
+		vr            *appmesh.VirtualRouter
+		conditionType appmesh.VirtualRouterConditionType
+	}
+	tests := []struct {
+		name string
+		args args
+		want *appmesh.VirtualRouterCondition
+	}{
+		{
+			name: "condition found",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualRouterActive,
+			},
+			want: &appmesh.VirtualRouterCondition{
+				Type:   appmesh.VirtualRouterActive,
+				Status: corev1.ConditionFalse,
+			},
+		},
+		{
+			name: "condition not found",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{},
+					},
+				},
+				conditionType: appmesh.VirtualRouterActive,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getCondition(tt.args.vr, tt.args.conditionType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_updateCondition(t *testing.T) {
+	type args struct {
+		vr            *appmesh.VirtualRouter
+		conditionType appmesh.VirtualRouterConditionType
+		status        corev1.ConditionStatus
+		reason        *string
+		message       *string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantVR      *appmesh.VirtualRouter
+		wantChanged bool
+	}{
+		{
+			name: "condition updated by modify condition status",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualRouterActive,
+				status:        corev1.ConditionTrue,
+			},
+			wantVR: &appmesh.VirtualRouter{
+				Status: appmesh.VirtualRouterStatus{
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:   appmesh.VirtualRouterActive,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition reason",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualRouterActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+			},
+			wantVR: &appmesh.VirtualRouter{
+				Status: appmesh.VirtualRouterStatus{
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:   appmesh.VirtualRouterActive,
+							Status: corev1.ConditionTrue,
+							Reason: aws.String("reason"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition message",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualRouterActive,
+				status:        corev1.ConditionTrue,
+				message:       aws.String("message"),
+			},
+			wantVR: &appmesh.VirtualRouter{
+				Status: appmesh.VirtualRouterStatus{
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:    appmesh.VirtualRouterActive,
+							Status:  corev1.ConditionTrue,
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition status/reason/message",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualRouterActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantVR: &appmesh.VirtualRouter{
+				Status: appmesh.VirtualRouterStatus{
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:    appmesh.VirtualRouterActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by new condition",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: nil,
+					},
+				},
+				conditionType: appmesh.VirtualRouterActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantVR: &appmesh.VirtualRouter{
+				Status: appmesh.VirtualRouterStatus{
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:    appmesh.VirtualRouterActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition unmodified",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Status: appmesh.VirtualRouterStatus{
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:    appmesh.VirtualRouterActive,
+								Status:  corev1.ConditionTrue,
+								Reason:  aws.String("reason"),
+								Message: aws.String("message"),
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualRouterActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantVR: &appmesh.VirtualRouter{
+				Status: appmesh.VirtualRouterStatus{
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:    appmesh.VirtualRouterActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChanged := updateCondition(tt.args.vr, tt.args.conditionType, tt.args.status, tt.args.reason, tt.args.message)
+			opts := cmpopts.IgnoreTypes((*metav1.Time)(nil))
+			assert.True(t, cmp.Equal(tt.wantVR, tt.args.vr, opts), "diff", cmp.Diff(tt.wantVR, tt.args.vr, opts))
+			assert.Equal(t, tt.wantChanged, gotChanged)
+		})
+	}
+}

--- a/pkg/virtualrouter/references.go
+++ b/pkg/virtualrouter/references.go
@@ -1,0 +1,31 @@
+package virtualrouter
+
+import appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+
+// extractVirtualNodeReferences extracts all virtualNodeReferences for this virtualRouter
+func extractVirtualNodeReferences(vr *appmesh.VirtualRouter) []appmesh.VirtualNodeReference {
+	var vnRefs []appmesh.VirtualNodeReference
+	for _, route := range vr.Spec.Routes {
+		if route.GRPCRoute != nil {
+			for _, target := range route.GRPCRoute.Action.WeightedTargets {
+				vnRefs = append(vnRefs, target.VirtualNodeRef)
+			}
+		}
+		if route.HTTPRoute != nil {
+			for _, target := range route.HTTPRoute.Action.WeightedTargets {
+				vnRefs = append(vnRefs, target.VirtualNodeRef)
+			}
+		}
+		if route.HTTP2Route != nil {
+			for _, target := range route.HTTP2Route.Action.WeightedTargets {
+				vnRefs = append(vnRefs, target.VirtualNodeRef)
+			}
+		}
+		if route.TCPRoute != nil {
+			for _, target := range route.TCPRoute.Action.WeightedTargets {
+				vnRefs = append(vnRefs, target.VirtualNodeRef)
+			}
+		}
+	}
+	return vnRefs
+}

--- a/pkg/virtualrouter/references_test.go
+++ b/pkg/virtualrouter/references_test.go
@@ -1,0 +1,269 @@
+package virtualrouter
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_extractVirtualNodeReferences(t *testing.T) {
+	type args struct {
+		vr *appmesh.VirtualRouter
+	}
+	tests := []struct {
+		name string
+		args args
+		want []appmesh.VirtualNodeReference
+	}{
+		{
+			name: "single GRPC route",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: []appmesh.Route{
+							{
+								GRPCRoute: &appmesh.GRPCRoute{
+									Action: appmesh.GRPCRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-1",
+												},
+											},
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-2",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []appmesh.VirtualNodeReference{
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-1",
+				},
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-2",
+				},
+			},
+		},
+		{
+			name: "single HTTP route",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: []appmesh.Route{
+							{
+								HTTPRoute: &appmesh.HTTPRoute{
+									Action: appmesh.HTTPRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-1",
+												},
+											},
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-2",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []appmesh.VirtualNodeReference{
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-1",
+				},
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-2",
+				},
+			},
+		},
+		{
+			name: "single HTTP2 route",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: []appmesh.Route{
+							{
+								HTTP2Route: &appmesh.HTTPRoute{
+									Action: appmesh.HTTPRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-1",
+												},
+											},
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-2",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []appmesh.VirtualNodeReference{
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-1",
+				},
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-2",
+				},
+			},
+		},
+		{
+			name: "single TCP route",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: []appmesh.Route{
+							{
+								TCPRoute: &appmesh.TCPRoute{
+									Action: appmesh.TCPRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-1",
+												},
+											},
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-2",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []appmesh.VirtualNodeReference{
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-1",
+				},
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-2",
+				},
+			},
+		},
+		{
+			name: "multiple routes",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: []appmesh.Route{
+							{
+								GRPCRoute: &appmesh.GRPCRoute{
+									Action: appmesh.GRPCRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-1",
+												},
+											},
+										},
+									},
+								},
+								HTTPRoute: &appmesh.HTTPRoute{
+									Action: appmesh.HTTPRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-2",
+												},
+											},
+										},
+									},
+								},
+								HTTP2Route: &appmesh.HTTPRoute{
+									Action: appmesh.HTTPRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-3",
+												},
+											},
+										},
+									},
+								},
+								TCPRoute: &appmesh.TCPRoute{
+									Action: appmesh.TCPRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-4",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []appmesh.VirtualNodeReference{
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-1",
+				},
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-2",
+				},
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-3",
+				},
+				{
+					Namespace: aws.String("my-ns"),
+					Name:      "vn-4",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractVirtualNodeReferences(tt.args.vr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/virtualrouter/resource_manager.go
+++ b/pkg/virtualrouter/resource_manager.go
@@ -1,0 +1,325 @@
+package virtualrouter
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/services"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/conversions"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/mesh"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/runtime"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ResourceManager is dedicated to manage AppMesh VirtualRouter resources for k8s VirtualRouter CRs.
+type ResourceManager interface {
+	// Reconcile will create/update AppMesh VirtualRouter to match vr.spec, and update vr.status
+	Reconcile(ctx context.Context, vr *appmesh.VirtualRouter) error
+
+	// Cleanup will delete AppMesh VirtualRouter created for vr.
+	Cleanup(ctx context.Context, vr *appmesh.VirtualRouter) error
+}
+
+func NewDefaultResourceManager(k8sClient client.Client, appMeshSDK services.AppMesh, referencesResolver references.Resolver,
+	accountID string, log logr.Logger) ResourceManager {
+	routesManager := newDefaultRoutesManager(appMeshSDK, log)
+	return &defaultResourceManager{
+		k8sClient:          k8sClient,
+		appMeshSDK:         appMeshSDK,
+		referencesResolver: referencesResolver,
+		routesManager:      routesManager,
+		accountID:          accountID,
+		log:                log,
+	}
+}
+
+type defaultResourceManager struct {
+	k8sClient          client.Client
+	appMeshSDK         services.AppMesh
+	referencesResolver references.Resolver
+	routesManager      routesManager
+	accountID          string
+	log                logr.Logger
+}
+
+func (m *defaultResourceManager) Reconcile(ctx context.Context, vr *appmesh.VirtualRouter) error {
+	ms, err := m.findMeshDependency(ctx, vr)
+	if err != nil {
+		return err
+	}
+	if err := m.validateMeshDependencies(ctx, ms); err != nil {
+		return err
+	}
+	vnByKey, err := m.findVirtualNodeDependencies(ctx, vr)
+	if err != nil {
+		return err
+	}
+	if err := m.validateVirtualNodeDependencies(ctx, ms, vnByKey); err != nil {
+		return err
+	}
+
+	sdkVR, err := m.findSDKVirtualRouter(ctx, ms, vr)
+	if err != nil {
+		return err
+	}
+	var sdkRouteByName map[string]*appmeshsdk.RouteData
+	if sdkVR == nil {
+		sdkVR, err = m.createSDKVirtualRouter(ctx, ms, vr)
+		if err != nil {
+			return err
+		}
+		sdkRouteByName, err = m.routesManager.create(ctx, ms, vr, vnByKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		sdkVR, err = m.updateSDKVirtualRouter(ctx, sdkVR, vr)
+		if err != nil {
+			return err
+		}
+		sdkRouteByName, err = m.routesManager.update(ctx, ms, vr, vnByKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	return m.updateCRDVirtualRouter(ctx, vr, sdkVR, sdkRouteByName)
+}
+
+func (m *defaultResourceManager) Cleanup(ctx context.Context, vr *appmesh.VirtualRouter) error {
+	ms, err := m.findMeshDependency(ctx, vr)
+	if err != nil {
+		return err
+	}
+	if err := m.validateMeshDependencies(ctx, ms); err != nil {
+		return err
+	}
+
+	sdkVR, err := m.findSDKVirtualRouter(ctx, ms, vr)
+	if sdkVR == nil {
+		return nil
+	}
+	if err := m.routesManager.cleanup(ctx, ms, vr); err != nil {
+		return err
+	}
+	return m.deleteSDKVirtualRouter(ctx, sdkVR, vr)
+}
+
+// findMeshDependency find the Mesh dependency for this VirtualRouter.
+func (m *defaultResourceManager) findMeshDependency(ctx context.Context, vr *appmesh.VirtualRouter) (*appmesh.Mesh, error) {
+	if vr.Spec.MeshRef == nil {
+		return nil, errors.Errorf("meshRef shouldn't be nil, please check webhook setup")
+	}
+	ms, err := m.referencesResolver.ResolveMeshReference(ctx, *vr.Spec.MeshRef)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve meshRef")
+	}
+	return ms, nil
+}
+
+// validateMeshDependencies validate the Mesh dependency for this VirtualRouter.
+func (m *defaultResourceManager) validateMeshDependencies(ctx context.Context, ms *appmesh.Mesh) error {
+	if !mesh.IsMeshActive(ms) {
+		return runtime.NewRequeueError(errors.New("mesh is not active yet"))
+	}
+	return nil
+}
+
+func (m *defaultResourceManager) findVirtualNodeDependencies(ctx context.Context, vr *appmesh.VirtualRouter) (map[types.NamespacedName]*appmesh.VirtualNode, error) {
+	vnRefs := extractVirtualNodeReferences(vr)
+	vnByKey := make(map[types.NamespacedName]*appmesh.VirtualNode)
+	for _, vnRef := range vnRefs {
+		vnKey := references.ObjectKeyForVirtualNodeReference(vr, vnRef)
+		if _, ok := vnByKey[vnKey]; ok {
+			continue
+		}
+		vn, err := m.referencesResolver.ResolveVirtualNodeReference(ctx, vr, vnRef)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to resolve virtualNodeRef")
+		}
+		vnByKey[vnKey] = vn
+	}
+	return vnByKey, nil
+}
+
+func (m *defaultResourceManager) validateVirtualNodeDependencies(ctx context.Context, ms *appmesh.Mesh, vnByKey map[types.NamespacedName]*appmesh.VirtualNode) error {
+	for _, vn := range vnByKey {
+		if vn.Spec.MeshRef == nil || !mesh.IsMeshReferenced(ms, *vn.Spec.MeshRef) {
+			return errors.Errorf("virtualNode %v didn't belong to mesh %v", k8s.NamespacedName(vn), k8s.NamespacedName(ms))
+		}
+		if !virtualnode.IsVirtualNodeActive(vn) {
+			return runtime.NewRequeueError(errors.New("virtualNode is not active yet"))
+		}
+	}
+	return nil
+}
+
+func (m *defaultResourceManager) findSDKVirtualRouter(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter) (*appmeshsdk.VirtualRouterData, error) {
+	resp, err := m.appMeshSDK.DescribeVirtualRouterWithContext(ctx, &appmeshsdk.DescribeVirtualRouterInput{
+		MeshName:          ms.Spec.AWSName,
+		MeshOwner:         ms.Spec.MeshOwner,
+		VirtualRouterName: vr.Spec.AWSName,
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return resp.VirtualRouter, nil
+}
+
+func (m *defaultResourceManager) createSDKVirtualRouter(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter) (*appmeshsdk.VirtualRouterData, error) {
+	sdkVRSpec, err := buildSDKVirtualRouterSpec(vr)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := m.appMeshSDK.CreateVirtualRouterWithContext(ctx, &appmeshsdk.CreateVirtualRouterInput{
+		MeshName:          ms.Spec.AWSName,
+		MeshOwner:         ms.Spec.MeshOwner,
+		VirtualRouterName: vr.Spec.AWSName,
+		Spec:              sdkVRSpec,
+		Tags:              nil,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.VirtualRouter, nil
+}
+
+func (m *defaultResourceManager) updateSDKVirtualRouter(ctx context.Context, sdkVR *appmeshsdk.VirtualRouterData, vr *appmesh.VirtualRouter) (*appmeshsdk.VirtualRouterData, error) {
+	actualSDKVRSpec := sdkVR.Spec
+	desiredSDKVRSpec, err := buildSDKVirtualRouterSpec(vr)
+	if err != nil {
+		return nil, err
+	}
+
+	// If an optional field is not set, AWS will provide default settings that will be in actualSDKVRSpec.
+	// We use IgnoreLeftHandUnset when doing the equality check here to allow AWS sever-side to provide default settings.
+	opts := equality.IgnoreLeftHandUnset()
+	if cmp.Equal(desiredSDKVRSpec, actualSDKVRSpec, opts) {
+		return sdkVR, nil
+	}
+	if !m.isSDKVirtualRouterControlledByCRDVirtualRouter(ctx, sdkVR, vr) {
+		m.log.V(2).Info("skip virtualRouter update since it's not controlled",
+			"virtualRouter", k8s.NamespacedName(vr),
+			"virtualRouterARN", aws.StringValue(sdkVR.Metadata.Arn),
+		)
+		return sdkVR, nil
+	}
+
+	diff := cmp.Diff(desiredSDKVRSpec, actualSDKVRSpec, opts)
+	m.log.V(2).Info("virtualRouterSpec changed",
+		"virtualRouter", k8s.NamespacedName(vr),
+		"actualSDKVRSpec", actualSDKVRSpec,
+		"desiredSDKVRSpec", desiredSDKVRSpec,
+		"diff", diff,
+	)
+	resp, err := m.appMeshSDK.UpdateVirtualRouterWithContext(ctx, &appmeshsdk.UpdateVirtualRouterInput{
+		MeshName:          sdkVR.MeshName,
+		MeshOwner:         sdkVR.Metadata.MeshOwner,
+		VirtualRouterName: sdkVR.VirtualRouterName,
+		Spec:              desiredSDKVRSpec,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.VirtualRouter, nil
+}
+
+func (m *defaultResourceManager) deleteSDKVirtualRouter(ctx context.Context, sdkVR *appmeshsdk.VirtualRouterData, vr *appmesh.VirtualRouter) error {
+	if !m.isSDKVirtualRouterOwnedByCRDVirtualRouter(ctx, sdkVR, vr) {
+		m.log.V(2).Info("skip virtualRouter deletion since its not owned",
+			"virtualRouter", k8s.NamespacedName(vr),
+			"virtualRouterARN", aws.StringValue(sdkVR.Metadata.Arn),
+		)
+		return nil
+	}
+	_, err := m.appMeshSDK.DeleteVirtualRouterWithContext(ctx, &appmeshsdk.DeleteVirtualRouterInput{
+		MeshName:          sdkVR.MeshName,
+		MeshOwner:         sdkVR.Metadata.MeshOwner,
+		VirtualRouterName: sdkVR.VirtualRouterName,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *defaultResourceManager) updateCRDVirtualRouter(ctx context.Context, vr *appmesh.VirtualRouter, sdkVR *appmeshsdk.VirtualRouterData, sdkRouteByName map[string]*appmeshsdk.RouteData) error {
+	oldVR := vr.DeepCopy()
+
+	needsUpdate := false
+	if aws.StringValue(vr.Status.VirtualRouterARN) != aws.StringValue(sdkVR.Metadata.Arn) {
+		vr.Status.VirtualRouterARN = sdkVR.Metadata.Arn
+		needsUpdate = true
+	}
+
+	routeARNByName := make(map[string]string)
+	for name, sdkRoute := range sdkRouteByName {
+		routeARNByName[name] = aws.StringValue(sdkRoute.Metadata.Arn)
+	}
+	if !cmp.Equal(vr.Status.RouteARNs, routeARNByName) {
+		vr.Status.RouteARNs = routeARNByName
+		needsUpdate = true
+	}
+
+	vrActiveConditionStatus := corev1.ConditionFalse
+	if sdkVR.Status != nil && aws.StringValue(sdkVR.Status.Status) == appmeshsdk.VirtualRouterStatusCodeActive {
+		vrActiveConditionStatus = corev1.ConditionTrue
+	}
+	if updateCondition(vr, appmesh.VirtualRouterActive, vrActiveConditionStatus, nil, nil) {
+		needsUpdate = true
+	}
+
+	if !needsUpdate {
+		return nil
+	}
+	return m.k8sClient.Patch(ctx, vr, client.MergeFrom(oldVR))
+}
+
+// isSDKVirtualRouterControlledByCRDVirtualRouter checks whether an AppMesh virtualRouter is controlled by CRD VirtualRouter.
+// if it's controlled, CRD VirtualRouter update is responsible for update AppMesh virtualRouter.
+func (m *defaultResourceManager) isSDKVirtualRouterControlledByCRDVirtualRouter(ctx context.Context, sdkVR *appmeshsdk.VirtualRouterData, vr *appmesh.VirtualRouter) bool {
+	if aws.StringValue(sdkVR.Metadata.ResourceOwner) != m.accountID {
+		return false
+	}
+	return true
+}
+
+// isSDKVirtualRouterOwnedByCRDVirtualRouter checks whether an AppMesh virtualRouter is owned by CRD VirtualRouter.
+// if it's owned, CRD VirtualRouter deletion is responsible for delete AppMesh virtualRouter.
+func (m *defaultResourceManager) isSDKVirtualRouterOwnedByCRDVirtualRouter(ctx context.Context, sdkVR *appmeshsdk.VirtualRouterData, vr *appmesh.VirtualRouter) bool {
+	if !m.isSDKVirtualRouterControlledByCRDVirtualRouter(ctx, sdkVR, vr) {
+		return false
+	}
+
+	// TODO: Adding tagging support, so a existing virtualRouter in owner account but not ownership can be support.
+	// currently, virtualRouter controllership == ownership, but it don't have to be so once we add tagging support.
+	return true
+}
+
+func buildSDKVirtualRouterSpec(vr *appmesh.VirtualRouter) (*appmeshsdk.VirtualRouterSpec, error) {
+	converter := conversion.NewConverter(conversion.DefaultNameFunc)
+	converter.RegisterUntypedConversionFunc((*appmesh.VirtualRouterSpec)(nil), (*appmeshsdk.VirtualRouterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return conversions.Convert_CRD_VirtualRouterSpec_To_SDK__VirtualRouterSpec(a.(*appmesh.VirtualRouterSpec), b.(*appmeshsdk.VirtualRouterSpec), scope)
+	})
+	sdkVRSpec := &appmeshsdk.VirtualRouterSpec{}
+	if err := converter.Convert(&vr.Spec, sdkVRSpec, conversion.DestFromSource, nil); err != nil {
+		return nil, err
+	}
+	return sdkVRSpec, nil
+}

--- a/pkg/virtualrouter/resource_manager.go
+++ b/pkg/virtualrouter/resource_manager.go
@@ -292,16 +292,13 @@ func (m *defaultResourceManager) updateCRDVirtualRouter(ctx context.Context, vr 
 }
 
 // isSDKVirtualRouterControlledByCRDVirtualRouter checks whether an AppMesh virtualRouter is controlled by CRD VirtualRouter.
-// if it's controlled, CRD VirtualRouter update is responsible for update AppMesh virtualRouter.
+// if it's controlled, CRD VirtualRouter update is responsible for updating the AppMesh virtualRouter.
 func (m *defaultResourceManager) isSDKVirtualRouterControlledByCRDVirtualRouter(ctx context.Context, sdkVR *appmeshsdk.VirtualRouterData, vr *appmesh.VirtualRouter) bool {
-	if aws.StringValue(sdkVR.Metadata.ResourceOwner) != m.accountID {
-		return false
-	}
-	return true
+	return aws.StringValue(sdkVR.Metadata.ResourceOwner) == m.accountID
 }
 
 // isSDKVirtualRouterOwnedByCRDVirtualRouter checks whether an AppMesh virtualRouter is owned by CRD VirtualRouter.
-// if it's owned, CRD VirtualRouter deletion is responsible for delete AppMesh virtualRouter.
+// if it's owned, CRD VirtualRouter deletion is responsible for deleting the AppMesh virtualRouter.
 func (m *defaultResourceManager) isSDKVirtualRouterOwnedByCRDVirtualRouter(ctx context.Context, sdkVR *appmeshsdk.VirtualRouterData, vr *appmesh.VirtualRouter) bool {
 	if !m.isSDKVirtualRouterControlledByCRDVirtualRouter(ctx, sdkVR, vr) {
 		return false

--- a/pkg/virtualrouter/resource_manager_test.go
+++ b/pkg/virtualrouter/resource_manager_test.go
@@ -1,0 +1,393 @@
+package virtualrouter
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-sdk-go/aws"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_defaultResourceManager_updateCRDVirtualRouter(t *testing.T) {
+	type args struct {
+		vr             *appmesh.VirtualRouter
+		sdkVR          *appmeshsdk.VirtualRouterData
+		sdkRouteByName map[string]*appmeshsdk.RouteData
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantVR  *appmesh.VirtualRouter
+		wantErr error
+	}{
+		{
+			name: "virtualRouter needs patch arn, routeARNs and condition",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vr-1",
+					},
+					Status: appmesh.VirtualRouterStatus{},
+				},
+				sdkVR: &appmeshsdk.VirtualRouterData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						Arn: aws.String("arn-1"),
+					},
+					Status: &appmeshsdk.VirtualRouterStatus{
+						Status: aws.String(appmeshsdk.VirtualRouterStatusCodeActive),
+					},
+				},
+				sdkRouteByName: map[string]*appmeshsdk.RouteData{
+					"route-1": {
+						Metadata: &appmeshsdk.ResourceMetadata{
+							Arn: aws.String("route-arn-1"),
+						},
+					},
+					"route-2": {
+						Metadata: &appmeshsdk.ResourceMetadata{
+							Arn: aws.String("route-arn-2"),
+						},
+					},
+				},
+			},
+			wantVR: &appmesh.VirtualRouter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vr-1",
+				},
+				Status: appmesh.VirtualRouterStatus{
+					VirtualRouterARN: aws.String("arn-1"),
+					RouteARNs: map[string]string{
+						"route-1": "route-arn-1",
+						"route-2": "route-arn-2",
+					},
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:   appmesh.VirtualRouterActive,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "virtualRouter needs patch condition only",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vr-1",
+					},
+					Status: appmesh.VirtualRouterStatus{
+						VirtualRouterARN: aws.String("arn-1"),
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				sdkVR: &appmeshsdk.VirtualRouterData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						Arn: aws.String("arn-1"),
+					},
+					Status: &appmeshsdk.VirtualRouterStatus{
+						Status: aws.String(appmeshsdk.VirtualRouterStatusCodeInactive),
+					},
+				},
+			},
+			wantVR: &appmesh.VirtualRouter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vr-1",
+				},
+				Status: appmesh.VirtualRouterStatus{
+					VirtualRouterARN: aws.String("arn-1"),
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:   appmesh.VirtualRouterActive,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "virtualRouter needs patch routeARNs only",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vr-1",
+					},
+					Status: appmesh.VirtualRouterStatus{
+						VirtualRouterARN: aws.String("arn-1"),
+						RouteARNs: map[string]string{
+							"route-1": "route-arn-1",
+							"route-2": "route-arn-2",
+						},
+						Conditions: []appmesh.VirtualRouterCondition{
+							{
+								Type:   appmesh.VirtualRouterActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				sdkVR: &appmeshsdk.VirtualRouterData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						Arn: aws.String("arn-1"),
+					},
+					Status: &appmeshsdk.VirtualRouterStatus{
+						Status: aws.String(appmeshsdk.VirtualRouterStatusCodeActive),
+					},
+				},
+				sdkRouteByName: map[string]*appmeshsdk.RouteData{
+					"route-1": {
+						Metadata: &appmeshsdk.ResourceMetadata{
+							Arn: aws.String("route-arn-1"),
+						},
+					},
+					"route-2": {
+						Metadata: &appmeshsdk.ResourceMetadata{
+							Arn: aws.String("route-arn-2"),
+						},
+					},
+					"route-3": {
+						Metadata: &appmeshsdk.ResourceMetadata{
+							Arn: aws.String("route-arn-3"),
+						},
+					},
+				},
+			},
+			wantVR: &appmesh.VirtualRouter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vr-1",
+				},
+				Status: appmesh.VirtualRouterStatus{
+					VirtualRouterARN: aws.String("arn-1"),
+					RouteARNs: map[string]string{
+						"route-1": "route-arn-1",
+						"route-2": "route-arn-2",
+						"route-3": "route-arn-3",
+					},
+					Conditions: []appmesh.VirtualRouterCondition{
+						{
+							Type:   appmesh.VirtualRouterActive,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			m := &defaultResourceManager{
+				k8sClient: k8sClient,
+				log:       log.NullLogger{},
+			}
+
+			err := k8sClient.Create(ctx, tt.args.vr.DeepCopy())
+			assert.NoError(t, err)
+			err = m.updateCRDVirtualRouter(ctx, tt.args.vr, tt.args.sdkVR, tt.args.sdkRouteByName)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				gotVR := &appmesh.VirtualRouter{}
+				err = k8sClient.Get(ctx, k8s.NamespacedName(tt.args.vr), gotVR)
+				assert.NoError(t, err)
+				opts := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+					cmpopts.IgnoreTypes((*metav1.Time)(nil)),
+				}
+				assert.True(t, cmp.Equal(tt.wantVR, gotVR, opts), "diff", cmp.Diff(tt.wantVR, gotVR, opts))
+			}
+		})
+	}
+}
+
+func Test_defaultResourceManager_isSDKVirtualRouterControlledByCRDVirtualRouter(t *testing.T) {
+	type fields struct {
+		accountID string
+	}
+	type args struct {
+		sdkVR *appmeshsdk.VirtualRouterData
+		vr    *appmesh.VirtualRouter
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "sdkVR is controlled by vr",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVR: &appmeshsdk.VirtualRouterData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("222222222"),
+					},
+				},
+				vr: &appmesh.VirtualRouter{},
+			},
+			want: true,
+		},
+		{
+			name:   "sdkVR isn't controlled by vr",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVR: &appmeshsdk.VirtualRouterData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("33333333"),
+					},
+				},
+				vr: &appmesh.VirtualRouter{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := &defaultResourceManager{
+				accountID: tt.fields.accountID,
+				log:       &log.NullLogger{},
+			}
+			got := m.isSDKVirtualRouterControlledByCRDVirtualRouter(ctx, tt.args.sdkVR, tt.args.vr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_defaultResourceManager_isSDKVirtualRouterOwnedByCRDVirtualRouter(t *testing.T) {
+	type fields struct {
+		accountID string
+	}
+	type args struct {
+		sdkVR *appmeshsdk.VirtualRouterData
+		vr    *appmesh.VirtualRouter
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "sdkVR is owned by vr",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVR: &appmeshsdk.VirtualRouterData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("222222222"),
+					},
+				},
+				vr: &appmesh.VirtualRouter{},
+			},
+			want: true,
+		},
+		{
+			name:   "sdkVR isn't owned by vr",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVR: &appmeshsdk.VirtualRouterData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("33333333"),
+					},
+				},
+				vr: &appmesh.VirtualRouter{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := &defaultResourceManager{
+				accountID: tt.fields.accountID,
+				log:       &log.NullLogger{},
+			}
+			got := m.isSDKVirtualRouterOwnedByCRDVirtualRouter(ctx, tt.args.sdkVR, tt.args.vr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_buildSDKVirtualRouterSpec(t *testing.T) {
+	type args struct {
+		vr *appmesh.VirtualRouter
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *appmeshsdk.VirtualRouterSpec
+		wantErr error
+	}{
+		{
+			name: "normal case",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					Spec: appmesh.VirtualRouterSpec{
+						Listeners: []appmesh.VirtualRouterListener{
+							{
+								PortMapping: appmesh.PortMapping{
+									Port:     80,
+									Protocol: "http",
+								},
+							},
+							{
+								PortMapping: appmesh.PortMapping{
+									Port:     443,
+									Protocol: "http",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.VirtualRouterSpec{
+				Listeners: []*appmeshsdk.VirtualRouterListener{
+					{
+						PortMapping: &appmeshsdk.PortMapping{
+							Port:     aws.Int64(80),
+							Protocol: aws.String("http"),
+						},
+					},
+					{
+						PortMapping: &appmeshsdk.PortMapping{
+							Port:     aws.Int64(443),
+							Protocol: aws.String("http"),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildSDKVirtualRouterSpec(tt.args.vr)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/virtualrouter/routes_manager.go
+++ b/pkg/virtualrouter/routes_manager.go
@@ -1,0 +1,268 @@
+package virtualrouter
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/services"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/conversions"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// routesManager is responsible for manage routes for virtualRouter.
+type routesManager interface {
+	// create will create routes on AppMesh virtualRouter to match k8s virtualRouter spec.
+	create(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter, vnByRefHash map[types.NamespacedName]*appmesh.VirtualNode) (map[string]*appmeshsdk.RouteData, error)
+	// update will update routes on AppMesh virtualRouter to match k8s virtualRouter spec.
+	update(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter, vnByRefHash map[types.NamespacedName]*appmesh.VirtualNode) (map[string]*appmeshsdk.RouteData, error)
+	// cleanup will cleanup routes on AppMesh virtualRouter
+	cleanup(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter) error
+}
+
+// newDefaultRoutesManager constructs new routesManager
+func newDefaultRoutesManager(appMeshSDK services.AppMesh, log logr.Logger) routesManager {
+	return &defaultRoutesManager{
+		appMeshSDK: appMeshSDK,
+		log:        log,
+	}
+}
+
+type defaultRoutesManager struct {
+	appMeshSDK services.AppMesh
+	log        logr.Logger
+}
+
+func (m *defaultRoutesManager) create(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter, vnByKey map[types.NamespacedName]*appmesh.VirtualNode) (map[string]*appmeshsdk.RouteData, error) {
+	return m.reconcile(ctx, ms, vr, vnByKey, vr.Spec.Routes, nil)
+}
+
+func (m *defaultRoutesManager) update(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter, vnByKey map[types.NamespacedName]*appmesh.VirtualNode) (map[string]*appmeshsdk.RouteData, error) {
+	sdkRouteRefs, err := m.listSDKRouteRefs(ctx, ms, vr)
+	if err != nil {
+		return nil, err
+	}
+	return m.reconcile(ctx, ms, vr, vnByKey, vr.Spec.Routes, sdkRouteRefs)
+}
+
+func (m *defaultRoutesManager) cleanup(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter) error {
+	sdkRouteRefs, err := m.listSDKRouteRefs(ctx, ms, vr)
+	if err != nil {
+		return err
+	}
+	_, err = m.reconcile(ctx, ms, vr, nil, nil, sdkRouteRefs)
+	return err
+}
+
+// reconcile will make AppMesh routes(sdkRouteRefs) matches routes.
+func (m *defaultRoutesManager) reconcile(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter, vnByKey map[types.NamespacedName]*appmesh.VirtualNode,
+	routes []appmesh.Route, sdkRouteRefs []*appmeshsdk.RouteRef) (map[string]*appmeshsdk.RouteData, error) {
+
+	matchedRouteAndSDKRouteRefs, unmatchedRoutes, unmatchedSDKRouteRefs := matchRoutesAgainstSDKRouteRefs(routes, sdkRouteRefs)
+	sdkRouteByName := make(map[string]*appmeshsdk.RouteData, len(matchedRouteAndSDKRouteRefs)+len(unmatchedRoutes))
+
+	for _, route := range unmatchedRoutes {
+		sdkRoute, err := m.createSDKRoute(ctx, ms, vr, route, vnByKey)
+		if err != nil {
+			return nil, err
+		}
+		sdkRouteByName[route.Name] = sdkRoute
+	}
+
+	for _, routeAndSDKRouteRef := range matchedRouteAndSDKRouteRefs {
+		route := routeAndSDKRouteRef.route
+		sdkRouteRef := routeAndSDKRouteRef.sdkRouteRef
+		sdkRoute, err := m.findSDKRoute(ctx, sdkRouteRef)
+		if err != nil {
+			return nil, err
+		}
+		if sdkRoute == nil {
+			return nil, errors.Errorf("route not found: %v", aws.StringValue(sdkRouteRef.RouteName))
+		}
+		sdkRoute, err = m.updateSDKRoute(ctx, sdkRoute, vr, route, vnByKey)
+		if err != nil {
+			return nil, err
+		}
+		sdkRouteByName[route.Name] = sdkRoute
+	}
+
+	for _, sdkRouteRef := range unmatchedSDKRouteRefs {
+		sdkRoute, err := m.findSDKRoute(ctx, sdkRouteRef)
+		if err != nil {
+			return nil, err
+		}
+		if sdkRoute == nil {
+			return nil, errors.Errorf("route not found: %v", aws.StringValue(sdkRouteRef.RouteName))
+		}
+		if err = m.deleteSDKRoute(ctx, sdkRoute); err != nil {
+			return nil, err
+		}
+	}
+	return sdkRouteByName, nil
+}
+
+func (m *defaultRoutesManager) listSDKRouteRefs(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter) ([]*appmeshsdk.RouteRef, error) {
+	var sdkRouteRefs []*appmeshsdk.RouteRef
+	if err := m.appMeshSDK.ListRoutesPagesWithContext(ctx, &appmeshsdk.ListRoutesInput{
+		MeshName:          ms.Spec.AWSName,
+		MeshOwner:         ms.Spec.MeshOwner,
+		VirtualRouterName: vr.Spec.AWSName,
+	}, func(output *appmeshsdk.ListRoutesOutput, b bool) bool {
+		sdkRouteRefs = append(sdkRouteRefs, output.Routes...)
+		return true
+	}); err != nil {
+		return nil, err
+	}
+	return sdkRouteRefs, nil
+}
+
+func (m *defaultRoutesManager) findSDKRoute(ctx context.Context, sdkRouteRef *appmeshsdk.RouteRef) (*appmeshsdk.RouteData, error) {
+	resp, err := m.appMeshSDK.DescribeRouteWithContext(ctx, &appmeshsdk.DescribeRouteInput{
+		MeshName:          sdkRouteRef.MeshName,
+		MeshOwner:         sdkRouteRef.MeshOwner,
+		VirtualRouterName: sdkRouteRef.VirtualRouterName,
+		RouteName:         sdkRouteRef.RouteName,
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return resp.Route, nil
+}
+
+func (m *defaultRoutesManager) createSDKRoute(ctx context.Context, ms *appmesh.Mesh, vr *appmesh.VirtualRouter, route appmesh.Route, vnByKey map[types.NamespacedName]*appmesh.VirtualNode) (*appmeshsdk.RouteData, error) {
+	sdkRouteSpec, err := buildSDKRouteSpec(vr, route, vnByKey)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := m.appMeshSDK.CreateRouteWithContext(ctx, &appmeshsdk.CreateRouteInput{
+		MeshName:          ms.Spec.AWSName,
+		MeshOwner:         ms.Spec.MeshOwner,
+		VirtualRouterName: vr.Spec.AWSName,
+		RouteName:         aws.String(route.Name),
+		Spec:              sdkRouteSpec,
+		Tags:              nil,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Route, nil
+}
+
+func (m *defaultRoutesManager) updateSDKRoute(ctx context.Context, sdkRoute *appmeshsdk.RouteData, vr *appmesh.VirtualRouter, route appmesh.Route, vnByKey map[types.NamespacedName]*appmesh.VirtualNode) (*appmeshsdk.RouteData, error) {
+	actualSDKRouteSpec := sdkRoute.Spec
+	desiredSDKRouteSpec, err := buildSDKRouteSpec(vr, route, vnByKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// If an optional field is not set, AWS will provide default settings that will be in actualSDKRouteSpec.
+	// We use IgnoreLeftHandUnset when doing the equality check here to allow AWS sever-side to provide default settings.
+	opts := equality.IgnoreLeftHandUnset()
+	if cmp.Equal(desiredSDKRouteSpec, actualSDKRouteSpec, opts) {
+		return sdkRoute, nil
+	}
+	diff := cmp.Diff(desiredSDKRouteSpec, actualSDKRouteSpec, opts)
+	m.log.V(2).Info("routeSpec changed",
+		"virtualRouter", k8s.NamespacedName(vr),
+		"route", route.Name,
+		"actualSDKRouteSpec", actualSDKRouteSpec,
+		"desiredSDKRouteSpec", desiredSDKRouteSpec,
+		"diff", diff,
+	)
+	resp, err := m.appMeshSDK.UpdateRouteWithContext(ctx, &appmeshsdk.UpdateRouteInput{
+		MeshName:          sdkRoute.MeshName,
+		MeshOwner:         sdkRoute.Metadata.MeshOwner,
+		VirtualRouterName: sdkRoute.VirtualRouterName,
+		RouteName:         sdkRoute.RouteName,
+		Spec:              desiredSDKRouteSpec,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Route, nil
+}
+
+func (m *defaultRoutesManager) deleteSDKRoute(ctx context.Context, sdkRoute *appmeshsdk.RouteData) error {
+	_, err := m.appMeshSDK.DeleteRouteWithContext(ctx, &appmeshsdk.DeleteRouteInput{
+		MeshName:          sdkRoute.MeshName,
+		MeshOwner:         sdkRoute.Metadata.MeshOwner,
+		VirtualRouterName: sdkRoute.VirtualRouterName,
+		RouteName:         sdkRoute.RouteName,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type routeAndSDKRouteRef struct {
+	route       appmesh.Route
+	sdkRouteRef *appmeshsdk.RouteRef
+}
+
+// matchRoutesAgainstSDKRouteRefs will match routes against sdkRouteRefs.
+// return matched routeAndSDKRouteRef, not matched routes and not matched sdkRouteRefs
+func matchRoutesAgainstSDKRouteRefs(routes []appmesh.Route, sdkRouteRefs []*appmeshsdk.RouteRef) ([]routeAndSDKRouteRef, []appmesh.Route, []*appmeshsdk.RouteRef) {
+	routeByName := make(map[string]appmesh.Route, len(routes))
+	sdkRouteRefByName := make(map[string]*appmeshsdk.RouteRef, len(sdkRouteRefs))
+	for _, route := range routes {
+		routeByName[route.Name] = route
+	}
+	for _, sdkRouteRef := range sdkRouteRefs {
+		sdkRouteRefByName[aws.StringValue(sdkRouteRef.RouteName)] = sdkRouteRef
+	}
+	routeNameSet := sets.StringKeySet(routeByName)
+	sdkRouteRefNameSet := sets.StringKeySet(sdkRouteRefByName)
+	matchedNameSet := routeNameSet.Intersection(sdkRouteRefNameSet)
+	unmatchedRouteNameSet := routeNameSet.Difference(sdkRouteRefNameSet)
+	unmatchedSDKRouteRefNameSet := sdkRouteRefNameSet.Difference(routeNameSet)
+
+	matchedRouteAndSDKRouteRef := make([]routeAndSDKRouteRef, 0, len(matchedNameSet))
+	for _, name := range matchedNameSet.List() {
+		matchedRouteAndSDKRouteRef = append(matchedRouteAndSDKRouteRef, routeAndSDKRouteRef{
+			route:       routeByName[name],
+			sdkRouteRef: sdkRouteRefByName[name],
+		})
+	}
+
+	unmatchedRoutes := make([]appmesh.Route, 0, len(unmatchedRouteNameSet))
+	for _, name := range unmatchedRouteNameSet.List() {
+		unmatchedRoutes = append(unmatchedRoutes, routeByName[name])
+	}
+
+	unmatchedSDKRouteRefs := make([]*appmeshsdk.RouteRef, 0, len(unmatchedSDKRouteRefNameSet))
+	for _, name := range unmatchedSDKRouteRefNameSet.List() {
+		unmatchedSDKRouteRefs = append(unmatchedSDKRouteRefs, sdkRouteRefByName[name])
+	}
+
+	return matchedRouteAndSDKRouteRef, unmatchedRoutes, unmatchedSDKRouteRefs
+}
+
+func buildSDKRouteSpec(vr *appmesh.VirtualRouter, route appmesh.Route, vnByKey map[types.NamespacedName]*appmesh.VirtualNode) (*appmeshsdk.RouteSpec, error) {
+	sdkVNRefConvertFunc := references.BuildSDKVirtualNodeReferenceConvertFunc(vr, vnByKey)
+	converter := conversion.NewConverter(conversion.DefaultNameFunc)
+	converter.RegisterUntypedConversionFunc((*appmesh.Route)(nil), (*appmeshsdk.RouteSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return conversions.Convert_CRD_Route_To_SDK_RouteSpec(a.(*appmesh.Route), b.(*appmeshsdk.RouteSpec), scope)
+	})
+	converter.RegisterUntypedConversionFunc((*appmesh.VirtualNodeReference)(nil), (*string)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return sdkVNRefConvertFunc(a.(*appmesh.VirtualNodeReference), b.(*string), scope)
+	})
+	sdkRouteSpec := &appmeshsdk.RouteSpec{}
+	if err := converter.Convert(&route, sdkRouteSpec, conversion.DestFromSource, nil); err != nil {
+		return nil, err
+	}
+	return sdkRouteSpec, nil
+}

--- a/pkg/virtualrouter/routes_manager_test.go
+++ b/pkg/virtualrouter/routes_manager_test.go
@@ -1,0 +1,708 @@
+package virtualrouter
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+func Test_matchRoutesAgainstSDKRouteRefs(t *testing.T) {
+	type args struct {
+		routes       []appmesh.Route
+		sdkRouteRefs []*appmeshsdk.RouteRef
+	}
+	tests := []struct {
+		name                           string
+		args                           args
+		wantMatchedRouteAndSDKRouteRef []routeAndSDKRouteRef
+		wantUnmatchedRoutes            []appmesh.Route
+		wantUnmatchedSDKRouteRefs      []*appmeshsdk.RouteRef
+	}{
+		{
+			name: "all route matches",
+			args: args{
+				routes: []appmesh.Route{
+					{
+						Name: "route-1",
+					},
+					{
+						Name: "route-2",
+					},
+				},
+				sdkRouteRefs: []*appmeshsdk.RouteRef{
+					{
+						RouteName: aws.String("route-1"),
+					},
+					{
+						RouteName: aws.String("route-2"),
+					},
+				},
+			},
+			wantMatchedRouteAndSDKRouteRef: []routeAndSDKRouteRef{
+				{
+					route: appmesh.Route{
+						Name: "route-1",
+					},
+					sdkRouteRef: &appmeshsdk.RouteRef{
+						RouteName: aws.String("route-1"),
+					},
+				},
+				{
+					route: appmesh.Route{
+						Name: "route-2",
+					},
+					sdkRouteRef: &appmeshsdk.RouteRef{
+						RouteName: aws.String("route-2"),
+					},
+				},
+			},
+			wantUnmatchedRoutes:       []appmesh.Route{},
+			wantUnmatchedSDKRouteRefs: []*appmeshsdk.RouteRef{},
+		},
+		{
+			name: "all route un-matches",
+			args: args{
+				routes: []appmesh.Route{
+					{
+						Name: "route-1",
+					},
+					{
+						Name: "route-2",
+					},
+				},
+				sdkRouteRefs: []*appmeshsdk.RouteRef{},
+			},
+			wantMatchedRouteAndSDKRouteRef: []routeAndSDKRouteRef{},
+			wantUnmatchedRoutes: []appmesh.Route{
+				{
+					Name: "route-1",
+				},
+				{
+					Name: "route-2",
+				},
+			},
+			wantUnmatchedSDKRouteRefs: []*appmeshsdk.RouteRef{},
+		},
+		{
+			name: "all sdkRouteRef un-matches",
+			args: args{
+				routes: []appmesh.Route{},
+				sdkRouteRefs: []*appmeshsdk.RouteRef{
+					{
+						RouteName: aws.String("route-1"),
+					},
+					{
+						RouteName: aws.String("route-2"),
+					},
+				},
+			},
+			wantMatchedRouteAndSDKRouteRef: []routeAndSDKRouteRef{},
+			wantUnmatchedRoutes:            []appmesh.Route{},
+			wantUnmatchedSDKRouteRefs: []*appmeshsdk.RouteRef{
+				{
+					RouteName: aws.String("route-1"),
+				},
+				{
+					RouteName: aws.String("route-2"),
+				},
+			},
+		},
+		{
+			name: "some route un-match and some sdkRouteRef un-match",
+			args: args{
+				routes: []appmesh.Route{
+					{
+						Name: "route-1",
+					},
+					{
+						Name: "route-2",
+					},
+					{
+						Name: "route-3",
+					},
+				},
+				sdkRouteRefs: []*appmeshsdk.RouteRef{
+					{
+						RouteName: aws.String("route-2"),
+					},
+					{
+						RouteName: aws.String("route-3"),
+					},
+					{
+						RouteName: aws.String("route-4"),
+					},
+				},
+			},
+			wantMatchedRouteAndSDKRouteRef: []routeAndSDKRouteRef{
+				{
+					route: appmesh.Route{
+						Name: "route-2",
+					},
+					sdkRouteRef: &appmeshsdk.RouteRef{
+						RouteName: aws.String("route-2"),
+					},
+				},
+				{
+					route: appmesh.Route{
+						Name: "route-3",
+					},
+					sdkRouteRef: &appmeshsdk.RouteRef{
+						RouteName: aws.String("route-3"),
+					},
+				},
+			},
+			wantUnmatchedRoutes: []appmesh.Route{
+				{
+					Name: "route-1",
+				},
+			},
+			wantUnmatchedSDKRouteRefs: []*appmeshsdk.RouteRef{
+				{
+					RouteName: aws.String("route-4"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMatchedRouteAndSDKRouteRef, gotUnmatchedRoutes, gotUnmatchedSDKRouteRefs := matchRoutesAgainstSDKRouteRefs(tt.args.routes, tt.args.sdkRouteRefs)
+			assert.Equal(t, tt.wantMatchedRouteAndSDKRouteRef, gotMatchedRouteAndSDKRouteRef)
+			assert.Equal(t, tt.wantUnmatchedRoutes, gotUnmatchedRoutes)
+			assert.Equal(t, tt.wantUnmatchedSDKRouteRefs, gotUnmatchedSDKRouteRefs)
+		})
+	}
+}
+
+func Test_buildSDKRouteSpec(t *testing.T) {
+	type args struct {
+		vr      *appmesh.VirtualRouter
+		route   appmesh.Route
+		vnByKey map[types.NamespacedName]*appmesh.VirtualNode
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *appmeshsdk.RouteSpec
+		wantErr error
+	}{
+		{
+			name: "GRPC route",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+				},
+				route: appmesh.Route{
+					GRPCRoute: &appmesh.GRPCRoute{
+						Match: appmesh.GRPCRouteMatch{
+							Metadata: []appmesh.GRPCRouteMetadata{
+								{
+									Name: "User-Agent: X",
+									Match: &appmesh.GRPCRouteMetadataMatchMethod{
+										Exact: aws.String("User-Agent: X"),
+										Range: &appmesh.MatchRange{
+											Start: int64(20),
+											End:   int64(80),
+										},
+										Prefix: aws.String("prefix-1"),
+										Regex:  aws.String("am*zon"),
+										Suffix: aws.String("suffix-1"),
+									},
+									Invert: aws.Bool(false),
+								},
+								{
+									Name: "User-Agent: Y",
+									Match: &appmesh.GRPCRouteMetadataMatchMethod{
+										Exact: aws.String("User-Agent: Y"),
+										Range: &appmesh.MatchRange{
+											Start: int64(20),
+											End:   int64(80),
+										},
+										Prefix: aws.String("prefix-2"),
+										Regex:  aws.String("am*zon"),
+										Suffix: aws.String("suffix-2"),
+									},
+									Invert: aws.Bool(true),
+								},
+							},
+							MethodName:  aws.String("stream"),
+							ServiceName: aws.String("foo.foodomain.local"),
+						},
+						Action: appmesh.GRPCRouteAction{
+							WeightedTargets: []appmesh.WeightedTarget{
+								{
+									VirtualNodeRef: appmesh.VirtualNodeReference{
+										Namespace: aws.String("ns-1"),
+										Name:      "vn-1",
+									},
+									Weight: int64(100),
+								},
+								{
+									VirtualNodeRef: appmesh.VirtualNodeReference{
+										Namespace: aws.String("ns-2"),
+										Name:      "vn-2",
+									},
+									Weight: int64(90),
+								},
+							},
+						},
+						RetryPolicy: &appmesh.GRPCRetryPolicy{
+							GRPCRetryEvents: []appmesh.GRPCRetryPolicyEvent{"cancelled", "deadline-exceeded"},
+							HTTPRetryEvents: []appmesh.HTTPRetryPolicyEvent{"server-error", "client-error"},
+							TCPRetryEvents:  []appmesh.TCPRetryPolicyEvent{"connection-error"},
+							MaxRetries:      int64(5),
+							PerRetryTimeout: appmesh.Duration{
+								Unit:  "ms",
+								Value: int64(200),
+							},
+						},
+					},
+				},
+				vnByKey: map[types.NamespacedName]*appmesh.VirtualNode{
+					types.NamespacedName{Namespace: "ns-1", Name: "vn-1"}: {
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-1_ns-1"),
+						},
+					},
+					types.NamespacedName{Namespace: "ns-2", Name: "vn-2"}: {
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-2_ns-2"),
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.RouteSpec{
+				GrpcRoute: &appmeshsdk.GrpcRoute{
+					Match: &appmeshsdk.GrpcRouteMatch{
+						Metadata: []*appmeshsdk.GrpcRouteMetadata{
+							{
+								Name: aws.String("User-Agent: X"),
+								Match: &appmeshsdk.GrpcRouteMetadataMatchMethod{
+									Exact: aws.String("User-Agent: X"),
+									Range: &appmeshsdk.MatchRange{
+										Start: aws.Int64(20),
+										End:   aws.Int64(80),
+									},
+									Prefix: aws.String("prefix-1"),
+									Regex:  aws.String("am*zon"),
+									Suffix: aws.String("suffix-1"),
+								},
+								Invert: aws.Bool(false),
+							},
+							{
+								Name: aws.String("User-Agent: Y"),
+								Match: &appmeshsdk.GrpcRouteMetadataMatchMethod{
+									Exact: aws.String("User-Agent: Y"),
+									Range: &appmeshsdk.MatchRange{
+										Start: aws.Int64(20),
+										End:   aws.Int64(80),
+									},
+									Prefix: aws.String("prefix-2"),
+									Regex:  aws.String("am*zon"),
+									Suffix: aws.String("suffix-2"),
+								},
+								Invert: aws.Bool(true),
+							},
+						},
+						MethodName:  aws.String("stream"),
+						ServiceName: aws.String("foo.foodomain.local"),
+					},
+					Action: &appmeshsdk.GrpcRouteAction{
+						WeightedTargets: []*appmeshsdk.WeightedTarget{
+							{
+								VirtualNode: aws.String("vn-1_ns-1"),
+								Weight:      aws.Int64(100),
+							},
+							{
+								VirtualNode: aws.String("vn-2_ns-2"),
+								Weight:      aws.Int64(90),
+							},
+						},
+					},
+					RetryPolicy: &appmeshsdk.GrpcRetryPolicy{
+						GrpcRetryEvents: []*string{aws.String("cancelled"), aws.String("deadline-exceeded")},
+						HttpRetryEvents: []*string{aws.String("server-error"), aws.String("client-error")},
+						TcpRetryEvents:  []*string{aws.String("connection-error")},
+						MaxRetries:      aws.Int64(5),
+						PerRetryTimeout: &appmeshsdk.Duration{
+							Unit:  aws.String("ms"),
+							Value: aws.Int64(200),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "HTTP route",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+				},
+				route: appmesh.Route{
+					HTTPRoute: &appmesh.HTTPRoute{
+						Match: appmesh.HTTPRouteMatch{
+							Headers: []appmesh.HTTPRouteHeader{
+								{
+									Name: "User-Agent: X",
+									Match: &appmesh.HeaderMatchMethod{
+										Exact: aws.String("User-Agent: X"),
+										Range: &appmesh.MatchRange{
+											Start: int64(20),
+											End:   int64(80),
+										},
+										Prefix: aws.String("prefix-1"),
+										Regex:  aws.String("am*zon"),
+										Suffix: aws.String("suffix-1"),
+									},
+									Invert: aws.Bool(false),
+								},
+								{
+									Name: "User-Agent: Y",
+									Match: &appmesh.HeaderMatchMethod{
+										Exact: aws.String("User-Agent: Y"),
+										Range: &appmesh.MatchRange{
+											Start: int64(20),
+											End:   int64(80),
+										},
+										Prefix: aws.String("prefix-2"),
+										Regex:  aws.String("am*zon"),
+										Suffix: aws.String("suffix-2"),
+									},
+									Invert: aws.Bool(true),
+								},
+							},
+							Method: aws.String("GET"),
+							Prefix: "/appmesh",
+							Scheme: aws.String("https"),
+						},
+						Action: appmesh.HTTPRouteAction{
+							WeightedTargets: []appmesh.WeightedTarget{
+								{
+									VirtualNodeRef: appmesh.VirtualNodeReference{
+										Namespace: aws.String("ns-1"),
+										Name:      "vn-1",
+									},
+									Weight: int64(100),
+								},
+								{
+									VirtualNodeRef: appmesh.VirtualNodeReference{
+										Namespace: aws.String("ns-2"),
+										Name:      "vn-2",
+									},
+									Weight: int64(90),
+								},
+							},
+						},
+						RetryPolicy: &appmesh.HTTPRetryPolicy{
+							HTTPRetryEvents: []appmesh.HTTPRetryPolicyEvent{"server-error", "client-error"},
+							TCPRetryEvents:  []appmesh.TCPRetryPolicyEvent{"connection-error"},
+							MaxRetries:      int64(5),
+							PerRetryTimeout: appmesh.Duration{
+								Unit:  "ms",
+								Value: int64(200),
+							},
+						},
+					},
+				},
+				vnByKey: map[types.NamespacedName]*appmesh.VirtualNode{
+					types.NamespacedName{Namespace: "ns-1", Name: "vn-1"}: {
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-1_ns-1"),
+						},
+					},
+					types.NamespacedName{Namespace: "ns-2", Name: "vn-2"}: {
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-2_ns-2"),
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.RouteSpec{
+				HttpRoute: &appmeshsdk.HttpRoute{
+					Match: &appmeshsdk.HttpRouteMatch{
+						Headers: []*appmeshsdk.HttpRouteHeader{
+							{
+								Name: aws.String("User-Agent: X"),
+								Match: &appmeshsdk.HeaderMatchMethod{
+									Exact: aws.String("User-Agent: X"),
+									Range: &appmeshsdk.MatchRange{
+										Start: aws.Int64(20),
+										End:   aws.Int64(80),
+									},
+									Prefix: aws.String("prefix-1"),
+									Regex:  aws.String("am*zon"),
+									Suffix: aws.String("suffix-1"),
+								},
+								Invert: aws.Bool(false),
+							},
+							{
+								Name: aws.String("User-Agent: Y"),
+								Match: &appmeshsdk.HeaderMatchMethod{
+									Exact: aws.String("User-Agent: Y"),
+									Range: &appmeshsdk.MatchRange{
+										Start: aws.Int64(20),
+										End:   aws.Int64(80),
+									},
+									Prefix: aws.String("prefix-2"),
+									Regex:  aws.String("am*zon"),
+									Suffix: aws.String("suffix-2"),
+								},
+								Invert: aws.Bool(true),
+							},
+						},
+						Method: aws.String("GET"),
+						Prefix: aws.String("/appmesh"),
+						Scheme: aws.String("https"),
+					},
+					Action: &appmeshsdk.HttpRouteAction{
+						WeightedTargets: []*appmeshsdk.WeightedTarget{
+							{
+								VirtualNode: aws.String("vn-1_ns-1"),
+								Weight:      aws.Int64(100),
+							},
+							{
+								VirtualNode: aws.String("vn-2_ns-2"),
+								Weight:      aws.Int64(90),
+							},
+						},
+					},
+					RetryPolicy: &appmeshsdk.HttpRetryPolicy{
+						HttpRetryEvents: []*string{aws.String("server-error"), aws.String("client-error")},
+						TcpRetryEvents:  []*string{aws.String("connection-error")},
+						MaxRetries:      aws.Int64(5),
+						PerRetryTimeout: &appmeshsdk.Duration{
+							Unit:  aws.String("ms"),
+							Value: aws.Int64(200),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "HTTP2 route",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+				},
+				route: appmesh.Route{
+					HTTP2Route: &appmesh.HTTPRoute{
+						Match: appmesh.HTTPRouteMatch{
+							Headers: []appmesh.HTTPRouteHeader{
+								{
+									Name: "User-Agent: X",
+									Match: &appmesh.HeaderMatchMethod{
+										Exact: aws.String("User-Agent: X"),
+										Range: &appmesh.MatchRange{
+											Start: int64(20),
+											End:   int64(80),
+										},
+										Prefix: aws.String("prefix-1"),
+										Regex:  aws.String("am*zon"),
+										Suffix: aws.String("suffix-1"),
+									},
+									Invert: aws.Bool(false),
+								},
+								{
+									Name: "User-Agent: Y",
+									Match: &appmesh.HeaderMatchMethod{
+										Exact: aws.String("User-Agent: Y"),
+										Range: &appmesh.MatchRange{
+											Start: int64(20),
+											End:   int64(80),
+										},
+										Prefix: aws.String("prefix-2"),
+										Regex:  aws.String("am*zon"),
+										Suffix: aws.String("suffix-2"),
+									},
+									Invert: aws.Bool(true),
+								},
+							},
+							Method: aws.String("GET"),
+							Prefix: "/appmesh",
+							Scheme: aws.String("https"),
+						},
+						Action: appmesh.HTTPRouteAction{
+							WeightedTargets: []appmesh.WeightedTarget{
+								{
+									VirtualNodeRef: appmesh.VirtualNodeReference{
+										Namespace: aws.String("ns-1"),
+										Name:      "vn-1",
+									},
+									Weight: int64(100),
+								},
+								{
+									VirtualNodeRef: appmesh.VirtualNodeReference{
+										Namespace: aws.String("ns-2"),
+										Name:      "vn-2",
+									},
+									Weight: int64(90),
+								},
+							},
+						},
+						RetryPolicy: &appmesh.HTTPRetryPolicy{
+							HTTPRetryEvents: []appmesh.HTTPRetryPolicyEvent{"server-error", "client-error"},
+							TCPRetryEvents:  []appmesh.TCPRetryPolicyEvent{"connection-error"},
+							MaxRetries:      int64(5),
+							PerRetryTimeout: appmesh.Duration{
+								Unit:  "ms",
+								Value: int64(200),
+							},
+						},
+					},
+				},
+				vnByKey: map[types.NamespacedName]*appmesh.VirtualNode{
+					types.NamespacedName{Namespace: "ns-1", Name: "vn-1"}: {
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-1_ns-1"),
+						},
+					},
+					types.NamespacedName{Namespace: "ns-2", Name: "vn-2"}: {
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-2_ns-2"),
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.RouteSpec{
+				Http2Route: &appmeshsdk.HttpRoute{
+					Match: &appmeshsdk.HttpRouteMatch{
+						Headers: []*appmeshsdk.HttpRouteHeader{
+							{
+								Name: aws.String("User-Agent: X"),
+								Match: &appmeshsdk.HeaderMatchMethod{
+									Exact: aws.String("User-Agent: X"),
+									Range: &appmeshsdk.MatchRange{
+										Start: aws.Int64(20),
+										End:   aws.Int64(80),
+									},
+									Prefix: aws.String("prefix-1"),
+									Regex:  aws.String("am*zon"),
+									Suffix: aws.String("suffix-1"),
+								},
+								Invert: aws.Bool(false),
+							},
+							{
+								Name: aws.String("User-Agent: Y"),
+								Match: &appmeshsdk.HeaderMatchMethod{
+									Exact: aws.String("User-Agent: Y"),
+									Range: &appmeshsdk.MatchRange{
+										Start: aws.Int64(20),
+										End:   aws.Int64(80),
+									},
+									Prefix: aws.String("prefix-2"),
+									Regex:  aws.String("am*zon"),
+									Suffix: aws.String("suffix-2"),
+								},
+								Invert: aws.Bool(true),
+							},
+						},
+						Method: aws.String("GET"),
+						Prefix: aws.String("/appmesh"),
+						Scheme: aws.String("https"),
+					},
+					Action: &appmeshsdk.HttpRouteAction{
+						WeightedTargets: []*appmeshsdk.WeightedTarget{
+							{
+								VirtualNode: aws.String("vn-1_ns-1"),
+								Weight:      aws.Int64(100),
+							},
+							{
+								VirtualNode: aws.String("vn-2_ns-2"),
+								Weight:      aws.Int64(90),
+							},
+						},
+					},
+					RetryPolicy: &appmeshsdk.HttpRetryPolicy{
+						HttpRetryEvents: []*string{aws.String("server-error"), aws.String("client-error")},
+						TcpRetryEvents:  []*string{aws.String("connection-error")},
+						MaxRetries:      aws.Int64(5),
+						PerRetryTimeout: &appmeshsdk.Duration{
+							Unit:  aws.String("ms"),
+							Value: aws.Int64(200),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "TCP route",
+			args: args{
+				vr: &appmesh.VirtualRouter{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+				},
+				route: appmesh.Route{
+					TCPRoute: &appmesh.TCPRoute{
+						Action: appmesh.TCPRouteAction{
+							WeightedTargets: []appmesh.WeightedTarget{
+								{
+									VirtualNodeRef: appmesh.VirtualNodeReference{
+										Namespace: aws.String("ns-1"),
+										Name:      "vn-1",
+									},
+									Weight: int64(100),
+								},
+								{
+									VirtualNodeRef: appmesh.VirtualNodeReference{
+										Namespace: aws.String("ns-2"),
+										Name:      "vn-2",
+									},
+									Weight: int64(90),
+								},
+							},
+						},
+					},
+				},
+				vnByKey: map[types.NamespacedName]*appmesh.VirtualNode{
+					types.NamespacedName{Namespace: "ns-1", Name: "vn-1"}: {
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-1_ns-1"),
+						},
+					},
+					types.NamespacedName{Namespace: "ns-2", Name: "vn-2"}: {
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn-2_ns-2"),
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.RouteSpec{
+				TcpRoute: &appmeshsdk.TcpRoute{
+					Action: &appmeshsdk.TcpRouteAction{
+						WeightedTargets: []*appmeshsdk.WeightedTarget{
+							{
+								VirtualNode: aws.String("vn-1_ns-1"),
+								Weight:      aws.Int64(100),
+							},
+							{
+								VirtualNode: aws.String("vn-2_ns-2"),
+								Weight:      aws.Int64(90),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildSDKRouteSpec(tt.args.vr, tt.args.route, tt.args.vnByKey)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/virtualservice/conditions.go
+++ b/pkg/virtualservice/conditions.go
@@ -1,0 +1,51 @@
+package virtualservice
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// getCondition will get pointer to virtualService's existing condition.
+func getCondition(vs *appmesh.VirtualService, conditionType appmesh.VirtualServiceConditionType) *appmesh.VirtualServiceCondition {
+	for i := range vs.Status.Conditions {
+		if vs.Status.Conditions[i].Type == conditionType {
+			return &vs.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// updateCondition will update virtualService's condition. returns whether it's updated.
+func updateCondition(vs *appmesh.VirtualService, conditionType appmesh.VirtualServiceConditionType, status corev1.ConditionStatus, reason *string, message *string) bool {
+	now := metav1.Now()
+	existingCondition := getCondition(vs, conditionType)
+	if existingCondition == nil {
+		newCondition := appmesh.VirtualServiceCondition{
+			Type:               conditionType,
+			Status:             status,
+			LastTransitionTime: &now,
+			Reason:             reason,
+			Message:            message,
+		}
+		vs.Status.Conditions = append(vs.Status.Conditions, newCondition)
+		return true
+	}
+
+	hasChanged := false
+	if existingCondition.Status != status {
+		existingCondition.Status = status
+		existingCondition.LastTransitionTime = &now
+		hasChanged = true
+	}
+	if aws.StringValue(existingCondition.Reason) != aws.StringValue(reason) {
+		existingCondition.Reason = reason
+		hasChanged = true
+	}
+	if aws.StringValue(existingCondition.Message) != aws.StringValue(message) {
+		existingCondition.Message = message
+		hasChanged = true
+	}
+	return hasChanged
+}

--- a/pkg/virtualservice/conditions_test.go
+++ b/pkg/virtualservice/conditions_test.go
@@ -1,0 +1,269 @@
+package virtualservice
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_getCondition(t *testing.T) {
+	type args struct {
+		vs            *appmesh.VirtualService
+		conditionType appmesh.VirtualServiceConditionType
+	}
+	tests := []struct {
+		name string
+		args args
+		want *appmesh.VirtualServiceCondition
+	}{
+		{
+			name: "condition found",
+			args: args{
+				vs: &appmesh.VirtualService{
+					Status: appmesh.VirtualServiceStatus{
+						Conditions: []appmesh.VirtualServiceCondition{
+							{
+								Type:   appmesh.VirtualServiceActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualServiceActive,
+			},
+			want: &appmesh.VirtualServiceCondition{
+				Type:   appmesh.VirtualServiceActive,
+				Status: corev1.ConditionFalse,
+			},
+		},
+		{
+			name: "condition not found",
+			args: args{
+				vs: &appmesh.VirtualService{
+					Status: appmesh.VirtualServiceStatus{
+						Conditions: []appmesh.VirtualServiceCondition{},
+					},
+				},
+				conditionType: appmesh.VirtualServiceActive,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getCondition(tt.args.vs, tt.args.conditionType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_updateCondition(t *testing.T) {
+	type args struct {
+		vs            *appmesh.VirtualService
+		conditionType appmesh.VirtualServiceConditionType
+		status        corev1.ConditionStatus
+		reason        *string
+		message       *string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantVS      *appmesh.VirtualService
+		wantChanged bool
+	}{
+		{
+			name: "condition updated by modify condition status",
+			args: args{
+				vs: &appmesh.VirtualService{
+					Status: appmesh.VirtualServiceStatus{
+						Conditions: []appmesh.VirtualServiceCondition{
+							{
+								Type:   appmesh.VirtualServiceActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualServiceActive,
+				status:        corev1.ConditionTrue,
+			},
+			wantVS: &appmesh.VirtualService{
+				Status: appmesh.VirtualServiceStatus{
+					Conditions: []appmesh.VirtualServiceCondition{
+						{
+							Type:   appmesh.VirtualServiceActive,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition reason",
+			args: args{
+				vs: &appmesh.VirtualService{
+					Status: appmesh.VirtualServiceStatus{
+						Conditions: []appmesh.VirtualServiceCondition{
+							{
+								Type:   appmesh.VirtualServiceActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualServiceActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+			},
+			wantVS: &appmesh.VirtualService{
+				Status: appmesh.VirtualServiceStatus{
+					Conditions: []appmesh.VirtualServiceCondition{
+						{
+							Type:   appmesh.VirtualServiceActive,
+							Status: corev1.ConditionTrue,
+							Reason: aws.String("reason"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition message",
+			args: args{
+				vs: &appmesh.VirtualService{
+					Status: appmesh.VirtualServiceStatus{
+						Conditions: []appmesh.VirtualServiceCondition{
+							{
+								Type:   appmesh.VirtualServiceActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualServiceActive,
+				status:        corev1.ConditionTrue,
+				message:       aws.String("message"),
+			},
+			wantVS: &appmesh.VirtualService{
+				Status: appmesh.VirtualServiceStatus{
+					Conditions: []appmesh.VirtualServiceCondition{
+						{
+							Type:    appmesh.VirtualServiceActive,
+							Status:  corev1.ConditionTrue,
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by modify condition status/reason/message",
+			args: args{
+				vs: &appmesh.VirtualService{
+					Status: appmesh.VirtualServiceStatus{
+						Conditions: []appmesh.VirtualServiceCondition{
+							{
+								Type:   appmesh.VirtualServiceActive,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualServiceActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantVS: &appmesh.VirtualService{
+				Status: appmesh.VirtualServiceStatus{
+					Conditions: []appmesh.VirtualServiceCondition{
+						{
+							Type:    appmesh.VirtualServiceActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition updated by new condition",
+			args: args{
+				vs: &appmesh.VirtualService{
+					Status: appmesh.VirtualServiceStatus{
+						Conditions: nil,
+					},
+				},
+				conditionType: appmesh.VirtualServiceActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantVS: &appmesh.VirtualService{
+				Status: appmesh.VirtualServiceStatus{
+					Conditions: []appmesh.VirtualServiceCondition{
+						{
+							Type:    appmesh.VirtualServiceActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "condition unmodified",
+			args: args{
+				vs: &appmesh.VirtualService{
+					Status: appmesh.VirtualServiceStatus{
+						Conditions: []appmesh.VirtualServiceCondition{
+							{
+								Type:    appmesh.VirtualServiceActive,
+								Status:  corev1.ConditionTrue,
+								Reason:  aws.String("reason"),
+								Message: aws.String("message"),
+							},
+						},
+					},
+				},
+				conditionType: appmesh.VirtualServiceActive,
+				status:        corev1.ConditionTrue,
+				reason:        aws.String("reason"),
+				message:       aws.String("message"),
+			},
+			wantVS: &appmesh.VirtualService{
+				Status: appmesh.VirtualServiceStatus{
+					Conditions: []appmesh.VirtualServiceCondition{
+						{
+							Type:    appmesh.VirtualServiceActive,
+							Status:  corev1.ConditionTrue,
+							Reason:  aws.String("reason"),
+							Message: aws.String("message"),
+						},
+					},
+				},
+			},
+			wantChanged: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChanged := updateCondition(tt.args.vs, tt.args.conditionType, tt.args.status, tt.args.reason, tt.args.message)
+			opts := cmpopts.IgnoreTypes((*metav1.Time)(nil))
+			assert.True(t, cmp.Equal(tt.wantVS, tt.args.vs, opts), "diff", cmp.Diff(tt.wantVS, tt.args.vs, opts))
+			assert.Equal(t, tt.wantChanged, gotChanged)
+		})
+	}
+}

--- a/pkg/virtualservice/resource_manager.go
+++ b/pkg/virtualservice/resource_manager.go
@@ -1,0 +1,345 @@
+package virtualservice
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/services"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/conversions"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/mesh"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/runtime"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualrouter"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ResourceManager is dedicated to manage AppMesh VirtualService resources for k8s VirtualService CRs.
+type ResourceManager interface {
+	// Reconcile will create/update AppMesh VirtualService to match vs.spec, and update vs.status
+	Reconcile(ctx context.Context, vs *appmesh.VirtualService) error
+
+	// Cleanup will delete AppMesh VirtualService created for vs.
+	Cleanup(ctx context.Context, vs *appmesh.VirtualService) error
+}
+
+func NewDefaultResourceManager(
+	k8sClient client.Client,
+	appMeshSDK services.AppMesh,
+	referencesResolver references.Resolver,
+	accountID string,
+	log logr.Logger) ResourceManager {
+	return &defaultResourceManager{
+		k8sClient:          k8sClient,
+		appMeshSDK:         appMeshSDK,
+		referencesResolver: referencesResolver,
+		accountID:          accountID,
+		log:                log,
+	}
+}
+
+type defaultResourceManager struct {
+	k8sClient          client.Client
+	appMeshSDK         services.AppMesh
+	referencesResolver references.Resolver
+	accountID          string
+	log                logr.Logger
+}
+
+func (m *defaultResourceManager) Reconcile(ctx context.Context, vs *appmesh.VirtualService) error {
+	ms, err := m.findMeshDependency(ctx, vs)
+	if err != nil {
+		return err
+	}
+	if err := m.validateMeshDependencies(ctx, ms); err != nil {
+		return err
+	}
+	vnByKey, err := m.findVirtualNodeDependencies(ctx, vs)
+	if err != nil {
+		return err
+	}
+	if err := m.validateVirtualNodeDependencies(ctx, ms, vnByKey); err != nil {
+		return err
+	}
+	vrByKey, err := m.findVirtualRouterDependencies(ctx, vs)
+	if err != nil {
+		return err
+	}
+	if err := m.validateVirtualRouterDependencies(ctx, ms, vrByKey); err != nil {
+		return err
+	}
+
+	sdkVS, err := m.findSDKVirtualService(ctx, ms, vs)
+	if err != nil {
+		return err
+	}
+	if sdkVS == nil {
+		sdkVS, err = m.createSDKVirtualService(ctx, ms, vs, vnByKey, vrByKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		sdkVS, err = m.updateSDKVirtualService(ctx, sdkVS, vs, vnByKey, vrByKey)
+		if err != nil {
+			return err
+		}
+	}
+	return m.updateCRDVirtualService(ctx, vs, sdkVS)
+}
+
+func (m *defaultResourceManager) Cleanup(ctx context.Context, vs *appmesh.VirtualService) error {
+	ms, err := m.findMeshDependency(ctx, vs)
+	if err != nil {
+		return err
+	}
+	if err := m.validateMeshDependencies(ctx, ms); err != nil {
+		return err
+	}
+	sdkVS, err := m.findSDKVirtualService(ctx, ms, vs)
+	if sdkVS == nil {
+		return nil
+	}
+	return m.deleteSDKVirtualService(ctx, sdkVS, vs)
+}
+
+// findMeshDependency find the Mesh dependency for this VirtualService.
+func (m *defaultResourceManager) findMeshDependency(ctx context.Context, vs *appmesh.VirtualService) (*appmesh.Mesh, error) {
+	if vs.Spec.MeshRef == nil {
+		return nil, errors.Errorf("meshRef shouldn't be nil, please check webhook setup")
+	}
+	ms, err := m.referencesResolver.ResolveMeshReference(ctx, *vs.Spec.MeshRef)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve meshRef")
+	}
+	return ms, nil
+}
+
+// validateMeshDependencies validate the Mesh dependency for this VirtualService.
+func (m *defaultResourceManager) validateMeshDependencies(ctx context.Context, ms *appmesh.Mesh) error {
+	if !mesh.IsMeshActive(ms) {
+		return runtime.NewRequeueError(errors.New("mesh is not active yet"))
+	}
+	return nil
+}
+
+func (m *defaultResourceManager) findVirtualNodeDependencies(ctx context.Context, vs *appmesh.VirtualService) (map[types.NamespacedName]*appmesh.VirtualNode, error) {
+	if vs.Spec.Provider == nil || vs.Spec.Provider.VirtualNode == nil {
+		return nil, nil
+	}
+	vnRef := vs.Spec.Provider.VirtualNode.VirtualNodeRef
+	vnKey := references.ObjectKeyForVirtualNodeReference(vs, vnRef)
+	vn, err := m.referencesResolver.ResolveVirtualNodeReference(ctx, vs, vnRef)
+	if err != nil {
+		return nil, err
+	}
+	return map[types.NamespacedName]*appmesh.VirtualNode{
+		vnKey: vn,
+	}, nil
+}
+
+func (m *defaultResourceManager) validateVirtualNodeDependencies(ctx context.Context, ms *appmesh.Mesh, vnByKey map[types.NamespacedName]*appmesh.VirtualNode) error {
+	for _, vn := range vnByKey {
+		if vn.Spec.MeshRef == nil || !mesh.IsMeshReferenced(ms, *vn.Spec.MeshRef) {
+			return errors.Errorf("virtualNode %v didn't belong to mesh %v", k8s.NamespacedName(vn), k8s.NamespacedName(ms))
+		}
+		if !virtualnode.IsVirtualNodeActive(vn) {
+			return runtime.NewRequeueError(errors.New("virtualNode is not active yet"))
+		}
+	}
+	return nil
+}
+
+func (m *defaultResourceManager) findVirtualRouterDependencies(ctx context.Context, vs *appmesh.VirtualService) (map[types.NamespacedName]*appmesh.VirtualRouter, error) {
+	if vs.Spec.Provider == nil || vs.Spec.Provider.VirtualRouter == nil {
+		return nil, nil
+	}
+	vrRef := vs.Spec.Provider.VirtualRouter.VirtualRouterRef
+	vrKey := references.ObjectKeyForVirtualRouterReference(vs, vrRef)
+	vr, err := m.referencesResolver.ResolveVirtualRouterReference(ctx, vs, vrRef)
+	if err != nil {
+		return nil, err
+	}
+	return map[types.NamespacedName]*appmesh.VirtualRouter{
+		vrKey: vr,
+	}, nil
+}
+
+func (m *defaultResourceManager) validateVirtualRouterDependencies(ctx context.Context, ms *appmesh.Mesh, vrByKey map[types.NamespacedName]*appmesh.VirtualRouter) error {
+	for _, vr := range vrByKey {
+		if vr.Spec.MeshRef == nil || !mesh.IsMeshReferenced(ms, *vr.Spec.MeshRef) {
+			return errors.Errorf("virtualRouter %v didn't belong to mesh %v", k8s.NamespacedName(vr), k8s.NamespacedName(ms))
+		}
+		if !virtualrouter.IsVirtualRouterActive(vr) {
+			return runtime.NewRequeueError(errors.New("virtualRouter is not active yet"))
+		}
+	}
+	return nil
+}
+
+func (m *defaultResourceManager) findSDKVirtualService(ctx context.Context, ms *appmesh.Mesh, vs *appmesh.VirtualService) (*appmeshsdk.VirtualServiceData, error) {
+	resp, err := m.appMeshSDK.DescribeVirtualServiceWithContext(ctx, &appmeshsdk.DescribeVirtualServiceInput{
+		MeshName:           ms.Spec.AWSName,
+		MeshOwner:          ms.Spec.MeshOwner,
+		VirtualServiceName: vs.Spec.AWSName,
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return resp.VirtualService, nil
+}
+
+func (m *defaultResourceManager) createSDKVirtualService(ctx context.Context, ms *appmesh.Mesh, vs *appmesh.VirtualService,
+	vnByKey map[types.NamespacedName]*appmesh.VirtualNode, vrByKey map[types.NamespacedName]*appmesh.VirtualRouter) (*appmeshsdk.VirtualServiceData, error) {
+
+	sdkVSSpec, err := buildSDKVirtualServiceSpec(vs, vnByKey, vrByKey)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := m.appMeshSDK.CreateVirtualServiceWithContext(ctx, &appmeshsdk.CreateVirtualServiceInput{
+		MeshName:           ms.Spec.AWSName,
+		MeshOwner:          ms.Spec.MeshOwner,
+		VirtualServiceName: vs.Spec.AWSName,
+		Spec:               sdkVSSpec,
+		Tags:               nil,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.VirtualService, nil
+}
+
+func (m *defaultResourceManager) updateSDKVirtualService(ctx context.Context, sdkVS *appmeshsdk.VirtualServiceData, vs *appmesh.VirtualService,
+	vnByKey map[types.NamespacedName]*appmesh.VirtualNode, vrByKey map[types.NamespacedName]*appmesh.VirtualRouter) (*appmeshsdk.VirtualServiceData, error) {
+	actualSDKVSSpec := sdkVS.Spec
+	desiredSDKVSSpec, err := buildSDKVirtualServiceSpec(vs, vnByKey, vrByKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// If an optional field is not set, AWS will provide default settings that will be in actualSDKVSSpec.
+	// We use IgnoreLeftHandUnset when doing the equality check here to allow AWS sever-side to provide default settings.
+	opts := equality.IgnoreLeftHandUnset()
+	if cmp.Equal(desiredSDKVSSpec, actualSDKVSSpec, opts) {
+		return sdkVS, nil
+	}
+	if !m.isSDKVirtualServiceControlledByCRDVirtualService(ctx, sdkVS, vs) {
+		m.log.V(2).Info("skip virtualService update since it's not controlled",
+			"virtualService", k8s.NamespacedName(vs),
+			"virtualServiceARN", aws.StringValue(sdkVS.Metadata.Arn),
+		)
+		return sdkVS, nil
+	}
+
+	diff := cmp.Diff(desiredSDKVSSpec, actualSDKVSSpec, opts)
+	m.log.V(2).Info("virtualServiceSpec changed",
+		"virtualService", k8s.NamespacedName(vs),
+		"actualSDKVRSpec", actualSDKVSSpec,
+		"desiredSDKVRSpec", desiredSDKVSSpec,
+		"diff", diff,
+	)
+	resp, err := m.appMeshSDK.UpdateVirtualServiceWithContext(ctx, &appmeshsdk.UpdateVirtualServiceInput{
+		MeshName:           sdkVS.MeshName,
+		MeshOwner:          sdkVS.Metadata.MeshOwner,
+		VirtualServiceName: sdkVS.VirtualServiceName,
+		Spec:               desiredSDKVSSpec,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.VirtualService, nil
+}
+
+func (m *defaultResourceManager) deleteSDKVirtualService(ctx context.Context, sdkVS *appmeshsdk.VirtualServiceData, vs *appmesh.VirtualService) error {
+	if !m.isSDKVirtualServiceOwnedByCRDVirtualService(ctx, sdkVS, vs) {
+		m.log.V(2).Info("skip virtualService deletion since its not owned",
+			"virtualService", k8s.NamespacedName(vs),
+			"virtualServiceARN", aws.StringValue(sdkVS.Metadata.Arn),
+		)
+		return nil
+	}
+	_, err := m.appMeshSDK.DeleteVirtualServiceWithContext(ctx, &appmeshsdk.DeleteVirtualServiceInput{
+		MeshName:           sdkVS.MeshName,
+		MeshOwner:          sdkVS.Metadata.MeshOwner,
+		VirtualServiceName: sdkVS.VirtualServiceName,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *defaultResourceManager) updateCRDVirtualService(ctx context.Context, vs *appmesh.VirtualService, sdkVS *appmeshsdk.VirtualServiceData) error {
+	oldVS := vs.DeepCopy()
+	needsUpdate := false
+	if aws.StringValue(vs.Status.VirtualServiceARN) != aws.StringValue(sdkVS.Metadata.Arn) {
+		vs.Status.VirtualServiceARN = sdkVS.Metadata.Arn
+		needsUpdate = true
+	}
+	vsActiveConditionStatus := corev1.ConditionFalse
+	if sdkVS.Status != nil && aws.StringValue(sdkVS.Status.Status) == appmeshsdk.VirtualServiceStatusCodeActive {
+		vsActiveConditionStatus = corev1.ConditionTrue
+	}
+	if updateCondition(vs, appmesh.VirtualServiceActive, vsActiveConditionStatus, nil, nil) {
+		needsUpdate = true
+	}
+
+	if !needsUpdate {
+		return nil
+	}
+	return m.k8sClient.Patch(ctx, vs, client.MergeFrom(oldVS))
+}
+
+// isSDKVirtualServiceControlledByCRDVirtualService checks whether an AppMesh VirtualService is controlled by CRD VirtualService.
+// if it's controlled, CRD VirtualService update is responsible for update AppMesh VirtualService.
+func (m *defaultResourceManager) isSDKVirtualServiceControlledByCRDVirtualService(ctx context.Context, sdkVS *appmeshsdk.VirtualServiceData, vs *appmesh.VirtualService) bool {
+	if aws.StringValue(sdkVS.Metadata.ResourceOwner) != m.accountID {
+		return false
+	}
+	return true
+}
+
+// isSDKVirtualServiceOwnedByCRDVirtualService checks whether an AppMesh VirtualService is owned by CRD VirtualService.
+// if it's owned, CRD VirtualService deletion is responsible for delete AppMesh VirtualService.
+func (m *defaultResourceManager) isSDKVirtualServiceOwnedByCRDVirtualService(ctx context.Context, sdkVS *appmeshsdk.VirtualServiceData, vs *appmesh.VirtualService) bool {
+	if !m.isSDKVirtualServiceControlledByCRDVirtualService(ctx, sdkVS, vs) {
+		return false
+	}
+
+	// TODO: Adding tagging support, so a existing virtualService in owner account but not ownership can be support.
+	// currently, virtualService controllership == ownership, but it don't have to be so once we add tagging support.
+	return true
+}
+
+func buildSDKVirtualServiceSpec(vs *appmesh.VirtualService, vnByKey map[types.NamespacedName]*appmesh.VirtualNode, vrByKey map[types.NamespacedName]*appmesh.VirtualRouter) (*appmeshsdk.VirtualServiceSpec, error) {
+	sdkVNRefConvertFunc := references.BuildSDKVirtualNodeReferenceConvertFunc(vs, vnByKey)
+	sdkVRRefConvertFunc := references.BuildSDKVirtualRouterReferenceConvertFunc(vs, vrByKey)
+	converter := conversion.NewConverter(conversion.DefaultNameFunc)
+	converter.RegisterUntypedConversionFunc((*appmesh.VirtualServiceSpec)(nil), (*appmeshsdk.VirtualServiceSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return conversions.Convert_CRD_VirtualServiceSpec_To_SDK_VirtualServiceSpec(a.(*appmesh.VirtualServiceSpec), b.(*appmeshsdk.VirtualServiceSpec), scope)
+	})
+	converter.RegisterUntypedConversionFunc((*appmesh.VirtualNodeReference)(nil), (*string)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return sdkVNRefConvertFunc(a.(*appmesh.VirtualNodeReference), b.(*string), scope)
+	})
+	converter.RegisterUntypedConversionFunc((*appmesh.VirtualRouterReference)(nil), (*string)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return sdkVRRefConvertFunc(a.(*appmesh.VirtualRouterReference), b.(*string), scope)
+	})
+
+	sdkVSSpec := &appmeshsdk.VirtualServiceSpec{}
+	if err := converter.Convert(&vs.Spec, sdkVSSpec, conversion.DestFromSource, nil); err != nil {
+		return nil, err
+	}
+	return sdkVSSpec, nil
+}

--- a/pkg/virtualservice/resource_manager_test.go
+++ b/pkg/virtualservice/resource_manager_test.go
@@ -1,0 +1,411 @@
+package virtualservice
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-sdk-go/aws"
+	appmeshsdk "github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_defaultResourceManager_updateCRDVirtualService(t *testing.T) {
+	type args struct {
+		vs    *appmesh.VirtualService
+		sdkVS *appmeshsdk.VirtualServiceData
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantVS  *appmesh.VirtualService
+		wantErr error
+	}{
+		{
+			name: "VirtualService needs patch both arn and condition",
+			args: args{
+				vs: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vs-1",
+					},
+					Status: appmesh.VirtualServiceStatus{},
+				},
+				sdkVS: &appmeshsdk.VirtualServiceData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						Arn: aws.String("arn-1"),
+					},
+					Status: &appmeshsdk.VirtualServiceStatus{
+						Status: aws.String(appmeshsdk.VirtualServiceStatusCodeActive),
+					},
+				},
+			},
+			wantVS: &appmesh.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vs-1",
+				},
+				Status: appmesh.VirtualServiceStatus{
+					VirtualServiceARN: aws.String("arn-1"),
+					Conditions: []appmesh.VirtualServiceCondition{
+						{
+							Type:   appmesh.VirtualServiceActive,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "VirtualService needs patch condition only",
+			args: args{
+				vs: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vs-1",
+					},
+					Status: appmesh.VirtualServiceStatus{
+						VirtualServiceARN: aws.String("arn-1"),
+						Conditions: []appmesh.VirtualServiceCondition{
+							{
+								Type:   appmesh.VirtualServiceActive,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				sdkVS: &appmeshsdk.VirtualServiceData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						Arn: aws.String("arn-1"),
+					},
+					Status: &appmeshsdk.VirtualServiceStatus{
+						Status: aws.String(appmeshsdk.VirtualNodeStatusCodeInactive),
+					},
+				},
+			},
+			wantVS: &appmesh.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vs-1",
+				},
+				Status: appmesh.VirtualServiceStatus{
+					VirtualServiceARN: aws.String("arn-1"),
+					Conditions: []appmesh.VirtualServiceCondition{
+						{
+							Type:   appmesh.VirtualServiceActive,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			m := &defaultResourceManager{
+				k8sClient: k8sClient,
+				log:       log.NullLogger{},
+			}
+
+			err := k8sClient.Create(ctx, tt.args.vs.DeepCopy())
+			assert.NoError(t, err)
+			err = m.updateCRDVirtualService(ctx, tt.args.vs, tt.args.sdkVS)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				gotVS := &appmesh.VirtualService{}
+				err = k8sClient.Get(ctx, k8s.NamespacedName(tt.args.vs), gotVS)
+				assert.NoError(t, err)
+				opts := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+					cmpopts.IgnoreTypes((*metav1.Time)(nil)),
+				}
+				assert.True(t, cmp.Equal(tt.wantVS, gotVS, opts), "diff", cmp.Diff(tt.wantVS, gotVS, opts))
+			}
+		})
+	}
+}
+
+func Test_defaultResourceManager_isSDKVirtualServiceControlledByCRDVirtualService(t *testing.T) {
+	type fields struct {
+		accountID string
+	}
+	type args struct {
+		sdkVS *appmeshsdk.VirtualServiceData
+		vs    *appmesh.VirtualService
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "sdkVS is controlled by vs",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVS: &appmeshsdk.VirtualServiceData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("222222222"),
+					},
+				},
+				vs: &appmesh.VirtualService{},
+			},
+			want: true,
+		},
+		{
+			name:   "sdkVS isn't controlled by vs",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVS: &appmeshsdk.VirtualServiceData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("33333333"),
+					},
+				},
+				vs: &appmesh.VirtualService{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := &defaultResourceManager{
+				accountID: tt.fields.accountID,
+				log:       &log.NullLogger{},
+			}
+			got := m.isSDKVirtualServiceControlledByCRDVirtualService(ctx, tt.args.sdkVS, tt.args.vs)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_defaultResourceManager_isSDKVirtualServiceOwnedByCRDVirtualService(t *testing.T) {
+	type fields struct {
+		accountID string
+	}
+	type args struct {
+		sdkVS *appmeshsdk.VirtualServiceData
+		vs    *appmesh.VirtualService
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "sdkVS is controlled by vs",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVS: &appmeshsdk.VirtualServiceData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("222222222"),
+					},
+				},
+				vs: &appmesh.VirtualService{},
+			},
+			want: true,
+		},
+		{
+			name:   "sdkVS isn't controlled by vs",
+			fields: fields{accountID: "222222222"},
+			args: args{
+				sdkVS: &appmeshsdk.VirtualServiceData{
+					Metadata: &appmeshsdk.ResourceMetadata{
+						ResourceOwner: aws.String("33333333"),
+					},
+				},
+				vs: &appmesh.VirtualService{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := &defaultResourceManager{
+				accountID: tt.fields.accountID,
+				log:       &log.NullLogger{},
+			}
+			got := m.isSDKVirtualServiceControlledByCRDVirtualService(ctx, tt.args.sdkVS, tt.args.vs)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_buildSDKVirtualServiceSpec(t *testing.T) {
+	type args struct {
+		vs      *appmesh.VirtualService
+		vnByKey map[types.NamespacedName]*appmesh.VirtualNode
+		vrByKey map[types.NamespacedName]*appmesh.VirtualRouter
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *appmeshsdk.VirtualServiceSpec
+		wantErr error
+	}{
+		{
+			name: "VirtualNode provider - same namespace",
+			args: args{
+				vs: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "vs",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualNode: &appmesh.VirtualNodeServiceProvider{
+								VirtualNodeRef: appmesh.VirtualNodeReference{
+									Name: "vn",
+								},
+							},
+						},
+					},
+				},
+				vnByKey: map[types.NamespacedName]*appmesh.VirtualNode{
+					types.NamespacedName{Namespace: "my-ns", Name: "vn"}: &appmesh.VirtualNode{
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn_my-ns"),
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.VirtualServiceSpec{
+				Provider: &appmeshsdk.VirtualServiceProvider{
+					VirtualNode: &appmeshsdk.VirtualNodeServiceProvider{
+						VirtualNodeName: aws.String("vn_my-ns"),
+					},
+				},
+			},
+		},
+		{
+			name: "VirtualNode provider - different namespace",
+			args: args{
+				vs: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "vs",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualNode: &appmesh.VirtualNodeServiceProvider{
+								VirtualNodeRef: appmesh.VirtualNodeReference{
+									Namespace: aws.String("my-other-ns"),
+									Name:      "vn",
+								},
+							},
+						},
+					},
+				},
+				vnByKey: map[types.NamespacedName]*appmesh.VirtualNode{
+					types.NamespacedName{Namespace: "my-other-ns", Name: "vn"}: &appmesh.VirtualNode{
+						Spec: appmesh.VirtualNodeSpec{
+							AWSName: aws.String("vn_my-other-ns"),
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.VirtualServiceSpec{
+				Provider: &appmeshsdk.VirtualServiceProvider{
+					VirtualNode: &appmeshsdk.VirtualNodeServiceProvider{
+						VirtualNodeName: aws.String("vn_my-other-ns"),
+					},
+				},
+			},
+		},
+		{
+			name: "VirtualRouter provider - same namespace",
+			args: args{
+				vs: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "vs",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualRouter: &appmesh.VirtualRouterServiceProvider{
+								VirtualRouterRef: appmesh.VirtualRouterReference{
+									Name: "vr",
+								},
+							},
+						},
+					},
+				},
+				vrByKey: map[types.NamespacedName]*appmesh.VirtualRouter{
+					types.NamespacedName{Namespace: "my-ns", Name: "vr"}: &appmesh.VirtualRouter{
+						Spec: appmesh.VirtualRouterSpec{
+							AWSName: aws.String("vr_my-ns"),
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.VirtualServiceSpec{
+				Provider: &appmeshsdk.VirtualServiceProvider{
+					VirtualRouter: &appmeshsdk.VirtualRouterServiceProvider{
+						VirtualRouterName: aws.String("vr_my-ns"),
+					},
+				},
+			},
+		},
+		{
+			name: "VirtualRouter provider - different namespace",
+			args: args{
+				vs: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "vs",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualRouter: &appmesh.VirtualRouterServiceProvider{
+								VirtualRouterRef: appmesh.VirtualRouterReference{
+									Namespace: aws.String("my-other-ns"),
+									Name:      "vr",
+								},
+							},
+						},
+					},
+				},
+				vrByKey: map[types.NamespacedName]*appmesh.VirtualRouter{
+					types.NamespacedName{Namespace: "my-other-ns", Name: "vr"}: &appmesh.VirtualRouter{
+						Spec: appmesh.VirtualRouterSpec{
+							AWSName: aws.String("vr_my-other-ns"),
+						},
+					},
+				},
+			},
+			want: &appmeshsdk.VirtualServiceSpec{
+				Provider: &appmeshsdk.VirtualServiceProvider{
+					VirtualRouter: &appmeshsdk.VirtualRouterServiceProvider{
+						VirtualRouterName: aws.String("vr_my-other-ns"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildSDKVirtualServiceSpec(tt.args.vs, tt.args.vnByKey, tt.args.vrByKey)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add resource manager for virtualRouter and virtualService.

This PR is separated into 5 commits:
1. `add virtualRouter conversions`: a conversion function for virtualRouter spec.
2. `add reference handling utilities`: utilities dealing with references.
3. `add condition handling for virtual router and virtual service`: utilities to update virtualRouter & virtualService conditions
4. `add resource manager for virtual router`: resource manager for virtual router, which is responsible for create/update/delete Appmesh virtualRouter & routes.
5. `add resource manager for virtual node`: resource manager for virtual node, which is responsible for create/update/delete Appmesh virtualService

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
