### PR TITLE
add more comment about podSelector and namespaceSelector's semantic

### DIFF
--- a/apis/appmesh/v1beta2/mesh_types.go
+++ b/apis/appmesh/v1beta2/mesh_types.go
@@ -68,7 +68,9 @@ type MeshSpec struct {
 	// +optional
 	AWSName *string `json:"awsName,omitempty"`
 	// NamespaceSelector selects Namespaces using labels to designate mesh membership.
-	// This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+	// This field follows standard label selector semantics:
+	//	if present but empty, it selects all namespaces.
+	// 	if absent, it selects no namespace.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 	// The egress filter rules for the service mesh.

--- a/apis/appmesh/v1beta2/virtualnode_types.go
+++ b/apis/appmesh/v1beta2/virtualnode_types.go
@@ -298,7 +298,9 @@ type VirtualNodeSpec struct {
 	// +optional
 	AWSName *string `json:"awsName,omitempty"`
 	// PodSelector selects Pods using labels to designate VirtualNode membership.
-	// if unspecified or empty, it selects no pods.
+	// This field follows standard label selector semantics:
+	//	if present but empty, it selects all pods within namespace.
+	// 	if absent, it selects no pod.
 	// +optional
 	PodSelector *metav1.LabelSelector `json:"podSelector,omitempty"`
 	// The listener that the virtual node is expected to receive inbound traffic from

--- a/pkg/virtualnode/membership_designator_test.go
+++ b/pkg/virtualnode/membership_designator_test.go
@@ -36,7 +36,9 @@ func Test_membershipDesignator_Designate(t *testing.T) {
 			Namespace: testNS.Name,
 			Name:      "vn-with-empty-pod-selector",
 		},
-		Spec:   appmesh.VirtualNodeSpec{},
+		Spec:   appmesh.VirtualNodeSpec{
+			PodSelector: &metav1.LabelSelector{},
+		},
 		Status: appmesh.VirtualNodeStatus{},
 	}
 	vnWithPodSelectorPodX := &appmesh.VirtualNode{
@@ -81,7 +83,7 @@ func Test_membershipDesignator_Designate(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "[a single virtualNode with empty pod selector] pod without labels cannot be selected",
+			name: "[a single virtualNode with empty pod selector] pod without labels can be selected",
 			env: env{
 				namespaces: []*corev1.Namespace{testNS},
 				virtualNodes: []*appmesh.VirtualNode{
@@ -97,11 +99,11 @@ func Test_membershipDesignator_Designate(t *testing.T) {
 					Spec: corev1.PodSpec{},
 				},
 			},
-			want:    nil,
+			want:    vnWithEmptyPodSelector,
 			wantErr: nil,
 		},
 		{
-			name: "[a single virtualNode with empty pod selector] pod with labels cannot be selected",
+			name: "[a single virtualNode with empty pod selector] pod with labels can be selected",
 			env: env{
 				namespaces: []*corev1.Namespace{testNS},
 				virtualNodes: []*appmesh.VirtualNode{
@@ -120,7 +122,7 @@ func Test_membershipDesignator_Designate(t *testing.T) {
 					Spec: corev1.PodSpec{},
 				},
 			},
-			want:    nil,
+			want:    vnWithEmptyPodSelector,
 			wantErr: nil,
 		},
 		{


### PR DESCRIPTION
make the documentation about podSelector and namespaceSelector's semantic clear.
And fix a test case about podSelector

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
