### PR TITLE
adjust aws default limits

### DIFF
--- a/pkg/aws/throttle/defaults.go
+++ b/pkg/aws/throttle/defaults.go
@@ -65,19 +65,24 @@ func NewDefaultServiceOperationsThrottleConfig() *ServiceOperationsThrottleConfi
 					burst:        80,
 				},
 				{
+					operationPtn: regexp.MustCompile("^GetInstance"),
+					r:            rate.Limit(16),
+					burst:        80,
+				},
+				{
 					operationPtn: regexp.MustCompile("^GetOperation"),
 					r:            rate.Limit(4),
 					burst:        40,
 				},
 				{
+					operationPtn: regexp.MustCompile("^GetInstancesHealthStatus"),
+					r:            rate.Limit(80),
+					burst:        80,
+				},
+				{
 					operationPtn: regexp.MustCompile("^UpdateInstanceCustomHealthStatus"),
 					r:            rate.Limit(240),
 					burst:        240,
-				},
-				{
-					operationPtn: regexp.MustCompile("^DiscoverInstances"),
-					r:            rate.Limit(400),
-					burst:        80,
 				},
 			},
 		},


### PR DESCRIPTION
Add limits for GetInstancesHealthStatus & GetInstance
remove limits for DiscoveryInstances

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
