### PR TITLE
separate ecr_secret and iam-for-sa mutator

### DIFF
--- a/pkg/inject/cni_proxy_test.go
+++ b/pkg/inject/cni_proxy_test.go
@@ -1,6 +1,7 @@
 package inject
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,8 +102,8 @@ func Test_cniProxyMutator_mutate(t *testing.T) {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
 				assert.NoError(t, err)
+				assert.True(t, cmp.Equal(tt.wantPod, tt.args.pod), "diff", cmp.Diff(tt.wantPod, tt.args.pod))
 			}
-			assert.Equal(t, tt.wantPod, tt.args.pod)
 		})
 	}
 }

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -8,10 +8,10 @@ import (
 const (
 	flagInjectDefault               = "inject-default"
 	flagEnableIAMForServiceAccounts = "enable-iam-for-service-accounts"
+	flagEnableECRSecret             = "enable-ecr-secret"
 	flagAWSRegion                   = "aws-region"
 	flagEnvoyPreview                = "preview"
 	flagLogLevel                    = "log-level"
-	flagECRSecret                   = "ecr-secret"
 	flagSidecarImage                = "sidecar-image"
 	flagSidecarCpuRequests          = "sidecar-cpu-requests"
 	flagSidecarMemoryRequests       = "sidecar-memory-requests"
@@ -35,6 +35,8 @@ type Config struct {
 	// If enabled, an fsGroup: 1337 will be injected in the absence of it within pod securityContext
 	// see https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8 for more details
 	EnableIAMForServiceAccounts bool
+	// If enabled, additional image pull secret(appmesh-ecr-secret) will be injected.
+	EnableECRSecret bool
 
 	// Sidecar settings
 	SidecarImage  string
@@ -43,7 +45,6 @@ type Config struct {
 	Region        string
 	Preview       bool
 	LogLevel      string
-	EcrSecret     bool
 
 	// Init container settings
 	InitImage  string
@@ -74,15 +75,15 @@ func (cfg *Config) BindFlags() {
 	flag.BoolVar(&cfg.InjectDefault, flagInjectDefault, true,
 		`If enabled, sidecars will be injected in the absence of the corresponding pod annotation`)
 	flag.BoolVar(&cfg.EnableIAMForServiceAccounts, flagEnableIAMForServiceAccounts, true,
-		`If enabled, an fsGroup: 1337 will be injected in the absence of it within pod securityContext`)
+		`If enabled, a fsGroup: 1337 will be injected in the absence of it within pod securityContext`)
+	flag.BoolVar(&cfg.EnableECRSecret, flagEnableECRSecret, false,
+		"If enabled, 'appmesh-ecr-secret' secret will be injected in the absence of it within pod imagePullSecrets")
 	flag.StringVar(&cfg.Region, flagAWSRegion, "",
 		"AWS App Mesh region")
 	flag.BoolVar(&cfg.Preview, flagEnvoyPreview, false,
 		"Enable preview channel")
 	flag.StringVar(&cfg.LogLevel, flagLogLevel, "info",
 		"AWS App Mesh envoy log level")
-	flag.BoolVar(&cfg.EcrSecret, flagECRSecret, false,
-		"Inject AWS app mesh pull secrets")
 	flag.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.3.0-prod",
 		"Envoy sidecar container image.")
 	flag.StringVar(&cfg.SidecarCpu, flagSidecarCpuRequests, "10m",

--- a/pkg/inject/ecr_secret.go
+++ b/pkg/inject/ecr_secret.go
@@ -1,0 +1,36 @@
+package inject
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	defaultECRSecretName = "appmesh-ecr-secret"
+)
+
+func newECRSecretMutator(enabled bool) *ecrSecretMutator {
+	return &ecrSecretMutator{
+		enabled:    enabled,
+		secretName: defaultECRSecretName,
+	}
+}
+
+var _ PodMutator = &ecrSecretMutator{}
+
+// If enabled, additional image pull secret will be injected.
+type ecrSecretMutator struct {
+	enabled    bool
+	secretName string
+}
+
+func (m *ecrSecretMutator) mutate(pod *corev1.Pod) error {
+	if !m.enabled {
+		return nil
+	}
+	for _, imagePullSecret := range pod.Spec.ImagePullSecrets {
+		if imagePullSecret.Name == m.secretName {
+			return nil
+		}
+	}
+	secretRef := corev1.LocalObjectReference{Name: m.secretName}
+	pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, secretRef)
+	return nil
+}

--- a/pkg/inject/ecr_secret_test.go
+++ b/pkg/inject/ecr_secret_test.go
@@ -1,0 +1,136 @@
+package inject
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func Test_ecrSecretMutator_mutate(t *testing.T) {
+	type fields struct {
+		enabled    bool
+		secretName string
+	}
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantPod *corev1.Pod
+		wantErr error
+	}{
+		{
+			name: "no-op when disabled",
+			fields: fields{
+				enabled:    false,
+				secretName: "appmesh-ecr-secret",
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{},
+			},
+		},
+		{
+			name: "inject image pull secret when it's empty",
+			fields: fields{
+				enabled:    true,
+				secretName: "appmesh-ecr-secret",
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						ImagePullSecrets: nil,
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: "appmesh-ecr-secret",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "don't inject image pull secret when it already contain intended secret",
+			fields: fields{
+				enabled:    true,
+				secretName: "appmesh-ecr-secret",
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{
+								Name: "appmesh-ecr-secret",
+							},
+						},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: "appmesh-ecr-secret",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "inject image pull secret when it doesn't contain intended secret",
+			fields: fields{
+				enabled:    true,
+				secretName: "appmesh-ecr-secret",
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{
+								Name: "other-secrets",
+							},
+						},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: "other-secrets",
+						},
+						{
+							Name: "appmesh-ecr-secret",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ecrSecretMutator{
+				enabled:    tt.fields.enabled,
+				secretName: tt.fields.secretName,
+			}
+			err := m.mutate(tt.args.pod)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, cmp.Equal(tt.wantPod, tt.args.pod), "diff", cmp.Diff(tt.wantPod, tt.args.pod))
+			}
+		})
+	}
+}

