### PR TITLE
Add app mesh API override for aws-sdk-go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@ bin
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Ignore vendored files
 
-!vendor/**/zz_generated.*
+vendor
 
 # editor and IDE paraphernalia
 .idea

--- a/appmesh_models_override/api-2.json
+++ b/appmesh_models_override/api-2.json
@@ -1,0 +1,5688 @@
+{
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2019-01-25",
+    "endpointPrefix": "appmesh",
+    "jsonVersion": "1.1",
+    "protocol": "rest-json",
+    "serviceFullName": "AWS App Mesh",
+    "serviceId": "App Mesh",
+    "signatureVersion": "v4",
+    "signingName": "appmesh",
+    "uid": "appmesh-2019-01-25"
+  },
+  "documentation": null,
+  "operations": {
+    "CreateGatewayRoute": {
+      "name": "CreateGatewayRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateGatewayRouteInput"
+      },
+      "output": {
+        "shape": "CreateGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateMesh": {
+      "name": "CreateMesh",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateMeshInput"
+      },
+      "output": {
+        "shape": "CreateMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateRoute": {
+      "name": "CreateRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateRouteInput"
+      },
+      "output": {
+        "shape": "CreateRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualGateway": {
+      "name": "CreateVirtualGateway",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "CreateVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualNode": {
+      "name": "CreateVirtualNode",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualNodeInput"
+      },
+      "output": {
+        "shape": "CreateVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualRouter": {
+      "name": "CreateVirtualRouter",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualRouterInput"
+      },
+      "output": {
+        "shape": "CreateVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualService": {
+      "name": "CreateVirtualService",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualServiceInput"
+      },
+      "output": {
+        "shape": "CreateVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteGatewayRoute": {
+      "name": "DeleteGatewayRoute",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteGatewayRouteInput"
+      },
+      "output": {
+        "shape": "DeleteGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteMesh": {
+      "name": "DeleteMesh",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteMeshInput"
+      },
+      "output": {
+        "shape": "DeleteMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteMeshPolicy": {
+      "name": "DeleteMeshPolicy",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshPolicy",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteMeshPolicyInput"
+      },
+      "output": {
+        "shape": "DeleteMeshPolicyOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteRoute": {
+      "name": "DeleteRoute",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteRouteInput"
+      },
+      "output": {
+        "shape": "DeleteRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualGateway": {
+      "name": "DeleteVirtualGateway",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualNode": {
+      "name": "DeleteVirtualNode",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualNodeInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualRouter": {
+      "name": "DeleteVirtualRouter",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualRouterInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualService": {
+      "name": "DeleteVirtualService",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualServiceInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DescribeGatewayRoute": {
+      "name": "DescribeGatewayRoute",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeGatewayRouteInput"
+      },
+      "output": {
+        "shape": "DescribeGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeMesh": {
+      "name": "DescribeMesh",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeMeshInput"
+      },
+      "output": {
+        "shape": "DescribeMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeRoute": {
+      "name": "DescribeRoute",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeRouteInput"
+      },
+      "output": {
+        "shape": "DescribeRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualGateway": {
+      "name": "DescribeVirtualGateway",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualNode": {
+      "name": "DescribeVirtualNode",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualNodeInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualRouter": {
+      "name": "DescribeVirtualRouter",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualRouterInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualService": {
+      "name": "DescribeVirtualService",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualServiceInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "GetMeshPolicy": {
+      "name": "GetMeshPolicy",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshPolicy",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "GetMeshPolicyInput"
+      },
+      "output": {
+        "shape": "GetMeshPolicyOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListGatewayRoutes": {
+      "name": "ListGatewayRoutes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListGatewayRoutesInput"
+      },
+      "output": {
+        "shape": "ListGatewayRoutesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListMeshes": {
+      "name": "ListMeshes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListMeshesInput"
+      },
+      "output": {
+        "shape": "ListMeshesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListRoutes": {
+      "name": "ListRoutes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListRoutesInput"
+      },
+      "output": {
+        "shape": "ListRoutesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListTagsForResource": {
+      "name": "ListTagsForResource",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/tags",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListTagsForResourceInput"
+      },
+      "output": {
+        "shape": "ListTagsForResourceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualGateways": {
+      "name": "ListVirtualGateways",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualGatewaysInput"
+      },
+      "output": {
+        "shape": "ListVirtualGatewaysOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualNodes": {
+      "name": "ListVirtualNodes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualNodesInput"
+      },
+      "output": {
+        "shape": "ListVirtualNodesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualRouters": {
+      "name": "ListVirtualRouters",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualRoutersInput"
+      },
+      "output": {
+        "shape": "ListVirtualRoutersOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualServices": {
+      "name": "ListVirtualServices",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualServicesInput"
+      },
+      "output": {
+        "shape": "ListVirtualServicesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "PutMeshPolicy": {
+      "name": "PutMeshPolicy",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshPolicy",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "PutMeshPolicyInput"
+      },
+      "output": {
+        "shape": "PutMeshPolicyOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "TagResource": {
+      "name": "TagResource",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/tag",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "TagResourceInput"
+      },
+      "output": {
+        "shape": "TagResourceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        },
+        {
+          "shape": "TooManyTagsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UntagResource": {
+      "name": "UntagResource",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/untag",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UntagResourceInput"
+      },
+      "output": {
+        "shape": "UntagResourceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateGatewayRoute": {
+      "name": "UpdateGatewayRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateGatewayRouteInput"
+      },
+      "output": {
+        "shape": "UpdateGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateMesh": {
+      "name": "UpdateMesh",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateMeshInput"
+      },
+      "output": {
+        "shape": "UpdateMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateRoute": {
+      "name": "UpdateRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateRouteInput"
+      },
+      "output": {
+        "shape": "UpdateRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualGateway": {
+      "name": "UpdateVirtualGateway",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualNode": {
+      "name": "UpdateVirtualNode",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualNodeInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualRouter": {
+      "name": "UpdateVirtualRouter",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualRouterInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualService": {
+      "name": "UpdateVirtualService",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualServiceInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    }
+  },
+  "shapes": {
+    "VirtualRouterListener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "portMapping": {
+          "shape": "PortMapping"
+        }
+      }
+    },
+    "VirtualRouterStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "TagKeyList": {
+      "type": "list",
+      "member": {
+        "shape": "TagKey"
+      },
+      "min": 0,
+      "max": 50
+    },
+    "GrpcRetryPolicy": {
+      "type": "structure",
+      "required": [
+        "maxRetries",
+        "perRetryTimeout"
+      ],
+      "members": {
+        "grpcRetryEvents": {
+          "shape": "GrpcRetryPolicyEvents"
+        },
+        "httpRetryEvents": {
+          "shape": "HttpRetryPolicyEvents"
+        },
+        "maxRetries": {
+          "shape": "MaxRetries"
+        },
+        "perRetryTimeout": {
+          "shape": "Duration"
+        },
+        "tcpRetryEvents": {
+          "shape": "TcpRetryPolicyEvents"
+        }
+      }
+    },
+    "CreateVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData"
+        }
+      },
+      "payload": "virtualNode"
+    },
+    "VirtualGatewaySdsSecretName": {
+      "type": "string"
+    },
+    "Logging": {
+      "type": "structure",
+      "members": {
+        "accessLog": {
+          "shape": "AccessLog"
+        }
+      }
+    },
+    "Long": {
+      "type": "long",
+      "box": true
+    },
+    "UpdateVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData"
+        }
+      },
+      "payload": "virtualRouter"
+    },
+    "ListVirtualRoutersOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouters"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualRouters": {
+          "shape": "VirtualRouterList"
+        }
+      }
+    },
+    "CreateVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "tags": {
+          "shape": "TagList"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "UpdateVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "ListenerTlsSdsCertificate": {
+      "type": "structure",
+      "required": [
+        "secretName",
+        "source"
+      ],
+      "members": {
+        "secretName": {
+          "shape": "SdsSecretName"
+        },
+        "source": {
+          "shape": "SdsSource"
+        }
+      }
+    },
+    "PutMeshPolicyOutput": {
+      "type": "structure",
+      "members": { }
+    },
+    "ResourceMetadata": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshOwner",
+        "resourceOwner",
+        "uid",
+        "version"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "uid": {
+          "shape": "String"
+        },
+        "version": {
+          "shape": "Long"
+        }
+      }
+    },
+    "ResourceInUseException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "ResourceInUseException",
+        "httpStatusCode": 409,
+        "senderFault": true
+      }
+    },
+    "UpdateVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData"
+        }
+      },
+      "payload": "virtualNode"
+    },
+    "ListRoutesOutput": {
+      "type": "structure",
+      "required": [
+        "routes"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "routes": {
+          "shape": "RouteList"
+        }
+      }
+    },
+    "VirtualServiceBackend": {
+      "type": "structure",
+      "required": [
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientPolicy": {
+          "shape": "ClientPolicy"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "BadRequestException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "BadRequestException",
+        "httpStatusCode": 400,
+        "senderFault": true
+      }
+    },
+    "HttpGatewayRouteMatch": {
+      "type": "structure",
+      "required": [
+        "prefix"
+      ],
+      "members": {
+        "prefix": {
+          "shape": "String"
+        }
+      }
+    },
+    "GrpcRouteMetadataList": {
+      "type": "list",
+      "member": {
+        "shape": "GrpcRouteMetadata"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "ListenerTlsMode": {
+      "type": "string",
+      "enum": [
+        "DISABLED",
+        "PERMISSIVE",
+        "STRICT"
+      ]
+    },
+    "HealthCheckPolicy": {
+      "type": "structure",
+      "required": [
+        "healthyThreshold",
+        "intervalMillis",
+        "protocol",
+        "timeoutMillis",
+        "unhealthyThreshold"
+      ],
+      "members": {
+        "healthyThreshold": {
+          "shape": "HealthCheckThreshold"
+        },
+        "intervalMillis": {
+          "shape": "HealthCheckIntervalMillis"
+        },
+        "path": {
+          "shape": "String"
+        },
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "PortProtocol"
+        },
+        "timeoutMillis": {
+          "shape": "HealthCheckTimeoutMillis"
+        },
+        "unhealthyThreshold": {
+          "shape": "HealthCheckThreshold"
+        }
+      }
+    },
+    "VirtualGatewayHealthCheckTimeoutMillis": {
+      "type": "long",
+      "box": true,
+      "min": 2000,
+      "max": 60000
+    },
+    "EgressFilter": {
+      "type": "structure",
+      "required": [
+        "type"
+      ],
+      "members": {
+        "type": {
+          "shape": "EgressFilterType"
+        }
+      }
+    },
+    "VirtualServiceList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualServiceRef"
+      }
+    },
+    "ClientPolicy": {
+      "type": "structure",
+      "members": {
+        "tls": {
+          "shape": "ClientPolicyTls"
+        }
+      }
+    },
+    "VirtualGatewayHealthCheckIntervalMillis": {
+      "type": "long",
+      "box": true,
+      "min": 5000,
+      "max": 300000
+    },
+    "Boolean": {
+      "type": "boolean",
+      "box": true
+    },
+    "VirtualGatewaySpec": {
+      "type": "structure",
+      "required": [
+        "listeners"
+      ],
+      "members": {
+        "backendDefaults": {
+          "shape": "VirtualGatewayBackendDefaults"
+        },
+        "listeners": {
+          "shape": "VirtualGatewayListeners"
+        }
+      }
+    },
+    "HttpRetryPolicyEvent": {
+      "type": "string",
+      "min": 1,
+      "max": 25
+    },
+    "VirtualGatewayFileAccessLog": {
+      "type": "structure",
+      "required": [
+        "path"
+      ],
+      "members": {
+        "path": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "DescribeVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData"
+        }
+      },
+      "payload": "virtualService"
+    },
+    "CreateGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "tags": {
+          "shape": "TagList"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "CertificateAuthorityArns": {
+      "type": "list",
+      "member": {
+        "shape": "Arn"
+      },
+      "min": 1,
+      "max": 3
+    },
+    "DescribeVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData"
+        }
+      },
+      "payload": "virtualNode"
+    },
+    "AwsCloudMapName": {
+      "type": "string",
+      "min": 1,
+      "max": 1024,
+      "pattern": "((?=^.{1,127}$)^([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9])(.([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9]))*$)|(^.$)"
+    },
+    "VirtualGatewayData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "status": {
+          "shape": "VirtualGatewayStatus"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "CreateRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData"
+        }
+      },
+      "payload": "route"
+    },
+    "VirtualGatewayListener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "healthCheck": {
+          "shape": "VirtualGatewayHealthCheckPolicy"
+        },
+        "logging": {
+          "shape": "VirtualGatewayLogging"
+        },
+        "portMapping": {
+          "shape": "VirtualGatewayPortMapping"
+        },
+        "tls": {
+          "shape": "VirtualGatewayListenerTls"
+        }
+      }
+    },
+    "DnsServiceDiscovery": {
+      "type": "structure",
+      "required": [
+        "hostname"
+      ],
+      "members": {
+        "hostname": {
+          "shape": "Hostname"
+        }
+      }
+    },
+    "VirtualGatewayPortMapping": {
+      "type": "structure",
+      "required": [
+        "port",
+        "protocol"
+      ],
+      "members": {
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "VirtualGatewayPortProtocol"
+        }
+      }
+    },
+    "DeleteVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "DeleteRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "VirtualNodeData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec"
+        },
+        "status": {
+          "shape": "VirtualNodeStatus"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "UntagResourceOutput": {
+      "type": "structure",
+      "members": { }
+    },
+    "ListGatewayRoutesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "TcpRetryPolicyEvent": {
+      "type": "string",
+      "enum": [
+        "connection-error"
+      ]
+    },
+    "VirtualGatewayListenerTls": {
+      "type": "structure",
+      "required": [
+        "certificate",
+        "mode"
+      ],
+      "members": {
+        "certificate": {
+          "shape": "VirtualGatewayListenerTlsCertificate"
+        },
+        "mode": {
+          "shape": "VirtualGatewayListenerTlsMode"
+        }
+      }
+    },
+    "Backend": {
+      "type": "structure",
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceBackend"
+        }
+      }
+    },
+    "ListMeshesInput": {
+      "type": "structure",
+      "members": {
+        "limit": {
+          "shape": "ListMeshesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner",
+          "tags": [
+            "internal"
+          ]
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "VirtualGatewayListenerTlsFileCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateChain",
+        "privateKey"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        },
+        "privateKey": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "ListGatewayRoutesInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListGatewayRoutesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "VirtualRouterData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec"
+        },
+        "status": {
+          "shape": "VirtualRouterStatus"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "UpdateMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "spec": {
+          "shape": "MeshSpec"
+        }
+      }
+    },
+    "VirtualGatewayHealthCheckPolicy": {
+      "type": "structure",
+      "required": [
+        "healthyThreshold",
+        "intervalMillis",
+        "protocol",
+        "timeoutMillis",
+        "unhealthyThreshold"
+      ],
+      "members": {
+        "healthyThreshold": {
+          "shape": "VirtualGatewayHealthCheckThreshold"
+        },
+        "intervalMillis": {
+          "shape": "VirtualGatewayHealthCheckIntervalMillis"
+        },
+        "path": {
+          "shape": "String"
+        },
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "VirtualGatewayPortProtocol"
+        },
+        "timeoutMillis": {
+          "shape": "VirtualGatewayHealthCheckTimeoutMillis"
+        },
+        "unhealthyThreshold": {
+          "shape": "VirtualGatewayHealthCheckThreshold"
+        }
+      }
+    },
+    "CreateVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec"
+        },
+        "tags": {
+          "shape": "TagList",
+          "tags": [
+            "not-preview"
+          ]
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "DescribeVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData"
+        }
+      },
+      "payload": "virtualRouter"
+    },
+    "GetMeshPolicyInput": {
+      "type": "structure",
+      "required": [
+        "meshArn"
+      ],
+      "members": {
+        "meshArn": {
+          "shape": "Arn",
+          "location": "querystring",
+          "locationName": "meshArn"
+        }
+      }
+    },
+    "CreateMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "payload": "mesh"
+    },
+    "CreateVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData"
+        }
+      },
+      "payload": "virtualRouter"
+    },
+    "VirtualServiceStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualServiceStatusCode"
+        }
+      }
+    },
+    "HttpRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "HttpRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 25
+    },
+    "VirtualGatewayListenerTlsCertificate": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "VirtualGatewayListenerTlsAcmCertificate"
+        },
+        "file": {
+          "shape": "VirtualGatewayListenerTlsFileCertificate"
+        },
+        "sds": {
+          "shape": "VirtualGatewayListenerTlsSdsCertificate",
+          "tags": [
+            "internal"
+          ]
+        }
+      }
+    },
+    "ListenerTlsCertificate": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "ListenerTlsAcmCertificate"
+        },
+        "file": {
+          "shape": "ListenerTlsFileCertificate"
+        },
+        "sds": {
+          "shape": "ListenerTlsSdsCertificate",
+          "tags": [
+            "internal"
+          ]
+        }
+      }
+    },
+    "ListMeshesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "AwsCloudMapInstanceAttributeKey": {
+      "type": "string",
+      "min": 1,
+      "max": 255,
+      "pattern": "^[a-zA-Z0-9!-~]+$"
+    },
+    "VirtualRouterSpec": {
+      "type": "structure",
+      "members": {
+        "listeners": {
+          "shape": "VirtualRouterListeners"
+        }
+      }
+    },
+    "DeleteMeshPolicyInput": {
+      "type": "structure",
+      "required": [
+        "meshArn"
+      ],
+      "members": {
+        "meshArn": {
+          "shape": "Arn",
+          "location": "querystring",
+          "locationName": "meshArn"
+        }
+      }
+    },
+    "GatewayRouteVirtualService": {
+      "type": "structure",
+      "required": [
+        "virtualServiceName"
+      ],
+      "members": {
+        "virtualServiceName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "VirtualNodeSpec": {
+      "type": "structure",
+      "members": {
+        "backendDefaults": {
+          "shape": "BackendDefaults"
+        },
+        "backends": {
+          "shape": "Backends"
+        },
+        "listeners": {
+          "shape": "Listeners"
+        },
+        "logging": {
+          "shape": "Logging"
+        },
+        "serviceDiscovery": {
+          "shape": "ServiceDiscovery"
+        }
+      }
+    },
+    "ListMeshesOutput": {
+      "type": "structure",
+      "required": [
+        "meshes"
+      ],
+      "members": {
+        "meshes": {
+          "shape": "MeshList"
+        },
+        "nextToken": {
+          "shape": "String"
+        }
+      }
+    },
+    "VirtualRouterListeners": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualRouterListener"
+      },
+      "min": 1,
+      "max": 1
+    },
+    "GatewayRouteSpec": {
+      "type": "structure",
+      "members": {
+        "grpcRoute": {
+          "shape": "GrpcGatewayRoute"
+        },
+        "http2Route": {
+          "shape": "HttpGatewayRoute"
+        },
+        "httpRoute": {
+          "shape": "HttpGatewayRoute"
+        }
+      }
+    },
+    "PortSet": {
+      "type": "list",
+      "member": {
+        "shape": "PortNumber"
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "CONNECT",
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "PUT",
+        "TRACE"
+      ]
+    },
+    "ConflictException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "ConflictException",
+        "httpStatusCode": 409,
+        "senderFault": true
+      }
+    },
+    "VirtualGatewayBackendDefaults": {
+      "type": "structure",
+      "members": {
+        "clientPolicy": {
+          "shape": "VirtualGatewayClientPolicy"
+        }
+      }
+    },
+    "ListenerTimeout": {
+      "type": "structure",
+      "members": {
+        "grpc": {
+          "shape": "GrpcTimeout"
+        },
+        "http": {
+          "shape": "HttpTimeout"
+        },
+        "http2": {
+          "shape": "HttpTimeout"
+        },
+        "tcp": {
+          "shape": "TcpTimeout"
+        }
+      }
+    },
+    "MeshList": {
+      "type": "list",
+      "member": {
+        "shape": "MeshRef"
+      }
+    },
+    "MaxRetries": {
+      "type": "long",
+      "box": true,
+      "min": 0
+    },
+    "DescribeGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "TlsValidationContextTrust": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "TlsValidationContextAcmTrust"
+        },
+        "file": {
+          "shape": "TlsValidationContextFileTrust"
+        },
+        "sds": {
+          "shape": "TlsValidationContextSdsTrust",
+          "tags": [
+            "internal"
+          ]
+        }
+      }
+    },
+    "PortMapping": {
+      "type": "structure",
+      "required": [
+        "port",
+        "protocol"
+      ],
+      "members": {
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "PortProtocol"
+        }
+      }
+    },
+    "VirtualGatewayHealthCheckThreshold": {
+      "type": "integer",
+      "min": 2,
+      "max": 10
+    },
+    "ListVirtualServicesOutput": {
+      "type": "structure",
+      "required": [
+        "virtualServices"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualServices": {
+          "shape": "VirtualServiceList"
+        }
+      }
+    },
+    "AwsCloudMapInstanceAttributeValue": {
+      "type": "string",
+      "min": 1,
+      "max": 1024,
+      "pattern": "^([a-zA-Z0-9!-~][ ta-zA-Z0-9!-~]*){0,1}[a-zA-Z0-9!-~]{0,1}$"
+    },
+    "WeightedTarget": {
+      "type": "structure",
+      "required": [
+        "virtualNode",
+        "weight"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "ResourceName"
+        },
+        "weight": {
+          "shape": "PercentInt"
+        }
+      }
+    },
+    "GrpcGatewayRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "GrpcGatewayRouteAction"
+        },
+        "match": {
+          "shape": "GrpcGatewayRouteMatch"
+        }
+      }
+    },
+    "GatewayRouteData": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "status": {
+          "shape": "GatewayRouteStatus"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "RouteRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "routeName",
+        "version",
+        "virtualRouterName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "routeName": {
+          "shape": "ResourceName"
+        },
+        "version": {
+          "shape": "Long",
+          "tags": [
+            "internal"
+          ]
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "DeleteVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      }
+    },
+    "RouteData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "routeName",
+        "spec",
+        "status",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "routeName": {
+          "shape": "ResourceName"
+        },
+        "spec": {
+          "shape": "RouteSpec"
+        },
+        "status": {
+          "shape": "RouteStatus"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "RouteStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "InternalServerErrorException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "InternalServerErrorException",
+        "httpStatusCode": 500,
+        "fault": true
+      }
+    },
+    "HeaderName": {
+      "type": "string",
+      "min": 1,
+      "max": 50
+    },
+    "TagList": {
+      "type": "list",
+      "member": {
+        "shape": "TagRef"
+      },
+      "min": 0,
+      "max": 50
+    },
+    "GrpcRetryPolicyEvent": {
+      "type": "string",
+      "enum": [
+        "cancelled",
+        "deadline-exceeded",
+        "internal",
+        "resource-exhausted",
+        "unavailable"
+      ]
+    },
+    "TlsValidationContextAcmTrust": {
+      "type": "structure",
+      "required": [
+        "certificateAuthorityArns"
+      ],
+      "members": {
+        "certificateAuthorityArns": {
+          "shape": "CertificateAuthorityArns"
+        }
+      }
+    },
+    "ForbiddenException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "ForbiddenException",
+        "httpStatusCode": 403,
+        "senderFault": true
+      }
+    },
+    "HeaderMatchMethod": {
+      "type": "structure",
+      "members": {
+        "exact": {
+          "shape": "HeaderMatch"
+        },
+        "prefix": {
+          "shape": "HeaderMatch"
+        },
+        "range": {
+          "shape": "MatchRange"
+        },
+        "regex": {
+          "shape": "HeaderMatch"
+        },
+        "suffix": {
+          "shape": "HeaderMatch"
+        }
+      }
+    },
+    "DeleteMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "payload": "mesh"
+    },
+    "VirtualGatewayClientPolicyTls": {
+      "type": "structure",
+      "required": [
+        "validation"
+      ],
+      "members": {
+        "enforce": {
+          "shape": "Boolean",
+          "box": true
+        },
+        "ports": {
+          "shape": "PortSet"
+        },
+        "validation": {
+          "shape": "VirtualGatewayTlsValidationContext"
+        }
+      }
+    },
+    "EgressFilterType": {
+      "type": "string",
+      "enum": [
+        "ALLOW_ALL",
+        "DROP_ALL"
+      ]
+    },
+    "DurationValue": {
+      "type": "long",
+      "box": true,
+      "min": 0
+    },
+    "Hostname": {
+      "type": "string"
+    },
+    "TlsValidationContextSdsTrust": {
+      "type": "structure",
+      "required": [
+        "secretName",
+        "source"
+      ],
+      "members": {
+        "secretName": {
+          "shape": "SdsSecretName"
+        },
+        "source": {
+          "shape": "SdsSource"
+        }
+      }
+    },
+    "VirtualGatewayStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualGatewayStatusCode"
+        }
+      }
+    },
+    "GatewayRouteStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "GatewayRouteStatusCode"
+        }
+      }
+    },
+    "VirtualGatewayListeners": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualGatewayListener"
+      },
+      "min": 0,
+      "max": 1
+    },
+    "TagResourceInput": {
+      "type": "structure",
+      "required": [
+        "resourceArn",
+        "tags"
+      ],
+      "members": {
+        "resourceArn": {
+          "shape": "Arn",
+          "location": "querystring",
+          "locationName": "resourceArn"
+        },
+        "tags": {
+          "shape": "TagList"
+        }
+      }
+    },
+    "CreateVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "ListVirtualGatewaysOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateways"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualGateways": {
+          "shape": "VirtualGatewayList"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContext": {
+      "type": "structure",
+      "required": [
+        "trust"
+      ],
+      "members": {
+        "trust": {
+          "shape": "VirtualGatewayTlsValidationContextTrust"
+        }
+      }
+    },
+    "VirtualServiceProvider": {
+      "type": "structure",
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeServiceProvider"
+        },
+        "virtualRouter": {
+          "shape": "VirtualRouterServiceProvider"
+        }
+      }
+    },
+    "GrpcRouteMatch": {
+      "type": "structure",
+      "members": {
+        "metadata": {
+          "shape": "GrpcRouteMetadataList"
+        },
+        "methodName": {
+          "shape": "MethodName"
+        },
+        "serviceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "AwsCloudMapServiceDiscovery": {
+      "type": "structure",
+      "required": [
+        "namespaceName",
+        "serviceName"
+      ],
+      "members": {
+        "attributes": {
+          "shape": "AwsCloudMapInstanceAttributes"
+        },
+        "namespaceName": {
+          "shape": "AwsCloudMapName"
+        },
+        "serviceName": {
+          "shape": "AwsCloudMapName"
+        }
+      }
+    },
+    "UpdateVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData"
+        }
+      },
+      "payload": "virtualService"
+    },
+    "MeshStatus": {
+      "type": "structure",
+      "members": {
+        "status": {
+          "shape": "MeshStatusCode"
+        }
+      }
+    },
+    "CreateVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualNodeName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec"
+        },
+        "tags": {
+          "shape": "TagList",
+          "tags": [
+            "not-preview"
+          ]
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "NotFoundException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "NotFoundException",
+        "httpStatusCode": 404,
+        "senderFault": true
+      }
+    },
+    "RouteSpec": {
+      "type": "structure",
+      "members": {
+        "grpcRoute": {
+          "shape": "GrpcRoute"
+        },
+        "http2Route": {
+          "shape": "HttpRoute"
+        },
+        "httpRoute": {
+          "shape": "HttpRoute"
+        },
+        "priority": {
+          "shape": "RoutePriority"
+        },
+        "tcpRoute": {
+          "shape": "TcpRoute"
+        }
+      }
+    },
+    "GatewayRouteRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "gatewayRouteName",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long",
+          "tags": [
+            "internal"
+          ]
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "VirtualGatewayListenerTlsAcmCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateArn"
+      ],
+      "members": {
+        "certificateArn": {
+          "shape": "Arn"
+        }
+      }
+    },
+    "ListGatewayRoutesOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoutes"
+      ],
+      "members": {
+        "gatewayRoutes": {
+          "shape": "GatewayRouteList"
+        },
+        "nextToken": {
+          "shape": "String"
+        }
+      }
+    },
+    "CreateVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData"
+        }
+      },
+      "payload": "virtualService"
+    },
+    "FileAccessLog": {
+      "type": "structure",
+      "required": [
+        "path"
+      ],
+      "members": {
+        "path": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "VirtualRouterServiceProvider": {
+      "type": "structure",
+      "required": [
+        "virtualRouterName"
+      ],
+      "members": {
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "HttpTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        },
+        "perRequest": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "DeleteVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      }
+    },
+    "VirtualGatewaySdsUnixDomainSocketSource": {
+      "type": "structure",
+      "required": [
+        "path"
+      ],
+      "members": {
+        "path": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "TlsValidationContext": {
+      "type": "structure",
+      "required": [
+        "trust"
+      ],
+      "members": {
+        "trust": {
+          "shape": "TlsValidationContextTrust"
+        }
+      }
+    },
+    "GatewayRouteStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "DeleteVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData"
+        }
+      },
+      "payload": "virtualRouter"
+    },
+    "DescribeVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "TagsLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 50
+    },
+    "GrpcGatewayRouteAction": {
+      "type": "structure",
+      "required": [
+        "target"
+      ],
+      "members": {
+        "target": {
+          "shape": "GatewayRouteTarget"
+        }
+      }
+    },
+    "GetMeshPolicyOutput": {
+      "type": "structure",
+      "required": [
+        "policy"
+      ],
+      "members": {
+        "policy": {
+          "shape": "IamPolicy"
+        }
+      }
+    },
+    "DeleteVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData"
+        }
+      },
+      "payload": "virtualNode"
+    },
+    "UpdateVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualNodeName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      }
+    },
+    "PutMeshPolicyInput": {
+      "type": "structure",
+      "required": [
+        "meshArn",
+        "policy"
+      ],
+      "members": {
+        "meshArn": {
+          "shape": "Arn",
+          "location": "querystring",
+          "locationName": "meshArn"
+        },
+        "policy": {
+          "shape": "IamPolicy"
+        }
+      }
+    },
+    "ListenerTls": {
+      "type": "structure",
+      "required": [
+        "certificate",
+        "mode"
+      ],
+      "members": {
+        "certificate": {
+          "shape": "ListenerTlsCertificate"
+        },
+        "mode": {
+          "shape": "ListenerTlsMode"
+        }
+      }
+    },
+    "DeleteMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        }
+      }
+    },
+    "TcpRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "TcpRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 1
+    },
+    "CreateVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec"
+        },
+        "tags": {
+          "shape": "TagList",
+          "tags": [
+            "not-preview"
+          ]
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContextSdsTrust": {
+      "type": "structure",
+      "required": [
+        "secretName",
+        "source"
+      ],
+      "members": {
+        "secretName": {
+          "shape": "VirtualGatewaySdsSecretName"
+        },
+        "source": {
+          "shape": "VirtualGatewaySdsSource"
+        }
+      }
+    },
+    "UpdateVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "HttpGatewayRouteAction": {
+      "type": "structure",
+      "required": [
+        "target"
+      ],
+      "members": {
+        "target": {
+          "shape": "GatewayRouteTarget"
+        }
+      }
+    },
+    "GrpcGatewayRouteMatch": {
+      "type": "structure",
+      "members": {
+        "serviceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "VirtualGatewayListenerTlsSdsCertificate": {
+      "type": "structure",
+      "required": [
+        "secretName",
+        "source"
+      ],
+      "members": {
+        "secretName": {
+          "shape": "VirtualGatewaySdsSecretName"
+        },
+        "source": {
+          "shape": "VirtualGatewaySdsSource"
+        }
+      }
+    },
+    "ListTagsForResourceInput": {
+      "type": "structure",
+      "required": [
+        "resourceArn"
+      ],
+      "members": {
+        "limit": {
+          "shape": "TagsLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "resourceArn": {
+          "shape": "Arn",
+          "location": "querystring",
+          "locationName": "resourceArn"
+        }
+      }
+    },
+    "GrpcRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "GrpcRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 5
+    },
+    "VirtualGatewayStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "ServiceUnavailableException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "ServiceUnavailableException",
+        "httpStatusCode": 503,
+        "fault": true
+      }
+    },
+    "DescribeMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "payload": "mesh"
+    },
+    "DeleteVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "UpdateGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "SdsSource": {
+      "type": "structure",
+      "members": {
+        "unixDomainSocket": {
+          "shape": "SdsUnixDomainSocketSource"
+        }
+      }
+    },
+    "DescribeRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "DeleteRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData"
+        }
+      },
+      "payload": "route"
+    },
+    "Listeners": {
+      "type": "list",
+      "member": {
+        "shape": "Listener"
+      },
+      "min": 0,
+      "max": 1
+    },
+    "Backends": {
+      "type": "list",
+      "member": {
+        "shape": "Backend"
+      }
+    },
+    "PortProtocol": {
+      "type": "string",
+      "enum": [
+        "grpc",
+        "http",
+        "http2",
+        "tcp"
+      ]
+    },
+    "DeleteGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "VirtualGatewayList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualGatewayRef"
+      }
+    },
+    "VirtualNodeStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "ServiceName": {
+      "type": "string"
+    },
+    "UpdateVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      }
+    },
+    "HealthCheckThreshold": {
+      "type": "integer",
+      "min": 2,
+      "max": 10
+    },
+    "UpdateRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData"
+        }
+      },
+      "payload": "route"
+    },
+    "PercentInt": {
+      "type": "integer",
+      "min": 0,
+      "max": 100
+    },
+    "MethodName": {
+      "type": "string",
+      "min": 1,
+      "max": 50
+    },
+    "SdsUnixDomainSocketSource": {
+      "type": "structure",
+      "required": [
+        "path"
+      ],
+      "members": {
+        "path": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "TagValue": {
+      "type": "string",
+      "min": 0,
+      "max": 256
+    },
+    "HttpRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets"
+        }
+      }
+    },
+    "ListRoutesInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListRoutesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "VirtualServiceRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualServiceName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long",
+          "tags": [
+            "internal"
+          ]
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "GrpcTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        },
+        "perRequest": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "VirtualNodeStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualNodeStatusCode"
+        }
+      }
+    },
+    "VirtualRouterRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualRouterName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long",
+          "tags": [
+            "internal"
+          ]
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "VirtualServiceData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec"
+        },
+        "status": {
+          "shape": "VirtualServiceStatus"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "HttpRouteHeader": {
+      "type": "structure",
+      "required": [
+        "name"
+      ],
+      "members": {
+        "invert": {
+          "shape": "Boolean"
+        },
+        "match": {
+          "shape": "HeaderMatchMethod"
+        },
+        "name": {
+          "shape": "HeaderName"
+        }
+      }
+    },
+    "FilePath": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "AwsCloudMapInstanceAttributes": {
+      "type": "list",
+      "member": {
+        "shape": "AwsCloudMapInstanceAttribute"
+      }
+    },
+    "VirtualNodeRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualNodeName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long",
+          "tags": [
+            "internal"
+          ]
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "CreateMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "spec": {
+          "shape": "MeshSpec"
+        },
+        "tags": {
+          "shape": "TagList",
+          "tags": [
+            "not-preview"
+          ]
+        }
+      }
+    },
+    "GrpcRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContextFileTrust": {
+      "type": "structure",
+      "required": [
+        "certificateChain"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "LimitExceededException",
+        "httpStatusCode": 400,
+        "senderFault": true
+      }
+    },
+    "UpdateMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "payload": "mesh"
+    },
+    "GrpcRouteMetadataMatchMethod": {
+      "type": "structure",
+      "members": {
+        "exact": {
+          "shape": "HeaderMatch"
+        },
+        "prefix": {
+          "shape": "HeaderMatch"
+        },
+        "range": {
+          "shape": "MatchRange"
+        },
+        "regex": {
+          "shape": "HeaderMatch"
+        },
+        "suffix": {
+          "shape": "HeaderMatch"
+        }
+      }
+    },
+    "DescribeVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      }
+    },
+    "IamPolicy": {
+      "type": "string",
+      "min": 1,
+      "max": 20000
+    },
+    "ListVirtualServicesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "AwsCloudMapInstanceAttribute": {
+      "type": "structure",
+      "required": [
+        "key",
+        "value"
+      ],
+      "members": {
+        "key": {
+          "shape": "AwsCloudMapInstanceAttributeKey"
+        },
+        "value": {
+          "shape": "AwsCloudMapInstanceAttributeValue"
+        }
+      }
+    },
+    "VirtualGatewayListenerTlsMode": {
+      "type": "string",
+      "enum": [
+        "DISABLED",
+        "PERMISSIVE",
+        "STRICT"
+      ]
+    },
+    "VirtualServiceSpec": {
+      "type": "structure",
+      "members": {
+        "provider": {
+          "shape": "VirtualServiceProvider"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContextAcmTrust": {
+      "type": "structure",
+      "required": [
+        "certificateAuthorityArns"
+      ],
+      "members": {
+        "certificateAuthorityArns": {
+          "shape": "VirtualGatewayCertificateAuthorityArns"
+        }
+      }
+    },
+    "VirtualGatewayAccessLog": {
+      "type": "structure",
+      "members": {
+        "file": {
+          "shape": "VirtualGatewayFileAccessLog"
+        }
+      }
+    },
+    "MatchRange": {
+      "type": "structure",
+      "required": [
+        "end",
+        "start"
+      ],
+      "members": {
+        "end": {
+          "shape": "Long"
+        },
+        "start": {
+          "shape": "Long"
+        }
+      }
+    },
+    "ListVirtualRoutersLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "HealthCheckIntervalMillis": {
+      "type": "long",
+      "box": true,
+      "min": 5000,
+      "max": 300000
+    },
+    "VirtualRouterList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualRouterRef"
+      }
+    },
+    "Arn": {
+      "type": "string"
+    },
+    "TcpRoute": {
+      "type": "structure",
+      "required": [
+        "action"
+      ],
+      "members": {
+        "action": {
+          "shape": "TcpRouteAction"
+        },
+        "timeout": {
+          "shape": "TcpTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      }
+    },
+    "VirtualNodeList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualNodeRef"
+      }
+    },
+    "UpdateVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "ListVirtualRoutersInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualRoutersLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "DurationUnit": {
+      "type": "string",
+      "enum": [
+        "ms",
+        "s"
+      ]
+    },
+    "RoutePriority": {
+      "type": "integer",
+      "box": true,
+      "min": 0,
+      "max": 1000
+    },
+    "ListVirtualServicesInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualServicesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "AccessLog": {
+      "type": "structure",
+      "members": {
+        "file": {
+          "shape": "FileAccessLog"
+        }
+      }
+    },
+    "ListVirtualNodesInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualNodesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "VirtualGatewayClientPolicy": {
+      "type": "structure",
+      "members": {
+        "tls": {
+          "shape": "VirtualGatewayClientPolicyTls"
+        }
+      }
+    },
+    "SdsSecretName": {
+      "type": "string"
+    },
+    "ListVirtualNodesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "HealthCheckTimeoutMillis": {
+      "type": "long",
+      "box": true,
+      "min": 2000,
+      "max": 60000
+    },
+    "ResourceName": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "TooManyRequestsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "TooManyRequestsException",
+        "httpStatusCode": 429,
+        "senderFault": true
+      }
+    },
+    "Timestamp": {
+      "type": "timestamp"
+    },
+    "VirtualGatewayLogging": {
+      "type": "structure",
+      "members": {
+        "accessLog": {
+          "shape": "VirtualGatewayAccessLog"
+        }
+      }
+    },
+    "VirtualGatewaySdsSource": {
+      "type": "structure",
+      "members": {
+        "unixDomainSocket": {
+          "shape": "VirtualGatewaySdsUnixDomainSocketSource"
+        }
+      }
+    },
+    "HeaderMatch": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "AccountId": {
+      "type": "string",
+      "min": 12,
+      "max": 12
+    },
+    "GatewayRouteTarget": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "GatewayRouteVirtualService"
+        }
+      }
+    },
+    "Duration": {
+      "type": "structure",
+      "members": {
+        "unit": {
+          "shape": "DurationUnit"
+        },
+        "value": {
+          "shape": "DurationValue"
+        }
+      }
+    },
+    "DescribeRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData"
+        }
+      },
+      "payload": "route"
+    },
+    "HttpRouteMatch": {
+      "type": "structure",
+      "required": [
+        "prefix"
+      ],
+      "members": {
+        "headers": {
+          "shape": "HttpRouteHeaders"
+        },
+        "method": {
+          "shape": "HttpMethod"
+        },
+        "prefix": {
+          "shape": "String"
+        },
+        "scheme": {
+          "shape": "HttpScheme"
+        }
+      }
+    },
+    "TagRef": {
+      "type": "structure",
+      "required": [
+        "key"
+      ],
+      "members": {
+        "key": {
+          "shape": "TagKey"
+        },
+        "value": {
+          "shape": "TagValue"
+        }
+      }
+    },
+    "MeshRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long",
+          "tags": [
+            "internal"
+          ]
+        }
+      }
+    },
+    "ListVirtualGatewaysLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "MeshStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "MeshData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "MeshSpec"
+        },
+        "status": {
+          "shape": "MeshStatus"
+        }
+      }
+    },
+    "CreateGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "GatewayRouteList": {
+      "type": "list",
+      "member": {
+        "shape": "GatewayRouteRef"
+      }
+    },
+    "VirtualRouterStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualRouterStatusCode"
+        }
+      }
+    },
+    "TcpRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets"
+        }
+      }
+    },
+    "DeleteVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "DescribeVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      }
+    },
+    "DeleteMeshPolicyOutput": {
+      "type": "structure",
+      "members": { }
+    },
+    "RouteStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "RouteStatusCode"
+        }
+      }
+    },
+    "Listener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "healthCheck": {
+          "shape": "HealthCheckPolicy"
+        },
+        "portMapping": {
+          "shape": "PortMapping"
+        },
+        "timeout": {
+          "shape": "ListenerTimeout",
+          "tags": [
+            "internal"
+          ]
+        },
+        "tls": {
+          "shape": "ListenerTls"
+        }
+      }
+    },
+    "GrpcRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "GrpcRouteAction"
+        },
+        "match": {
+          "shape": "GrpcRouteMatch"
+        },
+        "retryPolicy": {
+          "shape": "GrpcRetryPolicy"
+        },
+        "timeout": {
+          "shape": "GrpcTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      }
+    },
+    "ListRoutesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "ClientPolicyTls": {
+      "type": "structure",
+      "required": [
+        "validation"
+      ],
+      "members": {
+        "enforce": {
+          "shape": "Boolean",
+          "box": true
+        },
+        "ports": {
+          "shape": "PortSet"
+        },
+        "validation": {
+          "shape": "TlsValidationContext"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContextTrust": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "VirtualGatewayTlsValidationContextAcmTrust"
+        },
+        "file": {
+          "shape": "VirtualGatewayTlsValidationContextFileTrust"
+        },
+        "sds": {
+          "shape": "VirtualGatewayTlsValidationContextSdsTrust",
+          "tags": [
+            "internal"
+          ]
+        }
+      }
+    },
+    "DeleteVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData"
+        }
+      },
+      "payload": "virtualService"
+    },
+    "VirtualGatewayPortProtocol": {
+      "type": "string",
+      "enum": [
+        "grpc",
+        "http",
+        "http2"
+      ]
+    },
+    "VirtualNodeServiceProvider": {
+      "type": "structure",
+      "required": [
+        "virtualNodeName"
+      ],
+      "members": {
+        "virtualNodeName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "HttpGatewayRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "HttpGatewayRouteAction"
+        },
+        "match": {
+          "shape": "HttpGatewayRouteMatch"
+        }
+      }
+    },
+    "BackendDefaults": {
+      "type": "structure",
+      "members": {
+        "clientPolicy": {
+          "shape": "ClientPolicy"
+        }
+      }
+    },
+    "ListenerTlsFileCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateChain",
+        "privateKey"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        },
+        "privateKey": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "HttpRetryPolicy": {
+      "type": "structure",
+      "required": [
+        "maxRetries",
+        "perRetryTimeout"
+      ],
+      "members": {
+        "httpRetryEvents": {
+          "shape": "HttpRetryPolicyEvents"
+        },
+        "maxRetries": {
+          "shape": "MaxRetries"
+        },
+        "perRetryTimeout": {
+          "shape": "Duration"
+        },
+        "tcpRetryEvents": {
+          "shape": "TcpRetryPolicyEvents"
+        }
+      }
+    },
+    "DescribeVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "TagResourceOutput": {
+      "type": "structure",
+      "members": { }
+    },
+    "RouteList": {
+      "type": "list",
+      "member": {
+        "shape": "RouteRef"
+      }
+    },
+    "TooManyTagsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "TooManyTagsException",
+        "httpStatusCode": 400,
+        "senderFault": true
+      }
+    },
+    "UpdateGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "ListVirtualGatewaysInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualGatewaysLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "PortNumber": {
+      "type": "integer",
+      "min": 1,
+      "max": 65535
+    },
+    "TlsValidationContextFileTrust": {
+      "type": "structure",
+      "required": [
+        "certificateChain"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "GrpcRouteMetadata": {
+      "type": "structure",
+      "required": [
+        "name"
+      ],
+      "members": {
+        "invert": {
+          "shape": "Boolean"
+        },
+        "match": {
+          "shape": "GrpcRouteMetadataMatchMethod"
+        },
+        "name": {
+          "shape": "HeaderName"
+        }
+      }
+    },
+    "CreateRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName"
+        },
+        "spec": {
+          "shape": "RouteSpec"
+        },
+        "tags": {
+          "shape": "TagList",
+          "tags": [
+            "not-preview"
+          ]
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "VirtualGatewayCertificateAuthorityArns": {
+      "type": "list",
+      "member": {
+        "shape": "Arn"
+      },
+      "min": 1,
+      "max": 3
+    },
+    "WeightedTargets": {
+      "type": "list",
+      "member": {
+        "shape": "WeightedTarget"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "HttpRouteHeaders": {
+      "type": "list",
+      "member": {
+        "shape": "HttpRouteHeader"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "String": {
+      "type": "string"
+    },
+    "TcpTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "HttpScheme": {
+      "type": "string",
+      "enum": [
+        "http",
+        "https"
+      ]
+    },
+    "DeleteGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "UpdateRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "spec": {
+          "shape": "RouteSpec"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "HttpRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "HttpRouteAction"
+        },
+        "match": {
+          "shape": "HttpRouteMatch"
+        },
+        "retryPolicy": {
+          "shape": "HttpRetryPolicy"
+        },
+        "timeout": {
+          "shape": "HttpTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      }
+    },
+    "DescribeMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        }
+      }
+    },
+    "VirtualGatewayRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "tags": [
+            "internal"
+          ]
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long",
+          "tags": [
+            "internal"
+          ]
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "MeshSpec": {
+      "type": "structure",
+      "members": {
+        "egressFilter": {
+          "shape": "EgressFilter"
+        }
+      }
+    },
+    "DescribeVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "DescribeGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "ListTagsForResourceOutput": {
+      "type": "structure",
+      "required": [
+        "tags"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "tags": {
+          "shape": "TagList"
+        }
+      }
+    },
+    "ServiceDiscovery": {
+      "type": "structure",
+      "members": {
+        "awsCloudMap": {
+          "shape": "AwsCloudMapServiceDiscovery"
+        },
+        "dns": {
+          "shape": "DnsServiceDiscovery"
+        }
+      }
+    },
+    "ListVirtualNodesOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNodes"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualNodes": {
+          "shape": "VirtualNodeList"
+        }
+      }
+    },
+    "UntagResourceInput": {
+      "type": "structure",
+      "required": [
+        "resourceArn",
+        "tagKeys"
+      ],
+      "members": {
+        "resourceArn": {
+          "shape": "Arn",
+          "location": "querystring",
+          "locationName": "resourceArn"
+        },
+        "tagKeys": {
+          "shape": "TagKeyList"
+        }
+      }
+    },
+    "ListenerTlsAcmCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateArn"
+      ],
+      "members": {
+        "certificateArn": {
+          "shape": "Arn"
+        }
+      }
+    },
+    "TagKey": {
+      "type": "string",
+      "min": 1,
+      "max": 128
+    },
+    "VirtualServiceStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    }
+  }
+}

