### PR TITLE
Make log level configurable, disable auth-proxy kustomize config

### DIFF
--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -12,6 +12,9 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        - containerPort: 8080
+          name: metrics-server
+          protocol: TCP
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -12,9 +12,6 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        - containerPort: 8080
-          name: metrics-server
-          protocol: TCP
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,10 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics-server
+          protocol: TCP
         resources:
           limits:
             cpu: 100m

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml

--- a/main.go
+++ b/main.go
@@ -63,10 +63,12 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var logLevel string
 	flag.StringVar(&metricsAddr, "metrics-addr", "0.0.0.0:8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&logLevel, "log-level", "info", "Set the controller manager log level - info(default), debug")
 	var injectConfig inject.Config
 	injectConfig.BindFlags()
 	flag.Parse()
@@ -75,8 +77,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: make level configurable
-	lvl := zapraw.NewAtomicLevelAt(-2)
+	lvl := zapraw.NewAtomicLevelAt(0)
+	if logLevel == "debug" {
+		lvl = zapraw.NewAtomicLevelAt(-1)
+	}
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(&lvl)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -13,7 +13,7 @@ const (
 	flagSidecarCpuRequests    = "sidecar-cpu-requests"
 	flagSidecarMemoryRequests = "sidecar-memory-requests"
 	flagPreview               = "preview"
-	flagLogLevel              = "log-level"
+	flagLogLevel              = "sidecar-log-level"
 
 	flagInitImage  = "init-image"
 	flagIgnoredIPs = "ignored-ips"

--- a/pkg/mesh/resource_manager.go
+++ b/pkg/mesh/resource_manager.go
@@ -122,7 +122,7 @@ func (m *defaultResourceManager) updateSDKMesh(ctx context.Context, sdkMS *appme
 		return sdkMS, nil
 	}
 	if !m.isSDKMeshControlledByCRDMesh(ctx, sdkMS, ms) {
-		m.log.V(2).Info("skip mesh update since it's not controlled",
+		m.log.V(1).Info("skip mesh update since it's not controlled",
 			"mesh", k8s.NamespacedName(ms),
 			"meshARN", aws.StringValue(sdkMS.Metadata.Arn),
 		)
@@ -130,7 +130,7 @@ func (m *defaultResourceManager) updateSDKMesh(ctx context.Context, sdkMS *appme
 	}
 
 	diff := cmp.Diff(desiredSDKMSSpec, actualSDKMSSpec, opts)
-	m.log.V(2).Info("meshSpec changed",
+	m.log.V(1).Info("meshSpec changed",
 		"mesh", k8s.NamespacedName(ms),
 		"actualSDKMSSpec", actualSDKMSSpec,
 		"desiredSDKMSSpec", desiredSDKMSSpec,
@@ -148,7 +148,7 @@ func (m *defaultResourceManager) updateSDKMesh(ctx context.Context, sdkMS *appme
 
 func (m *defaultResourceManager) deleteSDKMesh(ctx context.Context, sdkMS *appmeshsdk.MeshData, ms *appmesh.Mesh) error {
 	if !m.isSDKMeshOwnedByCRDMesh(ctx, sdkMS, ms) {
-		m.log.V(2).Info("skip mesh deletion since its not owned",
+		m.log.V(1).Info("skip mesh deletion since its not owned",
 			"mesh", k8s.NamespacedName(ms),
 			"meshARN", aws.StringValue(sdkMS.Metadata.Arn),
 		)

--- a/pkg/runtime/reconcile.go
+++ b/pkg/runtime/reconcile.go
@@ -14,13 +14,13 @@ func HandleReconcileError(err error, log logr.Logger) (ctrl.Result, error) {
 
 	var requeueAfterErr *RequeueAfterError
 	if errors.As(err, &requeueAfterErr) {
-		log.V(2).Info("requeue after due to error", "duration", requeueAfterErr.Duration(), "error", requeueAfterErr.Unwrap())
+		log.V(1).Info("requeue after due to error", "duration", requeueAfterErr.Duration(), "error", requeueAfterErr.Unwrap())
 		return ctrl.Result{RequeueAfter: requeueAfterErr.Duration()}, nil
 	}
 
 	var requeueError *RequeueError
 	if errors.As(err, &requeueError) {
-		log.V(2).Info("requeue due to error", "error", requeueError.Unwrap())
+		log.V(1).Info("requeue due to error", "error", requeueError.Unwrap())
 		return ctrl.Result{Requeue: true}, nil
 	}
 

--- a/pkg/virtualnode/resource_manager.go
+++ b/pkg/virtualnode/resource_manager.go
@@ -203,7 +203,7 @@ func (m *defaultResourceManager) updateSDKVirtualNode(ctx context.Context, sdkVN
 		return sdkVN, nil
 	}
 	if !m.isSDKVirtualNodeControlledByCRDVirtualNode(ctx, sdkVN, vn) {
-		m.log.V(2).Info("skip virtualNode update since it's not controlled",
+		m.log.V(1).Info("skip virtualNode update since it's not controlled",
 			"virtualNode", k8s.NamespacedName(vn),
 			"virtualNodeARN", aws.StringValue(sdkVN.Metadata.Arn),
 		)
@@ -211,7 +211,7 @@ func (m *defaultResourceManager) updateSDKVirtualNode(ctx context.Context, sdkVN
 	}
 
 	diff := cmp.Diff(desiredSDKVNSpec, actualSDKVNSpec, opts)
-	m.log.V(2).Info("virtualNodeSpec changed",
+	m.log.V(1).Info("virtualNodeSpec changed",
 		"virtualNode", k8s.NamespacedName(vn),
 		"actualSDKVNSpec", actualSDKVNSpec,
 		"desiredSDKVNSpec", desiredSDKVNSpec,
@@ -231,7 +231,7 @@ func (m *defaultResourceManager) updateSDKVirtualNode(ctx context.Context, sdkVN
 
 func (m *defaultResourceManager) deleteSDKVirtualNode(ctx context.Context, sdkVN *appmeshsdk.VirtualNodeData, ms *appmesh.Mesh, vn *appmesh.VirtualNode) error {
 	if !m.isSDKVirtualNodeOwnedByCRDVirtualNode(ctx, sdkVN, vn) {
-		m.log.V(2).Info("skip mesh virtualNode since its not owned",
+		m.log.V(1).Info("skip mesh virtualNode since its not owned",
 			"virtualNode", k8s.NamespacedName(vn),
 			"virtualNodeARN", aws.StringValue(sdkVN.Metadata.Arn),
 		)

--- a/pkg/virtualrouter/resource_manager.go
+++ b/pkg/virtualrouter/resource_manager.go
@@ -211,7 +211,7 @@ func (m *defaultResourceManager) updateSDKVirtualRouter(ctx context.Context, sdk
 		return sdkVR, nil
 	}
 	if !m.isSDKVirtualRouterControlledByCRDVirtualRouter(ctx, sdkVR, vr) {
-		m.log.V(2).Info("skip virtualRouter update since it's not controlled",
+		m.log.V(1).Info("skip virtualRouter update since it's not controlled",
 			"virtualRouter", k8s.NamespacedName(vr),
 			"virtualRouterARN", aws.StringValue(sdkVR.Metadata.Arn),
 		)
@@ -219,7 +219,7 @@ func (m *defaultResourceManager) updateSDKVirtualRouter(ctx context.Context, sdk
 	}
 
 	diff := cmp.Diff(desiredSDKVRSpec, actualSDKVRSpec, opts)
-	m.log.V(2).Info("virtualRouterSpec changed",
+	m.log.V(1).Info("virtualRouterSpec changed",
 		"virtualRouter", k8s.NamespacedName(vr),
 		"actualSDKVRSpec", actualSDKVRSpec,
 		"desiredSDKVRSpec", desiredSDKVRSpec,
@@ -239,7 +239,7 @@ func (m *defaultResourceManager) updateSDKVirtualRouter(ctx context.Context, sdk
 
 func (m *defaultResourceManager) deleteSDKVirtualRouter(ctx context.Context, sdkVR *appmeshsdk.VirtualRouterData, vr *appmesh.VirtualRouter) error {
 	if !m.isSDKVirtualRouterOwnedByCRDVirtualRouter(ctx, sdkVR, vr) {
-		m.log.V(2).Info("skip virtualRouter deletion since its not owned",
+		m.log.V(1).Info("skip virtualRouter deletion since its not owned",
 			"virtualRouter", k8s.NamespacedName(vr),
 			"virtualRouterARN", aws.StringValue(sdkVR.Metadata.Arn),
 		)

--- a/pkg/virtualrouter/routes_manager.go
+++ b/pkg/virtualrouter/routes_manager.go
@@ -173,7 +173,7 @@ func (m *defaultRoutesManager) updateSDKRoute(ctx context.Context, sdkRoute *app
 		return sdkRoute, nil
 	}
 	diff := cmp.Diff(desiredSDKRouteSpec, actualSDKRouteSpec, opts)
-	m.log.V(2).Info("routeSpec changed",
+	m.log.V(1).Info("routeSpec changed",
 		"virtualRouter", k8s.NamespacedName(vr),
 		"route", route.Name,
 		"actualSDKRouteSpec", actualSDKRouteSpec,

--- a/pkg/virtualservice/resource_manager.go
+++ b/pkg/virtualservice/resource_manager.go
@@ -234,7 +234,7 @@ func (m *defaultResourceManager) updateSDKVirtualService(ctx context.Context, sd
 		return sdkVS, nil
 	}
 	if !m.isSDKVirtualServiceControlledByCRDVirtualService(ctx, sdkVS, vs) {
-		m.log.V(2).Info("skip virtualService update since it's not controlled",
+		m.log.V(1).Info("skip virtualService update since it's not controlled",
 			"virtualService", k8s.NamespacedName(vs),
 			"virtualServiceARN", aws.StringValue(sdkVS.Metadata.Arn),
 		)
@@ -242,7 +242,7 @@ func (m *defaultResourceManager) updateSDKVirtualService(ctx context.Context, sd
 	}
 
 	diff := cmp.Diff(desiredSDKVSSpec, actualSDKVSSpec, opts)
-	m.log.V(2).Info("virtualServiceSpec changed",
+	m.log.V(1).Info("virtualServiceSpec changed",
 		"virtualService", k8s.NamespacedName(vs),
 		"actualSDKVRSpec", actualSDKVSSpec,
 		"desiredSDKVRSpec", desiredSDKVSSpec,
@@ -262,7 +262,7 @@ func (m *defaultResourceManager) updateSDKVirtualService(ctx context.Context, sd
 
 func (m *defaultResourceManager) deleteSDKVirtualService(ctx context.Context, sdkVS *appmeshsdk.VirtualServiceData, vs *appmesh.VirtualService) error {
 	if !m.isSDKVirtualServiceOwnedByCRDVirtualService(ctx, sdkVS, vs) {
-		m.log.V(2).Info("skip virtualService deletion since its not owned",
+		m.log.V(1).Info("skip virtualService deletion since its not owned",
 			"virtualService", k8s.NamespacedName(vs),
 			"virtualServiceARN", aws.StringValue(sdkVS.Metadata.Arn),
 		)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add the log-level command line option
Comment out auth-proxy from kustomize config
Register metrics port 8080

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