--- a/pkg/inject/iam_for_service_accounts.go
+++ b/pkg/inject/iam_for_service_accounts.go
@@ -1,0 +1,42 @@
+package inject
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	// We don't want to make this configurable since users shouldn't rely on this
+	// feature to set a fsGroup for them. This feature is just to protect innocent
+	// users that are not aware of the limitation of iam-for-service-accounts:
+	// https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8
+	// Users should set fsGroup on the pod spec directly if a specific fsGroup is desired.
+	defaultIAMForSAFSGroup int64 = 1337
+)
+
+func newIAMForServiceAccountsMutator(enabled bool) *iamForServiceAccountsMutator {
+	return &iamForServiceAccountsMutator{
+		enabled:   enabled,
+		fsGroupID: defaultIAMForSAFSGroup,
+	}
+}
+
+var _ PodMutator = &iamForServiceAccountsMutator{}
+
+// If enabled, a fsGroup will be injected in the absence of it within pod securityContext
+// see https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8 for more details
+type iamForServiceAccountsMutator struct {
+	enabled   bool
+	fsGroupID int64
+}
+
+func (m *iamForServiceAccountsMutator) mutate(pod *corev1.Pod) error {
+	if !m.enabled {
+		return nil
+	}
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.FSGroup != nil {
+		return nil
+	}
+	if pod.Spec.SecurityContext == nil {
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{}
+	}
+	pod.Spec.SecurityContext.FSGroup = &m.fsGroupID
+	return nil
+}

--- a/pkg/inject/iam_for_service_accounts_test.go
+++ b/pkg/inject/iam_for_service_accounts_test.go
@@ -1,0 +1,122 @@
+package inject
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func Test_iamForServiceAccountsMutator_mutate(t *testing.T) {
+	type fields struct {
+		enabled   bool
+		fsGroupID int64
+	}
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantPod *corev1.Pod
+		wantErr error
+	}{
+		{
+			name: "no-op when disabled",
+			fields: fields{
+				enabled:   false,
+				fsGroupID: 1337,
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{},
+			},
+		},
+		{
+			name: "inject fsGroup when securityContext is nil",
+			fields: fields{
+				enabled:   true,
+				fsGroupID: 1337,
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: aws.Int64(1337),
+					},
+				},
+			},
+		},
+		{
+			name: "inject fsGroup when securityContext isn't nil but don't have fsGroup",
+			fields: fields{
+				enabled:   true,
+				fsGroupID: 1337,
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser: aws.Int64(1),
+						},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser: aws.Int64(1),
+						FSGroup:   aws.Int64(1337),
+					},
+				},
+			},
+		},
+		{
+			name: "don't inject fsGroup when securityContext isn't nil and have fsGroup",
+			fields: fields{
+				enabled: true,
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							FSGroup: aws.Int64(42),
+						},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: aws.Int64(42),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &iamForServiceAccountsMutator{
+				enabled:   tt.fields.enabled,
+				fsGroupID: tt.fields.fsGroupID,
+			}
+			err := m.mutate(tt.args.pod)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, cmp.Equal(tt.wantPod, tt.args.pod), "diff", cmp.Diff(tt.wantPod, tt.args.pod))
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. separate ecr_secret and iam-for-sa mutator from injector.
to make it more maintainable and testable.
2. renamed flag "ecr-secrets" to "enable-ecr-secrets" to reflect it's bool semantic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
