### PR TITLE
adjust injector logic for appmesh.k8s.aws/sidecarInjectorWebhook 

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,7 @@ patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+#- manager_auth_proxy_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,9 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
     spec:
       containers:
       - command:
@@ -32,8 +35,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 10

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-addr", "0.0.0.0:8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -135,7 +135,7 @@ func main() {
 
 	meshMembershipDesignator := mesh.NewMembershipDesignator(mgr.GetClient())
 	vnMembershipDesignator := virtualnode.NewMembershipDesignator(mgr.GetClient())
-	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.Region())
+	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.Region(), mgr.GetClient(), referencesResolver, vnMembershipDesignator)
 	appmeshwebhook.NewMeshMutator().SetupWithManager(mgr)
 	appmeshwebhook.NewMeshValidator().SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualNodeMutator(meshMembershipDesignator).SetupWithManager(mgr)
@@ -144,7 +144,7 @@ func main() {
 	appmeshwebhook.NewVirtualServiceValidator().SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualRouterMutator(meshMembershipDesignator).SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualRouterValidator().SetupWithManager(mgr)
-	corewebhook.NewPodMutator(referencesResolver, vnMembershipDesignator, sidecarInjector).SetupWithManager(mgr)
+	corewebhook.NewPodMutator(sidecarInjector).SetupWithManager(mgr)
 
 	if err = (&appmeshcontroller.VirtualGatewayReconciler{
 		Client: mgr.GetClient(),

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -6,9 +6,8 @@ import (
 )
 
 const (
-	flagEnableSidecarInjectorWebhook = "enable-sidecar-injector-webhook"
-	flagEnableIAMForServiceAccounts  = "enable-iam-for-service-accounts"
-	flagEnableECRSecret              = "enable-ecr-secret"
+	flagEnableIAMForServiceAccounts = "enable-iam-for-service-accounts"
+	flagEnableECRSecret             = "enable-ecr-secret"
 
 	flagSidecarImage          = "sidecar-image"
 	flagSidecarCpuRequests    = "sidecar-cpu-requests"
@@ -31,8 +30,6 @@ const (
 )
 
 type Config struct {
-	// whether enable pod injection webhook
-	EnableSidecarInjectorWebhook bool
 	// If enabled, an fsGroup: 1337 will be injected in the absence of it within pod securityContext
 	// see https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8 for more details
 	EnableIAMForServiceAccounts bool
@@ -72,8 +69,6 @@ func multipleTracer(config *Config) bool {
 }
 
 func (cfg *Config) BindFlags() {
-	flag.BoolVar(&cfg.EnableSidecarInjectorWebhook, flagEnableSidecarInjectorWebhook, true,
-		`If enabled, sidecars will be injected in the absence of the corresponding pod annotation`)
 	flag.BoolVar(&cfg.EnableIAMForServiceAccounts, flagEnableIAMForServiceAccounts, true,
 		`If enabled, a fsGroup: 1337 will be injected in the absence of it within pod securityContext`)
 	flag.BoolVar(&cfg.EnableECRSecret, flagEnableECRSecret, false,

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -1,9 +1,17 @@
 package inject
 
 import (
+	"context"
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/webhook"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
 var injectLogger = ctrl.Log.WithName("appmesh_inject")
@@ -13,23 +21,53 @@ type PodMutator interface {
 }
 
 type SidecarInjector struct {
-	config    Config
-	awsRegion string
+	config                 Config
+	awsRegion              string
+	k8sClient              client.Client
+	referenceResolver      references.Resolver
+	vnMembershipDesignator virtualnode.MembershipDesignator
 }
 
-func NewSidecarInjector(cfg Config, awsRegion string) *SidecarInjector {
+func NewSidecarInjector(cfg Config, awsRegion string,
+	k8sClient client.Client,
+	referenceResolver references.Resolver,
+	vnMembershipDesignator virtualnode.MembershipDesignator) *SidecarInjector {
 	return &SidecarInjector{
-		config:    cfg,
-		awsRegion: awsRegion,
+		config:                 cfg,
+		awsRegion:              awsRegion,
+		k8sClient:              k8sClient,
+		referenceResolver:      referenceResolver,
+		vnMembershipDesignator: vnMembershipDesignator,
 	}
 }
 
-func (m *SidecarInjector) InjectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.VirtualNode, pod *corev1.Pod) error {
-	if !shouldInject(m.config.EnableSidecarInjectorWebhook, pod) {
-		injectLogger.Info("Not injecting sidecars for pod ", pod.Name)
+func (m *SidecarInjector) Inject(ctx context.Context, pod *corev1.Pod) error {
+	injectMode, err := m.determineSidecarInjectMode(ctx, pod)
+	if err != nil {
+		return errors.Wrap(err, "failed to determine sidecarInject mode")
+	}
+	if injectMode == sidecarInjectModeDisabled {
 		return nil
 	}
+	vn, err := m.vnMembershipDesignator.Designate(ctx, pod)
+	if err != nil {
+		return err
+	}
 
+	if vn == nil || vn.Spec.MeshRef == nil {
+		if injectMode == sidecarInjectModeEnabled {
+			return errors.New("sidecarInject enabled but no matching VirtualNode found")
+		}
+		return nil
+	}
+	ms, err := m.referenceResolver.ResolveMeshReference(ctx, *vn.Spec.MeshRef)
+	if err != nil {
+		return err
+	}
+	return m.injectAppMeshPatches(ms, vn, pod)
+}
+
+func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.VirtualNode, pod *corev1.Pod) error {
 	// List out all the mutators in sequence
 	var mutators = []PodMutator{
 		newProxyMutator(proxyMutatorConfig{
@@ -77,4 +115,40 @@ func (m *SidecarInjector) InjectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 		}
 	}
 	return nil
+}
+
+type sidecarInjectMode string
+
+const (
+	// when enabled, a virtualNode must be found for pod, otherwise, pod will be rejected.
+	sidecarInjectModeEnabled = "enabled"
+	// when disabled, pod injection will be skipped.
+	sidecarInjectModeDisabled = "disabled"
+	// when unspecified, if a virtualNode is found for pod, pod will be injected, otherwise, pod will be skipped.
+	sidecarInjectModeUnspecified = "unspecified"
+)
+
+func (m *SidecarInjector) determineSidecarInjectMode(ctx context.Context, pod *corev1.Pod) (sidecarInjectMode, error) {
+	var sidecarInjectAnnotation string
+	if v, ok := pod.ObjectMeta.Annotations[AppMeshSidecarInjectAnnotation]; ok {
+		sidecarInjectAnnotation = v
+	} else {
+		// see https://github.com/kubernetes/kubernetes/issues/88282 and https://github.com/kubernetes/kubernetes/issues/76680
+		req := webhook.ContextGetAdmissionRequest(ctx)
+		objectNS := &corev1.Namespace{}
+		if err := m.k8sClient.Get(ctx, types.NamespacedName{Name: req.Namespace}, objectNS); err != nil {
+			return sidecarInjectModeUnspecified, err
+		}
+		if v, ok := objectNS.ObjectMeta.Annotations[AppMeshSidecarInjectAnnotation]; ok {
+			sidecarInjectAnnotation = v
+		}
+	}
+	switch strings.ToLower(sidecarInjectAnnotation) {
+	case "enabled":
+		return sidecarInjectModeEnabled, nil
+	case "disabled":
+		return sidecarInjectModeDisabled, nil
+	default:
+		return sidecarInjectModeUnspecified, nil
+	}
 }

--- a/pkg/inject/sidecar_utils.go
+++ b/pkg/inject/sidecar_utils.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 	"text/template"
 )
 
@@ -42,13 +41,6 @@ func escapeYaml(yaml string) (string, error) {
 		s = s[:len(s)-1]
 	}
 	return s, nil
-}
-
-func shouldInject(defaultShouldInject bool, pod *corev1.Pod) bool {
-	if v, ok := pod.ObjectMeta.Annotations[AppMeshSidecarInjectAnnotation]; ok {
-		return strings.ToLower(v) == "enabled"
-	}
-	return defaultShouldInject
 }
 
 func getSidecarCPURequest(defaultCPURequest string, pod *corev1.Pod) string {

--- a/pkg/virtualnode/membership_designator_test.go
+++ b/pkg/virtualnode/membership_designator_test.go
@@ -36,7 +36,7 @@ func Test_membershipDesignator_Designate(t *testing.T) {
 			Namespace: testNS.Name,
 			Name:      "vn-with-empty-pod-selector",
 		},
-		Spec:   appmesh.VirtualNodeSpec{
+		Spec: appmesh.VirtualNodeSpec{
 			PodSelector: &metav1.LabelSelector{},
 		},
 		Status: appmesh.VirtualNodeStatus{},

--- a/pkg/webhook/context.go
+++ b/pkg/webhook/context.go
@@ -1,0 +1,23 @@
+package webhook
+
+import (
+	"context"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type contextKey string
+
+const (
+	contextKeyAdmissionRequest contextKey = "admissionRequest"
+)
+
+func ContextGetAdmissionRequest(ctx context.Context) *admission.Request {
+	if v := ctx.Value(contextKeyAdmissionRequest); v != nil {
+		return v.(*admission.Request)
+	}
+	return nil
+}
+
+func ContextWithAdmissionRequest(ctx context.Context, req admission.Request) context.Context {
+	return context.WithValue(ctx, contextKeyAdmissionRequest, &req)
+}

--- a/pkg/webhook/context_test.go
+++ b/pkg/webhook/context_test.go
@@ -1,0 +1,53 @@
+package webhook
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"testing"
+)
+
+func TestContextGetAdmissionRequestAndContextWithAdmissionRequest(t *testing.T) {
+	type args struct {
+		req *admission.Request
+	}
+	tests := []struct {
+		name string
+		args args
+		want *admission.Request
+	}{
+		{
+			name: "with request",
+			args: args{
+				req: &admission.Request{
+					AdmissionRequest: admissionv1beta1.AdmissionRequest{
+						UID: "1",
+					},
+				},
+			},
+			want: &admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					UID: "1",
+				},
+			},
+		},
+		{
+			name: "without request",
+			args: args{
+				req: nil,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.args.req != nil {
+				ctx = ContextWithAdmissionRequest(ctx, *tt.args.req)
+			}
+			got := ContextGetAdmissionRequest(ctx)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/webhook/mutating_handler.go
+++ b/pkg/webhook/mutating_handler.go
@@ -50,7 +50,7 @@ func (h *mutatingHandler) handleCreate(ctx context.Context, req admission.Reques
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	mutatedObj, err := h.mutator.MutateCreate(ctx, obj)
+	mutatedObj, err := h.mutator.MutateCreate(ContextWithAdmissionRequest(ctx, req), obj)
 	if err != nil {
 		return admission.Denied(err.Error())
 	}
@@ -75,7 +75,7 @@ func (h *mutatingHandler) handleUpdate(ctx context.Context, req admission.Reques
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	mutatedObj, err := h.mutator.MutateUpdate(ctx, obj, oldObj)
+	mutatedObj, err := h.mutator.MutateUpdate(ContextWithAdmissionRequest(ctx, req), obj, oldObj)
 	if err != nil {
 		return admission.Denied(err.Error())
 	}

--- a/pkg/webhook/validating_handler.go
+++ b/pkg/webhook/validating_handler.go
@@ -51,7 +51,7 @@ func (h *validatingHandler) handleCreate(ctx context.Context, req admission.Requ
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if err := h.validator.ValidateCreate(ctx, obj); err != nil {
+	if err := h.validator.ValidateCreate(ContextWithAdmissionRequest(ctx, req), obj); err != nil {
 		return admission.Denied(err.Error())
 	}
 	return admission.Allowed("")
@@ -71,7 +71,7 @@ func (h *validatingHandler) handleUpdate(ctx context.Context, req admission.Requ
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if err := h.validator.ValidateUpdate(ctx, obj, oldObj); err != nil {
+	if err := h.validator.ValidateUpdate(ContextWithAdmissionRequest(ctx, req), obj, oldObj); err != nil {
 		return admission.Denied(err.Error())
 	}
 	return admission.Allowed("")
@@ -87,7 +87,7 @@ func (h *validatingHandler) handleDelete(ctx context.Context, req admission.Requ
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if err := h.validator.ValidateDelete(ctx, obj); err != nil {
+	if err := h.validator.ValidateDelete(ContextWithAdmissionRequest(ctx, req), obj); err != nil {
 		return admission.Denied(err.Error())
 	}
 	return admission.Allowed("")

--- a/webhooks/core/pod_mutator.go
+++ b/webhooks/core/pod_mutator.go
@@ -2,10 +2,7 @@ package core
 
 import (
 	"context"
-	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
-	appmeshinject "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/inject"
-	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
-	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/inject"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,20 +13,16 @@ import (
 const apiPathMutatePod = "/mutate-v1-pod"
 
 // NewPodMutator returns a mutator for Pod.
-func NewPodMutator(referenceResolver references.Resolver, vnMembershipDesignator virtualnode.MembershipDesignator, injector *appmeshinject.SidecarInjector) *podMutator {
+func NewPodMutator(injector *inject.SidecarInjector) *podMutator {
 	return &podMutator{
-		referenceResolver:      referenceResolver,
-		vnMembershipDesignator: vnMembershipDesignator,
-		sidecarInjector:        injector,
+		sidecarInjector: injector,
 	}
 }
 
 var _ webhook.Mutator = &podMutator{}
 
 type podMutator struct {
-	referenceResolver      references.Resolver
-	vnMembershipDesignator virtualnode.MembershipDesignator
-	sidecarInjector        *appmeshinject.SidecarInjector
+	sidecarInjector *inject.SidecarInjector
 }
 
 func (m *podMutator) Prototype(req admission.Request) (runtime.Object, error) {
@@ -38,18 +31,7 @@ func (m *podMutator) Prototype(req admission.Request) (runtime.Object, error) {
 
 func (m *podMutator) MutateCreate(ctx context.Context, obj runtime.Object) (runtime.Object, error) {
 	pod := obj.(*corev1.Pod)
-	vn, err := m.vnMembershipDesignator.Designate(ctx, pod)
-	if err != nil {
-		return nil, err
-	}
-	if vn == nil || vn.Spec.MeshRef == nil {
-		return obj, nil
-	}
-	ms, err := m.referenceResolver.ResolveMeshReference(ctx, *vn.Spec.MeshRef)
-	if err != nil {
-		return nil, err
-	}
-	if err := m.injectAppMeshPatches(ctx, ms, vn, pod); err != nil {
+	if err := m.sidecarInjector.Inject(ctx, pod); err != nil {
 		return nil, err
 	}
 	return pod, nil
@@ -57,10 +39,6 @@ func (m *podMutator) MutateCreate(ctx context.Context, obj runtime.Object) (runt
 
 func (m *podMutator) MutateUpdate(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
 	return obj, nil
-}
-
-func (m *podMutator) injectAppMeshPatches(ctx context.Context, ms *appmesh.Mesh, vn *appmesh.VirtualNode, pod *corev1.Pod) error {
-	return m.sidecarInjector.InjectAppMeshPatches(ms, vn, pod)
 }
 
 // +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create,versions=v1,name=mpod.appmesh.k8s.aws


### PR DESCRIPTION
1. adjust injector logic for `appmesh.k8s.aws/sidecarInjectorWebhook` as below:
   1. when `appmesh.k8s.aws/sidecarInjectorWebhook` presents on pod or namespace(pod takes priority):
        * `enabled`:  enforce sidecar injection, reject pod creation when VN absent.
        * `disabled`: skip sidecar injection
        *  other: inject when VN found, skip when not found.
   2. By default,   inject when VN found, skip when not found. (so the flag `enable-sidecar-injector` is no longer needed)
2. change metrics endpoint to 0.0.0.0:8080
3. adjust controller memory usage
4. remove metrics authProxy



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
