### PR TITLE
add version support to AWS SDK user-agent

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -28,6 +28,7 @@ type Cloud interface {
 // NewCloud constructs new Cloud implementation.
 func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, error) {
 	sess := session.Must(session.NewSession(aws.NewConfig()))
+	injectUserAgent(&sess.Handlers)
 	if cfg.ThrottleConfig != nil {
 		throttler := throttle.NewThrottler(cfg.ThrottleConfig)
 		throttler.InjectHandlers(&sess.Handlers)

--- a/pkg/aws/user_agent.go
+++ b/pkg/aws/user_agent.go
@@ -1,0 +1,17 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/version"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+const appName = "appmesh.k8s.aws"
+
+// injectUserAgent will inject app specific user-agent into awsSDK
+func injectUserAgent(handlers *request.Handlers) {
+	handlers.Build.PushFrontNamed(request.NamedHandler{
+		Name: fmt.Sprintf("%s/user-agent", appName),
+		Fn:   request.MakeAddToUserAgentHandler(appName, version.GitVersion),
+	})
+}

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -2,7 +2,7 @@ package inject
 
 import (
 	"errors"
-	"flag"
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -68,42 +68,42 @@ func multipleTracer(config *Config) bool {
 	return (j && d) || (d && x) || (j && x)
 }
 
-func (cfg *Config) BindFlags() {
-	flag.BoolVar(&cfg.EnableIAMForServiceAccounts, flagEnableIAMForServiceAccounts, true,
+func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&cfg.EnableIAMForServiceAccounts, flagEnableIAMForServiceAccounts, true,
 		`If enabled, a fsGroup: 1337 will be injected in the absence of it within pod securityContext`)
-	flag.BoolVar(&cfg.EnableECRSecret, flagEnableECRSecret, false,
+	fs.BoolVar(&cfg.EnableECRSecret, flagEnableECRSecret, false,
 		"If enabled, 'appmesh-ecr-secret' secret will be injected in the absence of it within pod imagePullSecrets")
-	flag.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.3.0-prod",
+	fs.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.3.0-prod",
 		"Envoy sidecar container image.")
-	flag.StringVar(&cfg.SidecarCpu, flagSidecarCpuRequests, "10m",
+	fs.StringVar(&cfg.SidecarCpu, flagSidecarCpuRequests, "10m",
 		"Envoy sidecar CPU resources requests.")
-	flag.StringVar(&cfg.SidecarMemory, flagSidecarMemoryRequests, "32Mi",
+	fs.StringVar(&cfg.SidecarMemory, flagSidecarMemoryRequests, "32Mi",
 		"Envoy sidecar memory resources requests.")
-	flag.BoolVar(&cfg.Preview, flagPreview, false,
+	fs.BoolVar(&cfg.Preview, flagPreview, false,
 		"Enable preview channel")
-	flag.StringVar(&cfg.LogLevel, flagLogLevel, "info",
+	fs.StringVar(&cfg.LogLevel, flagLogLevel, "info",
 		"AWS App Mesh envoy log level")
-	flag.StringVar(&cfg.InitImage, flagInitImage, "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
+	fs.StringVar(&cfg.InitImage, flagInitImage, "111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v2",
 		"Init container image.")
-	flag.StringVar(&cfg.IgnoredIPs, flagIgnoredIPs, "169.254.169.254",
+	fs.StringVar(&cfg.IgnoredIPs, flagIgnoredIPs, "169.254.169.254",
 		"Init container ignored IPs.")
-	flag.BoolVar(&cfg.EnableJaegerTracing, flagEnableJaegerTracing, false,
+	fs.BoolVar(&cfg.EnableJaegerTracing, flagEnableJaegerTracing, false,
 		"Enable Envoy Jaeger tracing")
-	flag.StringVar(&cfg.JaegerAddress, flagJaegerAddress, "appmesh-jaeger.appmesh-system",
+	fs.StringVar(&cfg.JaegerAddress, flagJaegerAddress, "appmesh-jaeger.appmesh-system",
 		"Jaeger address")
-	flag.StringVar(&cfg.JaegerPort, flagJaegerPort, "9411",
+	fs.StringVar(&cfg.JaegerPort, flagJaegerPort, "9411",
 		"Jaeger port")
-	flag.BoolVar(&cfg.EnableDatadogTracing, flagEnableDatadogTracing, false,
+	fs.BoolVar(&cfg.EnableDatadogTracing, flagEnableDatadogTracing, false,
 		"Enable Envoy Datadog tracing")
-	flag.StringVar(&cfg.DatadogAddress, flagDatadogAddress, "datadog.appmesh-system",
+	fs.StringVar(&cfg.DatadogAddress, flagDatadogAddress, "datadog.appmesh-system",
 		"Datadog Agent address")
-	flag.StringVar(&cfg.DatadogPort, flagDatadogPort, "8126",
+	fs.StringVar(&cfg.DatadogPort, flagDatadogPort, "8126",
 		"Datadog Agent tracing port")
-	flag.BoolVar(&cfg.EnableXrayTracing, flagEnableXrayTracing, false,
+	fs.BoolVar(&cfg.EnableXrayTracing, flagEnableXrayTracing, false,
 		"Enable Envoy X-Ray tracing integration and injects xray-daemon as sidecar")
-	flag.BoolVar(&cfg.EnableStatsTags, flagEnableStatsTags, false,
+	fs.BoolVar(&cfg.EnableStatsTags, flagEnableStatsTags, false,
 		"Enable Envoy to tag stats")
-	flag.BoolVar(&cfg.EnableStatsD, flagEnableStatsD, false,
+	fs.BoolVar(&cfg.EnableStatsD, flagEnableStatsD, false,
 		"If enabled, Envoy will send DogStatsD metrics to 127.0.0.1:8125")
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,22 @@
+package version
+
+import (
+	"encoding/json"
+)
+
+var (
+	GitVersion string
+	GitCommit  string
+	BuildDate  string
+)
+
+// PrintableVersion returns formatted version string
+func PrintableVersion() string {
+	versionData := map[string]string{
+		"GitVersion": GitVersion,
+		"GitCommit":  GitCommit,
+		"BuildDate":  BuildDate,
+	}
+	payload, _ := json.Marshal(versionData)
+	return string(payload)
+}


### PR DESCRIPTION
Multiple changes in this PR:
1. add version support to AWS SDK user-agent.
```
PUT /latest/api/token HTTP/1.1
Host: 169.254.169.254
User-Agent: appmesh.k8s.aws/v1.1.1-1-g3ceb1ce-dirty aws-sdk-go/1.30.7 (go1.14.2; linux; amd64)
Content-Length: 0
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 21600
Accept-Encoding: gzip
```
2. prints version at start up
```
{"level":"info","ts":1589997167.4042416,"logger":"setup","msg":"version","GitVersion":"v1.1.1-1-g3ceb1ce-dirty","GitCommit":"3ceb1ced4c6f5075902cea11e3faf8c657591941","BuildDate":"2020-05-20T17:48:56+0000"}
```
3. use prod zap config
4. expose aws configuration flags.
5. switch to use amazonlinux:2 base image per amazon's policy 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
