### PR TITLE
optimize reconcile by enqueue objects when dependent changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.14 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/controllers/appmesh/cloudmap_controller.go
+++ b/controllers/appmesh/cloudmap_controller.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -62,6 +63,7 @@ func (r *cloudMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("cloudMap").
 		For(&appmesh.VirtualNode{}).
 		Watches(&source.Kind{Type: &corev1.Pod{}}, r.enqueueRequestsForPodEvents).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		Complete(r)
 }
 

--- a/controllers/appmesh/virtualnode_controller.go
+++ b/controllers/appmesh/virtualnode_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -58,6 +59,7 @@ func (r *virtualNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appmesh.VirtualNode{}).
 		Watches(&source.Kind{Type: &appmesh.Mesh{}}, r.enqueueRequestsForMeshEvents).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		Complete(r)
 }
 

--- a/controllers/appmesh/virtualrouter_controller.go
+++ b/controllers/appmesh/virtualrouter_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/runtime"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualrouter"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -74,6 +75,7 @@ func (r *virtualRouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&appmesh.VirtualRouter{}).
 		Watches(&source.Kind{Type: &appmesh.Mesh{}}, r.enqueueRequestsForMeshEvents).
 		Watches(&source.Kind{Type: &appmesh.VirtualNode{}}, r.enqueueRequestsForVirtualNodeEvents).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		Complete(r)
 }
 

--- a/controllers/appmesh/virtualservice_controller.go
+++ b/controllers/appmesh/virtualservice_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/runtime"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualservice"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -78,6 +79,7 @@ func (r *virtualServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &appmesh.Mesh{}}, r.enqueueRequestsForMeshEvents).
 		Watches(&source.Kind{Type: &appmesh.VirtualNode{}}, r.enqueueRequestsForVirtualNodeEvents).
 		Watches(&source.Kind{Type: &appmesh.VirtualRouter{}}, r.enqueueRequestsForVirtualRouterEvents).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		Complete(r)
 }
 

--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func main() {
 	}
 
 	stopChan := ctrl.SetupSignalHandler()
+	referencesIndexer := references.NewDefaultObjectReferenceIndexer(mgr.GetCache(), mgr.GetFieldIndexer())
 	finalizerManager := k8s.NewDefaultFinalizerManager(mgr.GetClient(), ctrl.Log)
 	meshMembersFinalizer := mesh.NewPendingMembersFinalizer(mgr.GetClient(), mgr.GetEventRecorderFor("mesh-members"), ctrl.Log)
 	referencesResolver := references.NewDefaultResolver(mgr.GetClient(), ctrl.Log)
