### PR TITLE
adjust crd display settings

### DIFF
--- a/apis/appmesh/v1beta2/gatewayroute_types.go
+++ b/apis/appmesh/v1beta2/gatewayroute_types.go
@@ -131,7 +131,7 @@ type GatewayRouteCondition struct {
 
 // GatewayRouteStatus defines the observed state of GatewayRoute
 type GatewayRouteStatus struct {
-	// GatewayRouteARNs is a map of AppMesh GatewayRoute objects' Amazon Resource Names, indexed by gatewayRoute name.
+	// GatewayRouteARN is the AppMesh GatewayRoute object's Amazon Resource Name
 	// +optional
 	GatewayRouteARN *string `json:"gatewayRouteARN,omitempty"`
 	// The current GatewayRoute status.
@@ -144,7 +144,10 @@ type GatewayRouteStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ARN",type="string",JSONPath=".status.gatewayRouteARN",description="The AppMesh GatewayRoute object's Amazon Resource Name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // GatewayRoute is the Schema for the gatewayroutes API
 type GatewayRoute struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/appmesh/v1beta2/mesh_types.go
+++ b/apis/appmesh/v1beta2/mesh_types.go
@@ -100,6 +100,8 @@ type MeshStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ARN",type="string",JSONPath=".status.meshARN",description="The AppMesh Mesh object's Amazon Resource Name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // Mesh is the Schema for the meshes API
 type Mesh struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/appmesh/v1beta2/virtualgateway_types.go
+++ b/apis/appmesh/v1beta2/virtualgateway_types.go
@@ -283,7 +283,10 @@ type VirtualGatewayStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ARN",type="string",JSONPath=".status.virtualGatewayARN",description="The AppMesh VirtualGateway object's Amazon Resource Name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // VirtualGateway is the Schema for the virtualgateways API
 type VirtualGateway struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/appmesh/v1beta2/virtualnode_types.go
+++ b/apis/appmesh/v1beta2/virtualnode_types.go
@@ -337,7 +337,10 @@ type VirtualNodeStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ARN",type="string",JSONPath=".status.virtualNodeARN",description="The AppMesh VirtualNode object's Amazon Resource Name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // VirtualNode is the Schema for the virtualnodes API
 type VirtualNode struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/appmesh/v1beta2/virtualrouter_types.go
+++ b/apis/appmesh/v1beta2/virtualrouter_types.go
@@ -352,7 +352,10 @@ type VirtualRouterStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ARN",type="string",JSONPath=".status.virtualRouterARN",description="The AppMesh VirtualRouter object's Amazon Resource Name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // VirtualRouter is the Schema for the virtualrouters API
 type VirtualRouter struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/appmesh/v1beta2/virtualservice_types.go
+++ b/apis/appmesh/v1beta2/virtualservice_types.go
@@ -101,7 +101,10 @@ type VirtualServiceStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ARN",type="string",JSONPath=".status.virtualServiceARN",description="The AppMesh VirtualService object's Amazon Resource Name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // VirtualService is the Schema for the virtualservices API
 type VirtualService struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/appmesh.k8s.aws_gatewayroutes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_gatewayroutes.yaml
@@ -8,8 +8,18 @@ metadata:
   creationTimestamp: null
   name: gatewayroutes.appmesh.k8s.aws
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.gatewayRouteARN
+    description: The AppMesh GatewayRoute object's Amazon Resource Name
+    name: ARN
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: appmesh.k8s.aws
   names:
+    categories:
+    - all
     kind: GatewayRoute
     listKind: GatewayRouteList
     plural: gatewayroutes
@@ -272,8 +282,8 @@ spec:
                 type: object
               type: array
             gatewayRouteARN:
-              description: GatewayRouteARNs is a map of AppMesh GatewayRoute objects'
-                Amazon Resource Names, indexed by gatewayRoute name.
+              description: GatewayRouteARN is the AppMesh GatewayRoute object's Amazon
+                Resource Name
               type: string
             observedGeneration:
               description: The generation observed by the GatewayRoute controller.

--- a/config/crd/bases/appmesh.k8s.aws_meshes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_meshes.yaml
@@ -8,6 +8,14 @@ metadata:
   creationTimestamp: null
   name: meshes.appmesh.k8s.aws
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.meshARN
+    description: The AppMesh Mesh object's Amazon Resource Name
+    name: ARN
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: appmesh.k8s.aws
   names:
     kind: Mesh

--- a/config/crd/bases/appmesh.k8s.aws_virtualgateways.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualgateways.yaml
@@ -8,8 +8,18 @@ metadata:
   creationTimestamp: null
   name: virtualgateways.appmesh.k8s.aws
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.virtualGatewayARN
+    description: The AppMesh VirtualGateway object's Amazon Resource Name
+    name: ARN
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: appmesh.k8s.aws
   names:
+    categories:
+    - all
     kind: VirtualGateway
     listKind: VirtualGatewayList
     plural: virtualgateways

--- a/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
@@ -8,8 +8,18 @@ metadata:
   creationTimestamp: null
   name: virtualnodes.appmesh.k8s.aws
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.virtualNodeARN
+    description: The AppMesh VirtualNode object's Amazon Resource Name
+    name: ARN
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: appmesh.k8s.aws
   names:
+    categories:
+    - all
     kind: VirtualNode
     listKind: VirtualNodeList
     plural: virtualnodes

--- a/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
@@ -8,8 +8,18 @@ metadata:
   creationTimestamp: null
   name: virtualrouters.appmesh.k8s.aws
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.virtualRouterARN
+    description: The AppMesh VirtualRouter object's Amazon Resource Name
+    name: ARN
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: appmesh.k8s.aws
   names:
+    categories:
+    - all
     kind: VirtualRouter
     listKind: VirtualRouterList
     plural: virtualrouters

--- a/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
@@ -8,8 +8,18 @@ metadata:
   creationTimestamp: null
   name: virtualservices.appmesh.k8s.aws
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.virtualServiceARN
+    description: The AppMesh VirtualService object's Amazon Resource Name
+    name: ARN
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: appmesh.k8s.aws
   names:
+    categories:
+    - all
     kind: VirtualService
     listKind: VirtualServiceList
     plural: virtualservices


### PR DESCRIPTION
adjust crd display settings:
1. make them to become "all" category(except for mesh). (kubectl get all works)
    1. mesh is not added to "all", otherwise it will alway show up even list a specific namespace
2. add arn and age to kubectl get
```
kubectl get mesh
NAME                  ARN                                                               AGE
m00nf1sh-dev-868eac   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac   2d1h
```
```
kubectl get all -n appmesh-bacf1c

NAME                                      ARN                                                                                                      AGE
virtualrouter.appmesh.k8s.aws/service-0   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualRouter/service-0_appmesh-bacf1c   2d1h
virtualrouter.appmesh.k8s.aws/service-1   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualRouter/service-1_appmesh-bacf1c   2d1h
virtualrouter.appmesh.k8s.aws/service-2   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualRouter/service-2_appmesh-bacf1c   2d1h
virtualrouter.appmesh.k8s.aws/service-3   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualRouter/service-3_appmesh-bacf1c   2d1h
virtualrouter.appmesh.k8s.aws/service-4   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualRouter/service-4_appmesh-bacf1c   2d1h

NAME                                       ARN                                                                                                                         AGE
virtualservice.appmesh.k8s.aws/service-0   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualService/service-0.appmesh-bacf1c.svc.cluster.local   2d1h
virtualservice.appmesh.k8s.aws/service-1   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualService/service-1.appmesh-bacf1c.svc.cluster.local   2d1h
virtualservice.appmesh.k8s.aws/service-2   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualService/service-2.appmesh-bacf1c.svc.cluster.local   2d1h
virtualservice.appmesh.k8s.aws/service-3   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualService/service-3.appmesh-bacf1c.svc.cluster.local   2d1h
virtualservice.appmesh.k8s.aws/service-4   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualService/service-4.appmesh-bacf1c.svc.cluster.local   2d1h

NAME                                 ARN                                                                                                 AGE
virtualnode.appmesh.k8s.aws/node-0   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualNode/node-0_appmesh-bacf1c   2d1h
virtualnode.appmesh.k8s.aws/node-1   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualNode/node-1_appmesh-bacf1c   2d1h
virtualnode.appmesh.k8s.aws/node-2   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualNode/node-2_appmesh-bacf1c   2d1h
virtualnode.appmesh.k8s.aws/node-3   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualNode/node-3_appmesh-bacf1c   2d1h
virtualnode.appmesh.k8s.aws/node-4   arn:aws:appmesh:us-west-2:283511030707:mesh/m00nf1sh-dev-868eac/virtualNode/node-4_appmesh-bacf1c   2d1h
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