--- a/appmesh_models_override/cleanup.sh
+++ b/appmesh_models_override/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm -rf ./vendor
+go mod edit -dropreplace github.com/aws/aws-sdk-go
+go mod tidy

--- a/appmesh_models_override/docs-2.json
+++ b/appmesh_models_override/docs-2.json
@@ -1,0 +1,1235 @@
+{
+  "version": "2.0",
+  "service": null,
+  "operations": {
+    "CreateGatewayRoute": null,
+    "CreateMesh": null,
+    "CreateRoute": null,
+    "CreateVirtualGateway": null,
+    "CreateVirtualNode": null,
+    "CreateVirtualRouter": null,
+    "CreateVirtualService": null,
+    "DeleteGatewayRoute": null,
+    "DeleteMesh": null,
+    "DeleteMeshPolicy": null,
+    "DeleteRoute": null,
+    "DeleteVirtualGateway": null,
+    "DeleteVirtualNode": null,
+    "DeleteVirtualRouter": null,
+    "DeleteVirtualService": null,
+    "DescribeGatewayRoute": null,
+    "DescribeMesh": null,
+    "DescribeRoute": null,
+    "DescribeVirtualGateway": null,
+    "DescribeVirtualNode": null,
+    "DescribeVirtualRouter": null,
+    "DescribeVirtualService": null,
+    "GetMeshPolicy": null,
+    "ListGatewayRoutes": null,
+    "ListMeshes": null,
+    "ListRoutes": null,
+    "ListTagsForResource": null,
+    "ListVirtualGateways": null,
+    "ListVirtualNodes": null,
+    "ListVirtualRouters": null,
+    "ListVirtualServices": null,
+    "PutMeshPolicy": null,
+    "TagResource": null,
+    "UntagResource": null,
+    "UpdateGatewayRoute": null,
+    "UpdateMesh": null,
+    "UpdateRoute": null,
+    "UpdateVirtualGateway": null,
+    "UpdateVirtualNode": null,
+    "UpdateVirtualRouter": null,
+    "UpdateVirtualService": null
+  },
+  "shapes": {
+    "AccessLog": {
+      "base": null,
+      "refs": { }
+    },
+    "AccountId": {
+      "base": null,
+      "refs": { }
+    },
+    "Arn": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapInstanceAttribute": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapInstanceAttributeKey": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapInstanceAttributeValue": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapInstanceAttributes": {
+      "base": null,
+      "refs": {
+        "AwsCloudMapInstanceAttributes$member": null
+      }
+    },
+    "AwsCloudMapName": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapServiceDiscovery": {
+      "base": null,
+      "refs": { }
+    },
+    "Backend": {
+      "base": null,
+      "refs": { }
+    },
+    "BackendDefaults": {
+      "base": null,
+      "refs": { }
+    },
+    "Backends": {
+      "base": null,
+      "refs": {
+        "Backends$member": null
+      }
+    },
+    "BadRequestException": {
+      "base": null,
+      "refs": { }
+    },
+    "Boolean": {
+      "base": null,
+      "refs": { }
+    },
+    "CertificateAuthorityArns": {
+      "base": null,
+      "refs": {
+        "CertificateAuthorityArns$member": null
+      }
+    },
+    "ClientPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "ClientPolicyTls": {
+      "base": null,
+      "refs": { }
+    },
+    "ConflictException": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateGatewayRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateGatewayRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateMeshInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateMeshOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualGatewayInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualGatewayOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualNodeInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualNodeOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualRouterInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualRouterOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualServiceInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualServiceOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteGatewayRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteGatewayRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteMeshInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteMeshOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteMeshPolicyInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteMeshPolicyOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualGatewayInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualGatewayOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualNodeInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualNodeOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualRouterInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualRouterOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualServiceInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualServiceOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeGatewayRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeGatewayRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeMeshInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeMeshOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualGatewayInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualGatewayOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualNodeInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualNodeOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualRouterInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualRouterOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualServiceInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualServiceOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DnsServiceDiscovery": {
+      "base": null,
+      "refs": { }
+    },
+    "Duration": {
+      "base": null,
+      "refs": { }
+    },
+    "DurationUnit": {
+      "base": null,
+      "refs": { }
+    },
+    "DurationValue": {
+      "base": null,
+      "refs": { }
+    },
+    "EgressFilter": {
+      "base": null,
+      "refs": { }
+    },
+    "EgressFilterType": {
+      "base": null,
+      "refs": { }
+    },
+    "FileAccessLog": {
+      "base": null,
+      "refs": { }
+    },
+    "FilePath": {
+      "base": null,
+      "refs": { }
+    },
+    "ForbiddenException": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteData": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteList": {
+      "base": null,
+      "refs": {
+        "GatewayRouteList$member": null
+      }
+    },
+    "GatewayRouteRef": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteSpec": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteTarget": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteVirtualService": {
+      "base": null,
+      "refs": { }
+    },
+    "GetMeshPolicyInput": {
+      "base": null,
+      "refs": { }
+    },
+    "GetMeshPolicyOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcGatewayRoute": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcGatewayRouteAction": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcGatewayRouteMatch": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRetryPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRetryPolicyEvent": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRetryPolicyEvents": {
+      "base": null,
+      "refs": {
+        "GrpcRetryPolicyEvents$member": null
+      }
+    },
+    "GrpcRoute": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRouteAction": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRouteMatch": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRouteMetadata": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRouteMetadataList": {
+      "base": null,
+      "refs": {
+        "GrpcRouteMetadataList$member": null
+      }
+    },
+    "GrpcRouteMetadataMatchMethod": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcTimeout": {
+      "base": null,
+      "refs": { }
+    },
+    "HeaderMatch": {
+      "base": null,
+      "refs": { }
+    },
+    "HeaderMatchMethod": {
+      "base": null,
+      "refs": { }
+    },
+    "HeaderName": {
+      "base": null,
+      "refs": { }
+    },
+    "HealthCheckIntervalMillis": {
+      "base": null,
+      "refs": { }
+    },
+    "HealthCheckPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "HealthCheckThreshold": {
+      "base": null,
+      "refs": { }
+    },
+    "HealthCheckTimeoutMillis": {
+      "base": null,
+      "refs": { }
+    },
+    "Hostname": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpGatewayRoute": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpGatewayRouteAction": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpGatewayRouteMatch": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpMethod": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpRetryPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpRetryPolicyEvent": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpRetryPolicyEvents": {
+      "base": null,
+      "refs": {
+        "HttpRetryPolicyEvents$member": null
+      }
+    },
+    "HttpRoute": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpRouteAction": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpRouteHeader": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpRouteHeaders": {
+      "base": null,
+      "refs": {
+        "HttpRouteHeaders$member": null
+      }
+    },
+    "HttpRouteMatch": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpScheme": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpTimeout": {
+      "base": null,
+      "refs": { }
+    },
+    "IamPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "InternalServerErrorException": {
+      "base": null,
+      "refs": { }
+    },
+    "LimitExceededException": {
+      "base": null,
+      "refs": { }
+    },
+    "ListGatewayRoutesInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListGatewayRoutesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListGatewayRoutesOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListMeshesInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListMeshesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListMeshesOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListRoutesInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListRoutesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListRoutesOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListTagsForResourceInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListTagsForResourceOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualGatewaysInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualGatewaysLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualGatewaysOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualNodesInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualNodesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualNodesOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualRoutersInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualRoutersLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualRoutersOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualServicesInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualServicesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualServicesOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "Listener": {
+      "base": null,
+      "refs": { }
+    },
+    "ListenerTimeout": {
+      "base": null,
+      "refs": { }
+    },
+    "ListenerTls": {
+      "base": null,
+      "refs": { }
+    },
+    "ListenerTlsAcmCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "ListenerTlsCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "ListenerTlsFileCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "ListenerTlsMode": {
+      "base": null,
+      "refs": { }
+    },
+    "ListenerTlsSdsCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "Listeners": {
+      "base": null,
+      "refs": {
+        "Listeners$member": null
+      }
+    },
+    "Logging": {
+      "base": null,
+      "refs": { }
+    },
+    "Long": {
+      "base": null,
+      "refs": { }
+    },
+    "MatchRange": {
+      "base": null,
+      "refs": { }
+    },
+    "MaxRetries": {
+      "base": null,
+      "refs": { }
+    },
+    "MeshData": {
+      "base": null,
+      "refs": { }
+    },
+    "MeshList": {
+      "base": null,
+      "refs": {
+        "MeshList$member": null
+      }
+    },
+    "MeshRef": {
+      "base": null,
+      "refs": { }
+    },
+    "MeshSpec": {
+      "base": null,
+      "refs": { }
+    },
+    "MeshStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "MeshStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "MethodName": {
+      "base": null,
+      "refs": { }
+    },
+    "NotFoundException": {
+      "base": null,
+      "refs": { }
+    },
+    "PercentInt": {
+      "base": null,
+      "refs": { }
+    },
+    "PortMapping": {
+      "base": null,
+      "refs": { }
+    },
+    "PortNumber": {
+      "base": null,
+      "refs": { }
+    },
+    "PortProtocol": {
+      "base": null,
+      "refs": { }
+    },
+    "PortSet": {
+      "base": null,
+      "refs": {
+        "PortSet$member": null
+      }
+    },
+    "PutMeshPolicyInput": {
+      "base": null,
+      "refs": { }
+    },
+    "PutMeshPolicyOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ResourceInUseException": {
+      "base": null,
+      "refs": { }
+    },
+    "ResourceMetadata": {
+      "base": null,
+      "refs": { }
+    },
+    "ResourceName": {
+      "base": null,
+      "refs": { }
+    },
+    "RouteData": {
+      "base": null,
+      "refs": { }
+    },
+    "RouteList": {
+      "base": null,
+      "refs": {
+        "RouteList$member": null
+      }
+    },
+    "RoutePriority": {
+      "base": null,
+      "refs": { }
+    },
+    "RouteRef": {
+      "base": null,
+      "refs": { }
+    },
+    "RouteSpec": {
+      "base": null,
+      "refs": { }
+    },
+    "RouteStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "RouteStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "SdsSecretName": {
+      "base": null,
+      "refs": { }
+    },
+    "SdsSource": {
+      "base": null,
+      "refs": { }
+    },
+    "SdsUnixDomainSocketSource": {
+      "base": null,
+      "refs": { }
+    },
+    "ServiceDiscovery": {
+      "base": null,
+      "refs": { }
+    },
+    "ServiceName": {
+      "base": null,
+      "refs": { }
+    },
+    "ServiceUnavailableException": {
+      "base": null,
+      "refs": { }
+    },
+    "String": {
+      "base": null,
+      "refs": { }
+    },
+    "TagKey": {
+      "base": null,
+      "refs": { }
+    },
+    "TagKeyList": {
+      "base": null,
+      "refs": {
+        "TagKeyList$member": null
+      }
+    },
+    "TagList": {
+      "base": null,
+      "refs": {
+        "TagList$member": null
+      }
+    },
+    "TagRef": {
+      "base": null,
+      "refs": { }
+    },
+    "TagResourceInput": {
+      "base": null,
+      "refs": { }
+    },
+    "TagResourceOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "TagValue": {
+      "base": null,
+      "refs": { }
+    },
+    "TagsLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "TcpRetryPolicyEvent": {
+      "base": null,
+      "refs": { }
+    },
+    "TcpRetryPolicyEvents": {
+      "base": null,
+      "refs": {
+        "TcpRetryPolicyEvents$member": null
+      }
+    },
+    "TcpRoute": {
+      "base": null,
+      "refs": { }
+    },
+    "TcpRouteAction": {
+      "base": null,
+      "refs": { }
+    },
+    "TcpTimeout": {
+      "base": null,
+      "refs": { }
+    },
+    "Timestamp": {
+      "base": null,
+      "refs": { }
+    },
+    "TlsValidationContext": {
+      "base": null,
+      "refs": { }
+    },
+    "TlsValidationContextAcmTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "TlsValidationContextFileTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "TlsValidationContextSdsTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "TlsValidationContextTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "TooManyRequestsException": {
+      "base": null,
+      "refs": { }
+    },
+    "TooManyTagsException": {
+      "base": null,
+      "refs": { }
+    },
+    "UntagResourceInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UntagResourceOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateGatewayRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateGatewayRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateMeshInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateMeshOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualGatewayInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualGatewayOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualNodeInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualNodeOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualRouterInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualRouterOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualServiceInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualServiceOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayAccessLog": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayBackendDefaults": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayCertificateAuthorityArns": {
+      "base": null,
+      "refs": {
+        "VirtualGatewayCertificateAuthorityArns$member": null
+      }
+    },
+    "VirtualGatewayClientPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayClientPolicyTls": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayData": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayFileAccessLog": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayHealthCheckIntervalMillis": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayHealthCheckPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayHealthCheckThreshold": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayHealthCheckTimeoutMillis": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayList": {
+      "base": null,
+      "refs": {
+        "VirtualGatewayList$member": null
+      }
+    },
+    "VirtualGatewayListener": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTls": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsAcmCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsFileCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsMode": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsSdsCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListeners": {
+      "base": null,
+      "refs": {
+        "VirtualGatewayListeners$member": null
+      }
+    },
+    "VirtualGatewayLogging": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayPortMapping": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayPortProtocol": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayRef": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewaySdsSecretName": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewaySdsSource": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewaySdsUnixDomainSocketSource": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewaySpec": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContext": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContextAcmTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContextFileTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContextSdsTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContextTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualNodeData": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualNodeList": {
+      "base": null,
+      "refs": {
+        "VirtualNodeList$member": null
+      }
+    },
+    "VirtualNodeRef": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualNodeServiceProvider": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualNodeSpec": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualNodeStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualNodeStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualRouterData": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualRouterList": {
+      "base": null,
+      "refs": {
+        "VirtualRouterList$member": null
+      }
+    },
+    "VirtualRouterListener": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualRouterListeners": {
+      "base": null,
+      "refs": {
+        "VirtualRouterListeners$member": null
+      }
+    },
+    "VirtualRouterRef": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualRouterServiceProvider": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualRouterSpec": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualRouterStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualRouterStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualServiceBackend": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualServiceData": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualServiceList": {
+      "base": null,
+      "refs": {
+        "VirtualServiceList$member": null
+      }
+    },
+    "VirtualServiceProvider": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualServiceRef": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualServiceSpec": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualServiceStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualServiceStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "WeightedTarget": {
+      "base": null,
+      "refs": { }
+    },
+    "WeightedTargets": {
+      "base": null,
+      "refs": {
+        "WeightedTargets$member": null
+      }
+    }
+  }
+}