@@ -114,8 +115,8 @@ func main() {
 	msReconciler := appmeshcontroller.NewMeshReconciler(mgr.GetClient(), finalizerManager, meshMembersFinalizer, meshResManager, ctrl.Log.WithName("controllers").WithName("Mesh"))
 	vnReconciler := appmeshcontroller.NewVirtualNodeReconciler(mgr.GetClient(), finalizerManager, vnResManager, ctrl.Log.WithName("controllers").WithName("VirtualNode"))
 	cloudMapReconciler := appmeshcontroller.NewCloudMapReconciler(mgr.GetClient(), finalizerManager, cloudMapResManager, ctrl.Log.WithName("controllers").WithName("CloudMap"))
-	vsReconciler := appmeshcontroller.NewVirtualServiceReconciler(mgr.GetClient(), finalizerManager, vsResManager, ctrl.Log.WithName("controllers").WithName("VirtualService"))
-	vrReconciler := appmeshcontroller.NewVirtualRouterReconciler(mgr.GetClient(), finalizerManager, vrResManager, ctrl.Log.WithName("controllers").WithName("VirtualRouter"))
+	vsReconciler := appmeshcontroller.NewVirtualServiceReconciler(mgr.GetClient(), finalizerManager, referencesIndexer, vsResManager, ctrl.Log.WithName("controllers").WithName("VirtualService"))
+	vrReconciler := appmeshcontroller.NewVirtualRouterReconciler(mgr.GetClient(), finalizerManager, referencesIndexer, vrResManager, ctrl.Log.WithName("controllers").WithName("VirtualRouter"))
 	if err = msReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Mesh")
 		os.Exit(1)

--- a/pkg/references/indexer.go
+++ b/pkg/references/indexer.go
@@ -1,0 +1,65 @@
+package references
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ObjectReferenceIndexer is responsible for build indexes based on object's reference,
+// and fetch objects based on reference using index.
+type ObjectReferenceIndexer interface {
+	Setup(obj runtime.Object, indexFuncByKind map[string]ObjectReferenceIndexFunc) error
+	Fetch(ctx context.Context, objList runtime.Object, referentKind string, referentKey types.NamespacedName, opts ...client.ListOption) error
+}
+
+type ObjectReferenceIndexFunc func(obj runtime.Object) []types.NamespacedName
+
+func NewDefaultObjectReferenceIndexer(k8sCache cache.Cache, k8sFieldIndexer client.FieldIndexer) *defaultObjectReferenceIndexer {
+	return &defaultObjectReferenceIndexer{
+		k8sCache:        k8sCache,
+		k8sFieldIndexer: k8sFieldIndexer,
+	}
+}
+
+var _ ObjectReferenceIndexer = &defaultObjectReferenceIndexer{}
+
+type defaultObjectReferenceIndexer struct {
+	k8sCache        cache.Cache
+	k8sFieldIndexer client.FieldIndexer
+}
+
+func (i *defaultObjectReferenceIndexer) Setup(obj runtime.Object, indexFuncByKind map[string]ObjectReferenceIndexFunc) error {
+	for kind := range indexFuncByKind {
+		indexFunc := indexFuncByKind[kind]
+		ctrlIndexFunc := func(obj runtime.Object) []string {
+			var indexValues []string
+			for _, referent := range indexFunc(obj) {
+				indexValues = append(indexValues, buildIndexValue(referent))
+			}
+			return indexValues
+		}
+		if err := i.k8sFieldIndexer.IndexField(context.Background(), obj, buildIndexKey(kind), ctrlIndexFunc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (i *defaultObjectReferenceIndexer) Fetch(ctx context.Context, objList runtime.Object, referentKind string, referentKey types.NamespacedName, opts ...client.ListOption) error {
+	indexKey := buildIndexKey(referentKind)
+	indexValue := buildIndexValue(referentKey)
+	opts = append(opts, client.MatchingFields{indexKey: indexValue})
+	return i.k8sCache.List(ctx, objList, opts...)
+}
+
+func buildIndexKey(referentKind string) string {
+	return "objectRefIndex:" + referentKind
+}
+
+func buildIndexValue(referentKey types.NamespacedName) string {
+	return fmt.Sprintf("%s/%s", referentKey.Namespace, referentKey.Name)
+}

--- a/pkg/references/indexer_test.go
+++ b/pkg/references/indexer_test.go
@@ -1,0 +1,59 @@
+package references
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+func Test_buildIndexKey(t *testing.T) {
+	type args struct {
+		referentKind string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "normal case",
+			args: args{
+				referentKind: "VirtualNode",
+			},
+			want: "objectRefIndex:VirtualNode",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildIndexKey(tt.args.referentKind)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_buildIndexValue(t *testing.T) {
+	type args struct {
+		referentKey types.NamespacedName
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "normal case",
+			args: args{
+				referentKey: types.NamespacedName{
+					Namespace: "my-ns",
+					Name:      "my-obj",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildIndexValue(tt.args.referentKey)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/references/indexer_test.go
+++ b/pkg/references/indexer_test.go
@@ -48,6 +48,7 @@ func Test_buildIndexValue(t *testing.T) {
 					Name:      "my-obj",
 				},
 			},
+			want: "my-ns/my-obj",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/virtualrouter/enqueue_requests_for_virtualnode_events.go
+++ b/pkg/virtualrouter/enqueue_requests_for_virtualnode_events.go
@@ -1,0 +1,68 @@
+package virtualrouter
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+func NewEnqueueRequestsForVirtualNodeEvents(referencesIndexer references.ObjectReferenceIndexer, log logr.Logger) *enqueueRequestsForVirtualNodeEvents {
+	return &enqueueRequestsForVirtualNodeEvents{
+		referencesIndexer: referencesIndexer,
+		log:               log,
+	}
+}
+
+var _ handler.EventHandler = (*enqueueRequestsForVirtualNodeEvents)(nil)
+
+type enqueueRequestsForVirtualNodeEvents struct {
+	referencesIndexer references.ObjectReferenceIndexer
+	log               logr.Logger
+}
+
+// Create is called in response to an create event
+func (h *enqueueRequestsForVirtualNodeEvents) Create(e event.CreateEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+// Update is called in response to an update event
+func (h *enqueueRequestsForVirtualNodeEvents) Update(e event.UpdateEvent, queue workqueue.RateLimitingInterface) {
+	// virtualRouter reconcile depends on virtualNode is active or not.
+	// so we only need to trigger virtualRouter reconcile if virtualNode's active status changed.
+	vnOld := e.ObjectOld.(*appmesh.VirtualNode)
+	vnNew := e.ObjectNew.(*appmesh.VirtualNode)
+
+	if virtualnode.IsVirtualNodeActive(vnOld) != virtualnode.IsVirtualNodeActive(vnNew) {
+		h.enqueueVirtualRoutersForVirtualNode(context.Background(), queue, vnNew)
+	}
+}
+
+// Delete is called in response to a delete event
+func (h *enqueueRequestsForVirtualNodeEvents) Delete(e event.DeleteEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+// external trigger request
+func (h *enqueueRequestsForVirtualNodeEvents) Generic(e event.GenericEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+func (h *enqueueRequestsForVirtualNodeEvents) enqueueVirtualRoutersForVirtualNode(ctx context.Context, queue workqueue.RateLimitingInterface, vn *appmesh.VirtualNode) {
+	vrList := &appmesh.VirtualRouterList{}
+	if err := h.referencesIndexer.Fetch(ctx, vrList, ReferenceKindVirtualNode, k8s.NamespacedName(vn)); err != nil {
+		h.log.Error(err, "failed to enqueue virtualRouters for virtualNode events",
+			"virtualNode", k8s.NamespacedName(vn))
+		return
+	}
+	for _, vr := range vrList.Items {
+		queue.Add(ctrl.Request{NamespacedName: k8s.NamespacedName(&vr)})
+	}
+}

--- a/pkg/virtualrouter/references.go
+++ b/pkg/virtualrouter/references.go
@@ -1,6 +1,15 @@
 package virtualrouter
 
-import appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	ReferenceKindVirtualNode = "VirtualNode"
+)
 
 // extractVirtualNodeReferences extracts all virtualNodeReferences for this virtualRouter
 func extractVirtualNodeReferences(vr *appmesh.VirtualRouter) []appmesh.VirtualNodeReference {
@@ -28,4 +37,14 @@ func extractVirtualNodeReferences(vr *appmesh.VirtualRouter) []appmesh.VirtualNo
 		}
 	}
 	return vnRefs
+}
+
+func VirtualNodeReferenceIndexFunc(obj runtime.Object) []types.NamespacedName {
+	vr := obj.(*appmesh.VirtualRouter)
+	vnRefs := extractVirtualNodeReferences(vr)
+	var vnKeys []types.NamespacedName
+	for _, vnRef := range vnRefs {
+		vnKeys = append(vnKeys, references.ObjectKeyForVirtualNodeReference(vr, vnRef))
+	}
+	return vnKeys
 }

--- a/pkg/virtualrouter/references_test.go
+++ b/pkg/virtualrouter/references_test.go
@@ -4,6 +4,9 @@ import (
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"testing"
 )
 
@@ -263,6 +266,150 @@ func Test_extractVirtualNodeReferences(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := extractVirtualNodeReferences(tt.args.vr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVirtualNodeReferenceIndexFunc(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want []types.NamespacedName
+	}{
+		{
+			name: "single routes - with namespace",
+			args: args{
+				obj: &appmesh.VirtualRouter{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: []appmesh.Route{
+							{
+								GRPCRoute: &appmesh.GRPCRoute{
+									Action: appmesh.GRPCRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("other-ns"),
+													Name:      "vn-1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "other-ns",
+					Name:      "vn-1",
+				},
+			},
+		},
+		{
+			name: "single routes - without namespace",
+			args: args{
+				obj: &appmesh.VirtualRouter{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: []appmesh.Route{
+							{
+								GRPCRoute: &appmesh.GRPCRoute{
+									Action: appmesh.GRPCRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Name: "vn-1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "my-ns",
+					Name:      "vn-1",
+				},
+			},
+		},
+		{
+			name: "multiple routes",
+			args: args{
+				obj: &appmesh.VirtualRouter{
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: []appmesh.Route{
+							{
+								GRPCRoute: &appmesh.GRPCRoute{
+									Action: appmesh.GRPCRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-1",
+												},
+											},
+										},
+									},
+								},
+								HTTPRoute: &appmesh.HTTPRoute{
+									Action: appmesh.HTTPRouteAction{
+										WeightedTargets: []appmesh.WeightedTarget{
+											{
+												VirtualNodeRef: appmesh.VirtualNodeReference{
+													Namespace: aws.String("my-ns"),
+													Name:      "vn-2",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "my-ns",
+					Name:      "vn-1",
+				},
+				{
+					Namespace: "my-ns",
+					Name:      "vn-2",
+				},
+			},
+		},
+
+		{
+			name: "zero routes",
+			args: args{
+				obj: &appmesh.VirtualRouter{
+					Spec: appmesh.VirtualRouterSpec{
+						Routes: nil,
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := VirtualNodeReferenceIndexFunc(tt.args.obj)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/virtualservice/enqueue_requests_for_virtualnode_events.go
+++ b/pkg/virtualservice/enqueue_requests_for_virtualnode_events.go
@@ -1,0 +1,68 @@
+package virtualservice
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+func NewEnqueueRequestsForVirtualNodeEvents(referencesIndexer references.ObjectReferenceIndexer, log logr.Logger) *enqueueRequestsForVirtualNodeEvents {
+	return &enqueueRequestsForVirtualNodeEvents{
+		referencesIndexer: referencesIndexer,
+		log:               log,
+	}
+}
+
+var _ handler.EventHandler = (*enqueueRequestsForVirtualNodeEvents)(nil)
+
+type enqueueRequestsForVirtualNodeEvents struct {
+	referencesIndexer references.ObjectReferenceIndexer
+	log               logr.Logger
+}
+
+// Create is called in response to an create event
+func (h *enqueueRequestsForVirtualNodeEvents) Create(e event.CreateEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+// Update is called in response to an update event
+func (h *enqueueRequestsForVirtualNodeEvents) Update(e event.UpdateEvent, queue workqueue.RateLimitingInterface) {
+	// VirtualService reconcile depends on virtualNode is active or not.
+	// so we only need to trigger VirtualService reconcile if virtualNode's active status changed.
+	vnOld := e.ObjectOld.(*appmesh.VirtualNode)
+	vnNew := e.ObjectNew.(*appmesh.VirtualNode)
+
+	if virtualnode.IsVirtualNodeActive(vnOld) != virtualnode.IsVirtualNodeActive(vnNew) {
+		h.enqueueVirtualServicesForVirtualNode(context.Background(), queue, vnNew)
+	}
+}
+
+// Delete is called in response to a delete event
+func (h *enqueueRequestsForVirtualNodeEvents) Delete(e event.DeleteEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+// external trigger request
+func (h *enqueueRequestsForVirtualNodeEvents) Generic(e event.GenericEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+func (h *enqueueRequestsForVirtualNodeEvents) enqueueVirtualServicesForVirtualNode(ctx context.Context, queue workqueue.RateLimitingInterface, vn *appmesh.VirtualNode) {
+	vsList := &appmesh.VirtualServiceList{}
+	if err := h.referencesIndexer.Fetch(ctx, vsList, ReferenceKindVirtualNode, k8s.NamespacedName(vn)); err != nil {
+		h.log.Error(err, "failed to enqueue virtualServices for virtualNode events",
+			"virtualNode", k8s.NamespacedName(vn))
+		return
+	}
+	for _, vs := range vsList.Items {
+		queue.Add(ctrl.Request{NamespacedName: k8s.NamespacedName(&vs)})
+	}
+}

--- a/pkg/virtualservice/enqueue_requests_for_virtualrouter_events.go
+++ b/pkg/virtualservice/enqueue_requests_for_virtualrouter_events.go
@@ -1,0 +1,68 @@
+package virtualservice
+
+import (
+	"context"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualrouter"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+func NewEnqueueRequestsForVirtualRouterEvents(referencesIndexer references.ObjectReferenceIndexer, log logr.Logger) *enqueueRequestsForVirtualRouterEvents {
+	return &enqueueRequestsForVirtualRouterEvents{
+		referencesIndexer: referencesIndexer,
+		log:               log,
+	}
+}
+
+var _ handler.EventHandler = (*enqueueRequestsForVirtualRouterEvents)(nil)
+
+type enqueueRequestsForVirtualRouterEvents struct {
+	referencesIndexer references.ObjectReferenceIndexer
+	log               logr.Logger
+}
+
+// Create is called in response to an create event
+func (h *enqueueRequestsForVirtualRouterEvents) Create(e event.CreateEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+// Update is called in response to an update event
+func (h *enqueueRequestsForVirtualRouterEvents) Update(e event.UpdateEvent, queue workqueue.RateLimitingInterface) {
+	// VirtualService reconcile depends on virtualRouter is active or not.
+	// so we only need to trigger VirtualService reconcile if virtualRouter's active status changed.
+	vrOld := e.ObjectOld.(*appmesh.VirtualRouter)
+	vrNew := e.ObjectNew.(*appmesh.VirtualRouter)
+
+	if virtualrouter.IsVirtualRouterActive(vrOld) != virtualrouter.IsVirtualRouterActive(vrNew) {
+		h.enqueueVirtualServicesForVirtualRouter(context.Background(), queue, vrNew)
+	}
+}
+
+// Delete is called in response to a delete event
+func (h *enqueueRequestsForVirtualRouterEvents) Delete(e event.DeleteEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+// external trigger request
+func (h *enqueueRequestsForVirtualRouterEvents) Generic(e event.GenericEvent, queue workqueue.RateLimitingInterface) {
+	// no-op
+}
+
+func (h *enqueueRequestsForVirtualRouterEvents) enqueueVirtualServicesForVirtualRouter(ctx context.Context, queue workqueue.RateLimitingInterface, vr *appmesh.VirtualRouter) {
+	vsList := &appmesh.VirtualServiceList{}
+	if err := h.referencesIndexer.Fetch(ctx, vsList, ReferenceKindVirtualRouter, k8s.NamespacedName(vr)); err != nil {
+		h.log.Error(err, "failed to enqueue virtualServices for virtualRouter events",
+			"virtualRouter", k8s.NamespacedName(vr))
+		return
+	}
+	for _, vs := range vsList.Items {
+		queue.Add(ctrl.Request{NamespacedName: k8s.NamespacedName(&vs)})
+	}
+}

--- a/pkg/virtualservice/references.go
+++ b/pkg/virtualservice/references.go
@@ -1,0 +1,33 @@
+package virtualservice
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	ReferenceKindVirtualNode   = "VirtualNode"
+	ReferenceKindVirtualRouter = "VirtualRouter"
+)
+
+func VirtualNodeReferenceIndexFunc(obj runtime.Object) []types.NamespacedName {
+	vs := obj.(*appmesh.VirtualService)
+	if vs.Spec.Provider == nil || vs.Spec.Provider.VirtualNode == nil {
+		return nil
+	}
+	vnRef := vs.Spec.Provider.VirtualNode.VirtualNodeRef
+	vnKey := references.ObjectKeyForVirtualNodeReference(vs, vnRef)
+	return []types.NamespacedName{vnKey}
+}
+
+func VirtualRouterReferenceIndexFunc(obj runtime.Object) []types.NamespacedName {
+	vs := obj.(*appmesh.VirtualService)
+	if vs.Spec.Provider == nil || vs.Spec.Provider.VirtualRouter == nil {
+		return nil
+	}
+	vrRef := vs.Spec.Provider.VirtualRouter.VirtualRouterRef
+	vrKey := references.ObjectKeyForVirtualRouterReference(vs, vrRef)
+	return []types.NamespacedName{vrKey}
+}

--- a/pkg/virtualservice/references_test.go
+++ b/pkg/virtualservice/references_test.go
@@ -1,0 +1,219 @@
+package virtualservice
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+func TestVirtualNodeReferenceIndexFunc(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want []types.NamespacedName
+	}{
+		{
+			name: "using virtualNodeProvider - with namespace",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualNode: &appmesh.VirtualNodeServiceProvider{
+								VirtualNodeRef: appmesh.VirtualNodeReference{
+									Namespace: aws.String("other-ns"),
+									Name:      "vn",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "other-ns",
+					Name:      "vn",
+				},
+			},
+		},
+		{
+			name: "using virtualNodeProvider - without namespace",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualNode: &appmesh.VirtualNodeServiceProvider{
+								VirtualNodeRef: appmesh.VirtualNodeReference{
+									Name: "vn",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "my-ns",
+					Name:      "vn",
+				},
+			},
+		},
+		{
+			name: "using virtualRouterProvider",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualRouter: &appmesh.VirtualRouterServiceProvider{
+								VirtualRouterRef: appmesh.VirtualRouterReference{
+									Namespace: aws.String("other-ns"),
+									Name:      "vr",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "using no provider",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: nil,
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := VirtualNodeReferenceIndexFunc(tt.args.obj)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVirtualRouterReferenceIndexFunc(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want []types.NamespacedName
+	}{
+		{
+			name: "using virtualRouterProvider - with namespace",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualRouter: &appmesh.VirtualRouterServiceProvider{
+								VirtualRouterRef: appmesh.VirtualRouterReference{
+									Namespace: aws.String("other-ns"),
+									Name:      "vr",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "other-ns",
+					Name:      "vr",
+				},
+			},
+		},
+		{
+			name: "using virtualRouterProvider - without namespace",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualRouter: &appmesh.VirtualRouterServiceProvider{
+								VirtualRouterRef: appmesh.VirtualRouterReference{
+									Name: "vr",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "my-ns",
+					Name:      "vr",
+				},
+			},
+		},
+		{
+			name: "using virtualNodeProvider",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: &appmesh.VirtualServiceProvider{
+							VirtualNode: &appmesh.VirtualNodeServiceProvider{
+								VirtualNodeRef: appmesh.VirtualNodeReference{
+									Namespace: aws.String("other-ns"),
+									Name:      "vn",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "using no provider",
+			args: args{
+				obj: &appmesh.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+					},
+					Spec: appmesh.VirtualServiceSpec{
+						Provider: nil,
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := VirtualRouterReferenceIndexFunc(tt.args.obj)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
1. optimize reconcile by enqueue objects when dependent changes.
   * when virtualNode turns active, enqueue all virtualService referencing it.
   * when virtualNode turns active, enqueue all virtualRouter referencing it.
   * when virtualRouter turns active, enqueue all virtualService referencing it.
2. change concurrent reconcile to 3 for all controllers
3. use golang 1.14 docker build.

## test done:
1. create virtualRouter/virtualService first(with virtualnode dependencies), and wait for it pending several minutes.
2. create virtualnode, watch that virtualRouter/virtualService got reconciled immediatly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
