### PR TITLE
Allow abbreviated commit fallback in version during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go mod download
 
 # Build
 ENV VERSION_PKG=github.com/aws/aws-app-mesh-controller-for-k8s/pkg/version
-RUN GIT_VERSION=$(git describe --tags --dirty) && \
+RUN GIT_VERSION=$(git describe --tags --dirty --always) && \
     GIT_COMMIT=$(git rev-parse HEAD) && \
     BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \


### PR DESCRIPTION
*Description of changes:*

If no tags are relevant to the current HEAD commit, the build will fail with:

```
Step 6/11 : RUN GIT_VERSION=$(git describe --tags --dirty) &&     GIT_COMMIT=$(git rev-parse HEAD) &&     BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) &&     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build     -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -a -o manager main.go
 ---> Running in 159db7c07d14
fatal: No tags can describe 'bde822f4b8a9e4687474b1bb6a4d01ea86cd4a04'.
Try --always, or create some tags.
```

This change allows the version to be an abbreviated commit message, e.g. `be4c0fc-dirty`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
