### PR TITLE
two bug fix for cloudmap usage upgrade

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 	virtualNodeEndpointResolver := cloudmap.NewDefaultVirtualNodeEndpointResolver(mgr.GetClient(), ctrl.Log)
 	cloudMapInstancesCache := cloudmap.NewDefaultInstancesCache(cloud.CloudMap(), ctrl.Log, stopChan)
 	cloudMapInstancesHealthProber := cloudmap.NewDefaultInstancesHealthProber(mgr.GetClient(), cloud.CloudMap(), ctrl.Log, stopChan)
-	cloudMapInstancesReconciler := cloudmap.NewDefaultInstancesReconciler(cloud.CloudMap(), cloudMapInstancesCache, cloudMapInstancesHealthProber, ctrl.Log)
+	cloudMapInstancesReconciler := cloudmap.NewDefaultInstancesReconciler(mgr.GetClient(), cloud.CloudMap(), cloudMapInstancesCache, cloudMapInstancesHealthProber, ctrl.Log)
 	meshResManager := mesh.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), cloud.AccountID(), ctrl.Log)
 	vnResManager := virtualnode.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
 	vsResManager := virtualservice.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)

--- a/pkg/cloudmap/instances_healthprobe.go
+++ b/pkg/cloudmap/instances_healthprobe.go
@@ -79,7 +79,7 @@ type instanceProbeEntry struct {
 }
 
 func (p *defaultInstancesHealthProber) SubmitProbe(ctx context.Context, serviceID string, instances []InstanceProbe) error {
-	instancesToProbe := p.filterUnhealthyInstances(instances)
+	instancesToProbe := filterInstancesBlockedByCMHealthyReadinessGate(instances)
 	config := probeConfig{
 		serviceID: serviceID,
 		instances: instancesToProbe,
@@ -196,8 +196,8 @@ func (p *defaultInstancesHealthProber) updateInstanceProbeEntry(ctx context.Cont
 	return podHealthyConditionStatus != corev1.ConditionTrue, nil
 }
 
-// filterUnhealthyInstances returns unhealthy ones that needs to be probed
-func (p *defaultInstancesHealthProber) filterUnhealthyInstances(instances []InstanceProbe) []InstanceProbe {
+// filterInstancesBlockedByCMHealthyReadinessGate returns unhealthy ones that needs are blocked by ConditionAWSCloudMapHealthy readinessGate.
+func filterInstancesBlockedByCMHealthyReadinessGate(instances []InstanceProbe) []InstanceProbe {
 	var unhealthyInstances []InstanceProbe
 	for _, instance := range instances {
 		podHealthyCondition := k8s.GetPodCondition(instance.pod, k8s.ConditionAWSCloudMapHealthy)

--- a/pkg/cloudmap/instances_healthprobe_test.go
+++ b/pkg/cloudmap/instances_healthprobe_test.go
@@ -187,8 +187,7 @@ func Test_defaultInstancesHealthProber_filterUnhealthyInstances(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &defaultInstancesHealthProber{}
-			got := p.filterUnhealthyInstances(tt.args.instances)
+			got := filterInstancesBlockedByCMHealthyReadinessGate(tt.args.instances)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
two bug fix for cloudMap usage upgrade from old controller (<v1.0.0)
1. allow multiple virtualNode share same cloudMap service
2. unblock readinessGate if cloudMap service is created without customHealthCheck



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
