### PR TITLE
Check for ns labels to determine sidecar injection

### DIFF
--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patchesStrategicMerge:
+- pod_mutator_patch.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -120,7 +120,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-v1-pod
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: mpod.appmesh.k8s.aws
   rules:
   - apiGroups:

--- a/config/webhook/pod_mutator_patch.yaml
+++ b/config/webhook/pod_mutator_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+  - name: mpod.appmesh.k8s.aws
+    namespaceSelector:
+      matchLabels:
+        appmesh.k8s.aws/sidecarInjectorWebhook: enabled

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -140,7 +140,7 @@ func (m *SidecarInjector) determineSidecarInjectMode(ctx context.Context, pod *c
 		if err := m.k8sClient.Get(ctx, types.NamespacedName{Name: req.Namespace}, objectNS); err != nil {
 			return sidecarInjectModeUnspecified, err
 		}
-		if v, ok := objectNS.ObjectMeta.Annotations[AppMeshSidecarInjectAnnotation]; ok {
+		if v, ok := objectNS.Labels[AppMeshSidecarInjectAnnotation]; ok {
 			sidecarInjectAnnotation = v
 		}
 	}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -5,10 +5,8 @@ import (
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
-	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/webhook"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
@@ -42,7 +40,7 @@ func NewSidecarInjector(cfg Config, awsRegion string,
 }
 
 func (m *SidecarInjector) Inject(ctx context.Context, pod *corev1.Pod) error {
-	injectMode, err := m.determineSidecarInjectMode(ctx, pod)
+	injectMode, err := m.determineSidecarInjectMode(pod)
 	if err != nil {
 		return errors.Wrap(err, "failed to determine sidecarInject mode")
 	}
@@ -129,21 +127,18 @@ const (
 	sidecarInjectModeUnspecified = "unspecified"
 )
 
-func (m *SidecarInjector) determineSidecarInjectMode(ctx context.Context, pod *corev1.Pod) (sidecarInjectMode, error) {
-	var sidecarInjectAnnotation string
+func (m *SidecarInjector) determineSidecarInjectMode(pod *corev1.Pod) (sidecarInjectMode, error) {
+	// The injector webhook uses the namespaceSelector to filter which requests
+	// are intercepted. This makes sure all the requests sent to the injector have
+	// have sidecar injection enabled based on the label defined by the user.
+	// That's why we enable the sidecar inection by default here.
+	// Namespace behavior can be overriden by pod level inject annotation
+	sidecarInjectAnnotation := sidecarInjectModeEnabled
+
 	if v, ok := pod.ObjectMeta.Annotations[AppMeshSidecarInjectAnnotation]; ok {
 		sidecarInjectAnnotation = v
-	} else {
-		// see https://github.com/kubernetes/kubernetes/issues/88282 and https://github.com/kubernetes/kubernetes/issues/76680
-		req := webhook.ContextGetAdmissionRequest(ctx)
-		objectNS := &corev1.Namespace{}
-		if err := m.k8sClient.Get(ctx, types.NamespacedName{Name: req.Namespace}, objectNS); err != nil {
-			return sidecarInjectModeUnspecified, err
-		}
-		if v, ok := objectNS.Labels[AppMeshSidecarInjectAnnotation]; ok {
-			sidecarInjectAnnotation = v
-		}
 	}
+
 	switch strings.ToLower(sidecarInjectAnnotation) {
 	case "enabled":
 		return sidecarInjectModeEnabled, nil

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -259,7 +259,7 @@ func TestSidecarInjector_determineSidecarInjectMode(t *testing.T) {
 	nsEnabledSidecarInject := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "awesome-ns",
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				"appmesh.k8s.aws/sidecarInjectorWebhook": "enabled",
 			},
 		},
@@ -267,15 +267,15 @@ func TestSidecarInjector_determineSidecarInjectMode(t *testing.T) {
 	nsDisabledSidecarInject := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "awesome-ns",
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				"appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
 			},
 		},
 	}
 	nsUnspecifiedSidecarInject := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "awesome-ns",
-			Annotations: map[string]string{},
+			Name:   "awesome-ns",
+			Labels: map[string]string{},
 		},
 	}
 	podEnabledSidecarInject := &corev1.Pod{

--- a/webhooks/core/pod_mutator.go
+++ b/webhooks/core/pod_mutator.go
@@ -41,7 +41,7 @@ func (m *podMutator) MutateUpdate(ctx context.Context, obj runtime.Object, oldOb
 	return obj, nil
 }
 
-// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create,versions=v1,name=mpod.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mpod.appmesh.k8s.aws
 
 func (m *podMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutatePod, webhook.MutatingWebhookForMutator(m))


### PR DESCRIPTION
*Description of changes:*
To determine sidecar injection eligibility, we were matching on annotations instead of labels. We would see random injection misses when launching large number of pods at the same time. This was due to a race condition when VirtualNode would get created after it's corresponding pod.

This change introduces `namespaceSelector ` in the mutate webhook config to send label filtered requests to the injector

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
