### PR TITLE
Allow overlapping virtual node names/labels across namespaces

### DIFF
--- a/pkg/virtualnode/membership_designator.go
+++ b/pkg/virtualnode/membership_designator.go
@@ -34,7 +34,7 @@ type membershipDesignator struct {
 
 func (d *membershipDesignator) Designate(ctx context.Context, pod *corev1.Pod) (*appmesh.VirtualNode, error) {
 	vnList := appmesh.VirtualNodeList{}
-	if err := d.k8sClient.List(ctx, &vnList); err != nil {
+	if err := d.k8sClient.List(ctx, &vnList, client.InNamespace(pod.Namespace)); err != nil {
 		return nil, errors.Wrap(err, "failed to list VirtualNodes in cluster")
 	}
 


### PR DESCRIPTION
*Description of changes:*
If two different namespaces have pods, virtual nodes with overlapping labels, the current controller would block creation of the pod as it would match against multiple virtual nodes. This not the desired behavior. We should be able to handle overlapping resource names, labels across namespaces. This change fixes the issue by filtering the virtual node list based on pod namespace


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
