### PR TITLE
Use appmesh-preview endpoint in aws-sdk-go override

### DIFF
--- a/appmesh_models_override/api-2.json
+++ b/appmesh_models_override/api-2.json
@@ -2,13 +2,13 @@
   "version": "2.0",
   "metadata": {
     "apiVersion": "2019-01-25",
-    "endpointPrefix": "appmesh",
+    "endpointPrefix": "appmesh-preview",
     "jsonVersion": "1.1",
     "protocol": "rest-json",
     "serviceFullName": "AWS App Mesh",
     "serviceId": "App Mesh",
     "signatureVersion": "v4",
-    "signingName": "appmesh",
+    "signingName": "appmesh-preview",
     "uid": "appmesh-2019-01-25"
   },
   "documentation": null,

--- a/appmesh_models_override/setup.sh
+++ b/appmesh_models_override/setup.sh
@@ -2,7 +2,7 @@
 
 mkdir -p ./vendor/github.com/aws
 
-git clone --depth 1 git@github.com:aws/aws-sdk-go.git ./vendor/github.com/aws/aws-sdk-go/
+git clone --depth 1 https://github.com/aws/aws-sdk-go.git ./vendor/github.com/aws/aws-sdk-go/
 API_PATH=./vendor/github.com/aws/aws-sdk-go/models/apis/appmesh/2019-01-25
 cp appmesh_models_override/api-2.json $API_PATH/api-2.json
 cp appmesh_models_override/docs-2.json $API_PATH/docs-2.json


### PR DESCRIPTION
*Description of changes:*
Use appmesh-preview endpoint in aws-sdk-go override so the SDK makes calls to the appmesh-preview service [1]

[1]https://docs.aws.amazon.com/app-mesh/latest/userguide/preview.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