--- a/appmesh_models_override/examples-1.json
+++ b/appmesh_models_override/examples-1.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0",
+  "examples": { }
+}

--- a/appmesh_models_override/paginators-1.json
+++ b/appmesh_models_override/paginators-1.json
@@ -1,0 +1,52 @@
+{
+  "pagination": {
+    "ListGatewayRoutes": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "gatewayRoutes"
+    },
+    "ListMeshes": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "meshes"
+    },
+    "ListRoutes": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "routes"
+    },
+    "ListTagsForResource": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "tags"
+    },
+    "ListVirtualGateways": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "virtualGateways"
+    },
+    "ListVirtualNodes": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "virtualNodes"
+    },
+    "ListVirtualRouters": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "virtualRouters"
+    },
+    "ListVirtualServices": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "virtualServices"
+    }
+  }
+}

--- a/appmesh_models_override/setup.sh
+++ b/appmesh_models_override/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+mkdir -p ./vendor/github.com/aws
+
+git clone --depth 1 git@github.com:aws/aws-sdk-go.git ./vendor/github.com/aws/aws-sdk-go/
+API_PATH=./vendor/github.com/aws/aws-sdk-go/models/apis/appmesh/2019-01-25
+cp appmesh_models_override/api-2.json $API_PATH/api-2.json
+cp appmesh_models_override/docs-2.json $API_PATH/docs-2.json
+cp appmesh_models_override/examples-1.json $API_PATH/examples-1.json
+cp appmesh_models_override/paginators-1.json $API_PATH/paginators-1.json
+
+pushd ./vendor/github.com/aws/aws-sdk-go
+make generate
+popd
+
+# Use the vendored version of aws-sdk-go
+go mod edit -replace github.com/aws/aws-sdk-go=./vendor/github.com/aws/aws-sdk-go
+go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.0.0
-	github.com/prometheus/common v0.4.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.10.0
@@ -26,7 +25,6 @@ require (
 	k8s.io/apimachinery v0.18.2
 	k8s.io/cli-runtime v0.18.2
 	k8s.io/client-go v0.18.2
-	k8s.io/klog v1.0.0
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.6.0
 )


### PR DESCRIPTION
*Description of changes:*
Some of the App Mesh preview features are only available in the preview version of aws-sdk-go. To speed up the development and work in parallel to aws-sdk-go changes, we will have an option to override the api models for appmesh aws-sdk-go

This change includes aws-sdk-go API override support with App Mesh preview changes for Virtual Gateway to
- allow us to merge new preview features like virtual gateway controller, gateway route controller, upstream timeouts
- avoid broken builds

Note: the override option is disabled for master branch. We will evaluate later if we want to keep it in the long term or change it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
