### PR TITLE
use full-qualified url to reduce upstream dns queries in e2e tests

### DIFF
--- a/test/e2e/fishapp/dynamic_stack.go
+++ b/test/e2e/fishapp/dynamic_stack.go
@@ -965,7 +965,7 @@ func (s *DynamicStack) obtainPodToVirtualServiceConnectivityEntries(ctx context.
 			path := route.HTTPRoute.Match.Prefix
 			checkEntries = append(checkEntries, connectivityCheckEntry{
 				dstVirtualService: k8s.NamespacedName(vs),
-				dstURL:            fmt.Sprintf("http://%s:%d%s", aws.StringValue(vs.Spec.AWSName), shared.AppContainerPort, path),
+				dstURL:            fmt.Sprintf("http://%s.:%d%s", aws.StringValue(vs.Spec.AWSName), shared.AppContainerPort, path),
 			})
 		}
 	}

--- a/test/e2e/fishapp/shared/manifest_builder.go
+++ b/test/e2e/fishapp/shared/manifest_builder.go
@@ -261,7 +261,7 @@ func (b *ManifestBuilder) BuildServiceVirtualService(instanceName string) *appme
 
 func (b *ManifestBuilder) buildNodeDNSServiceDiscovery(instanceName string) *appmesh.ServiceDiscovery {
 	nodeServiceName := b.buildNodeName(instanceName)
-	nodeServiceDNS := fmt.Sprintf("%s.%s", nodeServiceName, b.Namespace)
+	nodeServiceDNS := fmt.Sprintf("%s.%s.svc.cluster.local.", nodeServiceName, b.Namespace)
 	return &appmesh.ServiceDiscovery{
 		DNS: &appmesh.DNSServiceDiscovery{
 			Hostname: nodeServiceDNS,


### PR DESCRIPTION
use full-qualified url to reduce upstream dns queries.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
