### PR TITLE
use dedicate config for mutators

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,10 @@ func main() {
 	var injectConfig inject.Config
 	injectConfig.BindFlags()
 	flag.Parse()
+	if err := injectConfig.Validate(); err != nil {
+		setupLog.Error(err, "invalid flags")
+		os.Exit(1)
+	}
 
 	// TODO: make level configurable
 	lvl := zapraw.NewAtomicLevelAt(-2)
@@ -125,7 +129,7 @@ func main() {
 
 	meshMembershipDesignator := mesh.NewMembershipDesignator(mgr.GetClient())
 	vnMembershipDesignator := virtualnode.NewMembershipDesignator(mgr.GetClient())
-	sidecarInjector := inject.NewSidecarInjector(&injectConfig, cloud.Region())
+	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.Region())
 	appmeshwebhook.NewMeshMutator().SetupWithManager(mgr)
 	appmeshwebhook.NewMeshValidator().SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualNodeMutator(meshMembershipDesignator).SetupWithManager(mgr)

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -6,32 +6,33 @@ import (
 )
 
 const (
-	flagInjectDefault               = "inject-default"
-	flagEnableIAMForServiceAccounts = "enable-iam-for-service-accounts"
-	flagEnableECRSecret             = "enable-ecr-secret"
-	flagAWSRegion                   = "aws-region"
-	flagEnvoyPreview                = "preview"
-	flagLogLevel                    = "log-level"
-	flagSidecarImage                = "sidecar-image"
-	flagSidecarCpuRequests          = "sidecar-cpu-requests"
-	flagSidecarMemoryRequests       = "sidecar-memory-requests"
-	flagInitImage                   = "init-image"
-	flagIgnoredIPs                  = "ignored-ips"
-	flagEnableJaegerTracing         = "enable-jaeger-tracing"
-	flagJaegerAddress               = "jaeger-address"
-	flagJaegerPort                  = "jaeger-port"
-	flagEnableDatadogTracing        = "enable-datadog-tracing"
-	flagDatadogAddress              = "datadog-address"
-	flagDatadogPort                 = "datadog-port"
-	flagEnableXrayTracing           = "enable-xray-tracing"
-	flagEnableStatsTags             = "enable-stats-tags"
-	flagEnableStatsD                = "enable-statsd"
+	flagEnableSidecarInjectorWebhook = "enable-sidecar-injector-webhook"
+	flagEnableIAMForServiceAccounts  = "enable-iam-for-service-accounts"
+	flagEnableECRSecret              = "enable-ecr-secret"
+
+	flagSidecarImage          = "sidecar-image"
+	flagSidecarCpuRequests    = "sidecar-cpu-requests"
+	flagSidecarMemoryRequests = "sidecar-memory-requests"
+	flagPreview               = "preview"
+	flagLogLevel              = "log-level"
+
+	flagInitImage  = "init-image"
+	flagIgnoredIPs = "ignored-ips"
+
+	flagEnableJaegerTracing  = "enable-jaeger-tracing"
+	flagJaegerAddress        = "jaeger-address"
+	flagJaegerPort           = "jaeger-port"
+	flagEnableDatadogTracing = "enable-datadog-tracing"
+	flagDatadogAddress       = "datadog-address"
+	flagDatadogPort          = "datadog-port"
+	flagEnableXrayTracing    = "enable-xray-tracing"
+	flagEnableStatsTags      = "enable-stats-tags"
+	flagEnableStatsD         = "enable-statsd"
 )
 
 type Config struct {
-	// Injection Settings
-	InjectDefault bool
-
+	// whether enable pod injection webhook
+	EnableSidecarInjectorWebhook bool
 	// If enabled, an fsGroup: 1337 will be injected in the absence of it within pod securityContext
 	// see https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8 for more details
 	EnableIAMForServiceAccounts bool
@@ -42,7 +43,6 @@ type Config struct {
 	SidecarImage  string
 	SidecarCpu    string
 	SidecarMemory string
-	Region        string
 	Preview       bool
 	LogLevel      string
 
@@ -51,19 +51,19 @@ type Config struct {
 	IgnoredIPs string
 
 	// Observability settings
-	EnableXrayTracing    bool
-	EnableStatsTags      bool
-	EnableStatsD         bool
 	EnableJaegerTracing  bool
 	JaegerAddress        string
 	JaegerPort           string
 	EnableDatadogTracing bool
 	DatadogAddress       string
 	DatadogPort          string
+	EnableXrayTracing    bool
+	EnableStatsTags      bool
+	EnableStatsD         bool
 }
 
 // MultipleTracer checks if more than one tracer is configured.
-func MultipleTracer(config *Config) bool {
+func multipleTracer(config *Config) bool {
 	j := config.EnableJaegerTracing
 	d := config.EnableDatadogTracing
 	x := config.EnableXrayTracing
@@ -72,24 +72,22 @@ func MultipleTracer(config *Config) bool {
 }
 
 func (cfg *Config) BindFlags() {
-	flag.BoolVar(&cfg.InjectDefault, flagInjectDefault, true,
+	flag.BoolVar(&cfg.EnableSidecarInjectorWebhook, flagEnableSidecarInjectorWebhook, true,
 		`If enabled, sidecars will be injected in the absence of the corresponding pod annotation`)
 	flag.BoolVar(&cfg.EnableIAMForServiceAccounts, flagEnableIAMForServiceAccounts, true,
 		`If enabled, a fsGroup: 1337 will be injected in the absence of it within pod securityContext`)
 	flag.BoolVar(&cfg.EnableECRSecret, flagEnableECRSecret, false,
 		"If enabled, 'appmesh-ecr-secret' secret will be injected in the absence of it within pod imagePullSecrets")
-	flag.StringVar(&cfg.Region, flagAWSRegion, "",
-		"AWS App Mesh region")
-	flag.BoolVar(&cfg.Preview, flagEnvoyPreview, false,
-		"Enable preview channel")
-	flag.StringVar(&cfg.LogLevel, flagLogLevel, "info",
-		"AWS App Mesh envoy log level")
 	flag.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.3.0-prod",
 		"Envoy sidecar container image.")
 	flag.StringVar(&cfg.SidecarCpu, flagSidecarCpuRequests, "10m",
 		"Envoy sidecar CPU resources requests.")
 	flag.StringVar(&cfg.SidecarMemory, flagSidecarMemoryRequests, "32Mi",
 		"Envoy sidecar memory resources requests.")
+	flag.BoolVar(&cfg.Preview, flagPreview, false,
+		"Enable preview channel")
+	flag.StringVar(&cfg.LogLevel, flagLogLevel, "info",
+		"AWS App Mesh envoy log level")
 	flag.StringVar(&cfg.InitImage, flagInitImage, "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
 		"Init container image.")
 	flag.StringVar(&cfg.IgnoredIPs, flagIgnoredIPs, "169.254.169.254",
@@ -119,7 +117,7 @@ func (cfg *Config) BindEnv() error {
 }
 
 func (cfg *Config) Validate() error {
-	if MultipleTracer(cfg) {
+	if multipleTracer(cfg) {
 		return errors.New("Envoy only supports a single tracer instance. Please choose between Jaeger, Datadog or X-Ray.")
 	}
 	return nil

--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -1,8 +1,10 @@
 package inject
 
 const (
-	//AppMeshCpuRequestAnnotation specifies the CPU requests for proxy
-	AppMeshCpuRequestAnnotation = "appmesh.k8s.aws/cpuRequest"
+	//AppMeshCPURequestAnnotation specifies the CPU requests for proxy
+	AppMeshCPURequestAnnotation = "appmesh.k8s.aws/cpuRequest"
+	//AppMeshMemoryRequestAnnotation specifies the memory requests for proxy
+	AppMeshMemoryRequestAnnotation = "appmesh.k8s.aws/memoryRequest"
 
 	// === begin proxy settings annotations ===
 	//AppMeshCNIAnnotation specifies that CNI will be used to configure traffic interception
@@ -23,15 +25,10 @@ const (
 	AppMeshProxyIngressPortAnnotation = "appmesh.k8s.aws/proxyIngressPort"
 	// == end proxy settings annotations ===
 
-	//AppMeshMemoryRequestAnnotation specifies the memory requests for proxy
-	AppMeshMemoryRequestAnnotation = "appmesh.k8s.aws/memoryRequest"
 	//AppMeshPreviewAnnotation specifies that proxy should use App Mesh preview endpoint
 	AppMeshPreviewAnnotation = "appmesh.k8s.aws/preview"
-
 	//AppMeshSidecarInjectAnnotation specifies proxy should be injected for pod. Other systems can use this annotation on pod to determine if proxy is injected or not
 	AppMeshSidecarInjectAnnotation = "appmesh.k8s.aws/sidecarInjectorWebhook"
-	//AppMeshVirtualNodeNameAnnotation specifies the App Mesh VirtualNode used by proxy
-	AppMeshVirtualNodeNameAnnotation = "appmesh.k8s.aws/virtualNode"
 
 	//Pod Labels
 

--- a/pkg/inject/datadog_test.go
+++ b/pkg/inject/datadog_test.go
@@ -1,71 +1,144 @@
 package inject
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 )
 
-func Test_RenderDatadogInitContainer(t *testing.T) {
+func Test_datadogMutator_mutate(t *testing.T) {
+	cpuLimits, _ := resource.ParseQuantity("100m")
+	cpuRequests, _ := resource.ParseQuantity("10m")
+	memoryLimits, _ := resource.ParseQuantity("64Mi")
+	memoryRequests, _ := resource.ParseQuantity("32Mi")
+	type fields struct {
+		mutatorConfig datadogMutatorConfig
+		enabled       bool
+	}
+	type args struct {
+		pod *corev1.Pod
+	}
 	tests := []struct {
-		name string
-		conf Config
-		pod  *corev1.Pod
-		want bool
+		name    string
+		fields  fields
+		args    args
+		wantPod *corev1.Pod
+		wantErr error
 	}{
 		{
-			name: "Enable Jaeger inject",
-			conf: getConfig(func(cnf Config) Config {
-				cnf.EnableDatadogTracing = true
-				cnf.DatadogAddress = "datadog.appmesh-system"
-				cnf.DatadogPort = "8126"
-				return cnf
-			}),
-			pod:  getPod(nil),
-			want: true,
+			name: "no-op when disabled",
+			fields: fields{
+				mutatorConfig: datadogMutatorConfig{
+					datadogAddress: "127.0.0.1",
+					datadogPort:    "8080",
+				},
+				enabled: false,
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{},
+			},
 		},
 		{
-			name: "No Datadog inject",
-			conf: getConfig(nil),
-			pod:  getPod(nil),
-			want: false,
+			name: "inject sidecar and volume",
+			fields: fields{
+				mutatorConfig: datadogMutatorConfig{
+					datadogAddress: "127.0.0.1",
+					datadogPort:    "8080",
+				},
+				enabled: true,
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{},
+				},
+			},
+			wantPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:            "inject-datadog-config",
+							Image:           "busybox",
+							ImagePullPolicy: "IfNotPresent",
+							Command: []string{
+								"sh",
+								"-c",
+								`cat <<EOF >> /tmp/envoy/envoyconf.yaml
+tracing:
+  http:
+    name: envoy.tracers.datadog
+    config:
+      collector_cluster: datadog_agent
+      service_name: envoy
+static_resources:
+  clusters:
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: datadog_agent
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+           address:
+            socket_address:
+             address: 127.0.0.1
+             port_value: 8080
+EOF
+
+cat /tmp/envoy/envoyconf.yaml
+`,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      envoyTracingConfigVolumeName,
+									MountPath: "/tmp/envoy",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"cpu":    cpuLimits,
+									"memory": memoryLimits,
+								},
+								Requests: corev1.ResourceList{
+									"cpu":    cpuRequests,
+									"memory": memoryRequests,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: envoyTracingConfigVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := NewDatadogMutator(&tt.conf)
-			before := len(tt.pod.Spec.InitContainers)
-			err := d.mutate(tt.pod)
-			var init *corev1.Container
-			assert.NoError(t, err, "Unexpected error")
-			found := false
-			for _, v := range tt.pod.Spec.InitContainers {
-				if v.Name == "inject-datadog-config" {
-					found = true
-					init = &v
-				}
+			m := &datadogMutator{
+				mutatorConfig: tt.fields.mutatorConfig,
+				enabled:       tt.fields.enabled,
 			}
-			assert.True(t, found == tt.want, "Unexpected datadog container")
-			if tt.want {
-				assert.NotNil(t, init)
-				assert.Equal(t, "busybox", init.Image)
-				if len(init.Command) < 1 {
-					t.Error("Datadog init container does not contain command")
-				}
-				allCommands := strings.Join(init.Command, " ")
-				if !strings.Contains(allCommands, tt.conf.DatadogPort) {
-					t.Errorf("Datadog port did not get configured correctly")
-				}
-				if !strings.Contains(allCommands, tt.conf.DatadogAddress) {
-					t.Errorf("Datadog address did not get configured correctly")
-				}
-				assert.True(t, len(tt.pod.Spec.Volumes) > 0)
-				assert.Greater(t, len(tt.pod.Spec.InitContainers), before)
+			pod := tt.args.pod.DeepCopy()
+			err := m.mutate(pod)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
-				assert.Nil(t, init)
-				assert.Equal(t, before, len(tt.pod.Spec.InitContainers))
+				assert.NoError(t, err)
+				assert.True(t, cmp.Equal(tt.wantPod, pod), "diff", cmp.Diff(tt.wantPod, pod))
 			}
 		})
 	}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -1,7 +1,6 @@
 package inject
 
 import (
-	"errors"
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -14,25 +13,21 @@ type PodMutator interface {
 }
 
 type SidecarInjector struct {
-	config *Config
+	config    Config
+	awsRegion string
 }
 
-func NewSidecarInjector(cfg *Config, region string) *SidecarInjector {
-	if len(cfg.Region) == 0 {
-		cfg.Region = region
-	}
+func NewSidecarInjector(cfg Config, awsRegion string) *SidecarInjector {
 	return &SidecarInjector{
-		config: cfg,
+		config:    cfg,
+		awsRegion: awsRegion,
 	}
 }
 
 func (m *SidecarInjector) InjectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.VirtualNode, pod *corev1.Pod) error {
-	if !ShouldInject(m.config, pod) {
+	if !shouldInject(m.config.EnableSidecarInjectorWebhook, pod) {
 		injectLogger.Info("Not injecting sidecars for pod ", pod.Name)
 		return nil
-	}
-	if MultipleTracer(m.config) {
-		return errors.New("Unable to apply patches with multiple tracers. Please choose between Jaeger, Datadog or X-Ray.")
 	}
 
 	// List out all the mutators in sequence
@@ -45,10 +40,32 @@ func (m *SidecarInjector) InjectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				memoryRequests: m.config.SidecarMemory,
 			},
 		}, vn),
-		NewEnvoyMutator(m.config, ms, vn),
-		NewXrayMutator(m.config),
-		NewDatadogMutator(m.config),
-		NewJaegerMutator(m.config),
+		newEnvoyMutator(envoyMutatorConfig{
+			awsRegion:             m.awsRegion,
+			preview:               m.config.Preview,
+			logLevel:              m.config.LogLevel,
+			sidecarImage:          m.config.SidecarImage,
+			sidecarCPURequests:    m.config.SidecarCpu,
+			sidecarMemoryRequests: m.config.SidecarMemory,
+			enableXrayTracing:     m.config.EnableXrayTracing,
+			enableJaegerTracing:   m.config.EnableJaegerTracing,
+			enableDatadogTracing:  m.config.EnableDatadogTracing,
+			enableStatsTags:       m.config.EnableStatsTags,
+			enableStatsD:          m.config.EnableStatsD,
+		}, ms, vn),
+		newXrayMutator(xrayMutatorConfig{
+			awsRegion:             m.awsRegion,
+			sidecarCPURequests:    m.config.SidecarCpu,
+			sidecarMemoryRequests: m.config.SidecarMemory,
+		}, m.config.EnableXrayTracing),
+		newDatadogMutator(datadogMutatorConfig{
+			datadogAddress: m.config.DatadogAddress,
+			datadogPort:    m.config.DatadogPort,
+		}, m.config.EnableDatadogTracing),
+		newJaegerMutator(jaegerMutatorConfig{
+			jaegerAddress: m.config.JaegerAddress,
+			jaegerPort:    m.config.JaegerPort,
+		}, m.config.EnableJaegerTracing),
 		newIAMForServiceAccountsMutator(m.config.EnableIAMForServiceAccounts),
 		newECRSecretMutator(m.config.EnableECRSecret),
 	}

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -11,16 +11,15 @@ import (
 
 func getConfig(fp func(Config) Config) Config {
 	conf := Config{
-		IgnoredIPs:                  "169.254.169.254",
-		LogLevel:                    "debug",
-		Region:                      "us-west-2",
-		Preview:                     false,
-		SidecarImage:                "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:latest",
-		InitImage:                   "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
-		InjectDefault:               true,
-		SidecarMemory:               "32Mi",
-		SidecarCpu:                  "10m",
-		EnableIAMForServiceAccounts: true,
+		IgnoredIPs:                   "169.254.169.254",
+		LogLevel:                     "debug",
+		Preview:                      false,
+		SidecarImage:                 "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:latest",
+		InitImage:                    "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
+		EnableSidecarInjectorWebhook: true,
+		SidecarMemory:                "32Mi",
+		SidecarCpu:                   "10m",
+		EnableIAMForServiceAccounts:  true,
 	}
 	if fp != nil {
 		conf = fp(conf)
@@ -224,7 +223,7 @@ func Test_InjectEnvoyContainer(t *testing.T) {
 				ms: getMesh(),
 				vn: getVn(nil),
 				pod: getPod(map[string]string{
-					AppMeshCpuRequestAnnotation:         "20m",
+					AppMeshCPURequestAnnotation:         "20m",
 					AppMeshMemoryRequestAnnotation:      "64Mi",
 					AppMeshPreviewAnnotation:            "0",
 					AppMeshEgressIgnoredPortsAnnotation: "33",
@@ -240,7 +239,7 @@ func Test_InjectEnvoyContainer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inj := NewSidecarInjector(&tt.conf, "")
+			inj := NewSidecarInjector(tt.conf, "us-west-2")
 			pod := tt.args.pod
 			inj.InjectAppMeshPatches(tt.args.ms, tt.args.vn, pod)
 			assert.Equal(t, tt.want.init, len(pod.Spec.InitContainers), "Numbers of init containers mismatch")

--- a/pkg/inject/sidecar_utils.go
+++ b/pkg/inject/sidecar_utils.go
@@ -5,12 +5,9 @@ import (
 	"bytes"
 	"encoding/json"
 	corev1 "k8s.io/api/core/v1"
-	"strconv"
 	"strings"
 	"text/template"
 )
-
-const tracingConfigVolumeName = "envoy-tracing-config"
 
 func renderTemplate(name string, t string, meta interface{}) (string, error) {
 	tmpl, err := template.New(name).Parse(t)
@@ -47,77 +44,23 @@ func escapeYaml(yaml string) (string, error) {
 	return s, nil
 }
 
-// renderInitContainer helper creates inject-datadog-config or inject-jaeger-config
-// container that writes the Envoy config in an empty dir volume
-// the same volume is mounted in the Envoy container at /tmp/envoy/
-// when Envoy starts it will load the tracing config
-func renderInitContainer(name string, confTmpl string, injectTmpl string, meta interface{}) (*corev1.Container, error) {
-	config, err := renderTemplate(name, confTmpl, meta)
-	if err != nil {
-		return nil, err
-	}
-	config, err = escapeYaml(config)
-	if err != nil {
-		return nil, err
-	}
-	initModel := struct {
-		EnvoyConfig string
-	}{
-		config,
-	}
-	initContainer, err := renderTemplate("initConfig", injectTmpl, initModel)
-	if err != nil {
-		return nil, err
-	}
-	var container corev1.Container
-	err = json.Unmarshal([]byte(initContainer), &container)
-	if err != nil {
-		return nil, err
-	}
-	return &container, nil
-
-}
-
-// get all the ports from containers
-func GetPortsFromContainers(containers []corev1.Container) string {
-	parts := make([]string, 0)
-	for _, container := range containers {
-		parts = append(parts, getPortsForContainer(container)...)
-	}
-	return strings.Join(parts, ",")
-}
-
-// get all the ports for that container
-func getPortsForContainer(container corev1.Container) []string {
-	parts := make([]string, 0)
-	for _, p := range container.Ports {
-		parts = append(parts, strconv.Itoa(int(p.ContainerPort)))
-	}
-	return parts
-}
-
-func ShouldInject(cfg *Config, pod *corev1.Pod) bool {
+func shouldInject(defaultShouldInject bool, pod *corev1.Pod) bool {
 	if v, ok := pod.ObjectMeta.Annotations[AppMeshSidecarInjectAnnotation]; ok {
-		switch strings.ToLower(v) {
-		case "enabled":
-			return true
-		case "disabled":
-			return false
-		}
+		return strings.ToLower(v) == "enabled"
 	}
-	return cfg.InjectDefault
+	return defaultShouldInject
 }
 
-func GetSidecarCpu(config *Config, pod *corev1.Pod) string {
-	if v, ok := pod.ObjectMeta.Annotations[AppMeshCpuRequestAnnotation]; ok {
+func getSidecarCPURequest(defaultCPURequest string, pod *corev1.Pod) string {
+	if v, ok := pod.ObjectMeta.Annotations[AppMeshCPURequestAnnotation]; ok {
 		return v
 	}
-	return config.SidecarCpu
+	return defaultCPURequest
 }
 
-func GetSidecarMemory(config *Config, pod *corev1.Pod) string {
+func getSidecarMemoryRequest(defaultMemoryRequest string, pod *corev1.Pod) string {
 	if v, ok := pod.ObjectMeta.Annotations[AppMeshMemoryRequestAnnotation]; ok {
 		return v
 	}
-	return config.SidecarMemory
+	return defaultMemoryRequest
 }


### PR DESCRIPTION
Changes in This PR
1. use dedicate configuration for mutators
2. rename flag `inject-defaults` to `enable-sidecar-injector-webhook` to match annotation `appmesh.k8s.aws/sidecarInjectorWebhook`
3. remove awsRegion flag from injector
4. fix [datadog's volume name](https://github.com/aws/aws-app-mesh-inject/blob/master/pkg/patch/datadog.go#L47), i believe it need to be `envoy-tracing-config`
5. a few renaming, `Cpu -> CPU`, 'sidecarCpu' -> 'sidecarCpuRequests', 'meta' -> 'templateVariables'
6. removed renderInitContainer, as it's not extensible and hides `EnvoyConfig` variable inside it.(it's highly likely other containers variables needs to be templated) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
