### PR TITLE
fix resource clean up issue

### DIFF
--- a/pkg/virtualnode/resource_manager.go
+++ b/pkg/virtualnode/resource_manager.go
@@ -97,6 +97,9 @@ func (m *defaultResourceManager) Cleanup(ctx context.Context, vn *appmesh.Virtua
 		return err
 	}
 	sdkVN, err := m.findSDKVirtualNode(ctx, ms, vn)
+	if err != nil {
+		return err
+	}
 	if sdkVN == nil {
 		return nil
 	}

--- a/pkg/virtualrouter/resource_manager.go
+++ b/pkg/virtualrouter/resource_manager.go
@@ -104,6 +104,9 @@ func (m *defaultResourceManager) Cleanup(ctx context.Context, vr *appmesh.Virtua
 		return err
 	}
 	sdkVR, err := m.findSDKVirtualRouter(ctx, ms, vr)
+	if err != nil {
+		return err
+	}
 	if sdkVR == nil {
 		return nil
 	}

--- a/pkg/virtualservice/resource_manager.go
+++ b/pkg/virtualservice/resource_manager.go
@@ -103,6 +103,9 @@ func (m *defaultResourceManager) Cleanup(ctx context.Context, vs *appmesh.Virtua
 		return err
 	}
 	sdkVS, err := m.findSDKVirtualService(ctx, ms, vs)
+	if err != nil {
+		return err
+	}
 	if sdkVS == nil {
 		return nil
 	}


### PR DESCRIPTION
fix resource clean up issue.
When find service get throttled, it may not be cleaned up.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
