### PR TITLE
Allow controller to optionally use App Mesh preview environment

### DIFF
--- a/appmesh_models_override/setup.sh
+++ b/appmesh_models_override/setup.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
+set -e
+
 mkdir -p ./vendor/github.com/aws
 
-git clone --depth 1 https://github.com/aws/aws-sdk-go.git ./vendor/github.com/aws/aws-sdk-go/
-API_PATH=./vendor/github.com/aws/aws-sdk-go/models/apis/appmesh/2019-01-25
-cp appmesh_models_override/api-2.json $API_PATH/api-2.json
+SDK_VENDOR_PATH=./vendor/github.com/aws/aws-sdk-go
+rm -rf $SDK_VENDOR_PATH
+git clone --depth 1 https://github.com/aws/aws-sdk-go.git $SDK_VENDOR_PATH
+API_PATH=$SDK_VENDOR_PATH/models/apis/appmesh/2019-01-25
+SERVICE_NAME=$([ "$APPMESH_PREVIEW" == "1" ] && echo "appmesh-preview" || echo "appmesh" )
+cat appmesh_models_override/api-2.json | jq "(.metadata | .endpointPrefix?, .signingName?) |= \"$SERVICE_NAME\"" > $API_PATH/api-2.json
 cp appmesh_models_override/docs-2.json $API_PATH/docs-2.json
 cp appmesh_models_override/examples-1.json $API_PATH/examples-1.json
 cp appmesh_models_override/paginators-1.json $API_PATH/paginators-1.json


### PR DESCRIPTION
*Issue #, if available:* #75 

*Description of changes:*

While not perfect, this change will allow us to swap out the signing name used for App Mesh, which differs between the preview and production environments.

A few more changes are needed to make this durable long term:
1. Currently the [published preview model](https://github.com/aws/aws-app-mesh-roadmap/tree/master/appmesh-preview) does not include common APIs used in production like `TagResource`, so it can't be used as the source. We can actually change that, as those APIs are gated by feature toggles in the preview environment anyway.
2. Once we've solved #1 above, we can effectively use this solution to make the controller capable of running against preview long term by `curl`ing the published preview API model and building the controller against it.

*Testing:*

Tested both variants:
```
APPMESH_PREVIEW=1 make setup-appmesh-sdk-override
make setup-appmesh-sdk-override
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
