### PR TITLE
Remove podSelector from virtual gateway

### DIFF
--- a/apis/appmesh/v1beta2/virtualgateway_types.go
+++ b/apis/appmesh/v1beta2/virtualgateway_types.go
@@ -244,10 +244,6 @@ type VirtualGatewaySpec struct {
 	// This field follows standard label selector semantics; if present but empty, it selects all namespaces.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
-	// PodSelector selects Pods using labels to designate VirtualGateway membership.
-	// if unspecified or empty, it selects no pods.
-	// +optional
-	PodSelector *metav1.LabelSelector `json:"podSelector,omitempty"`
 	// The listener that the virtual gateway is expected to receive inbound traffic from
 	// +kubebuilder:validation:MinItems=0
 	// +kubebuilder:validation:MaxItems=1

--- a/apis/appmesh/v1beta2/zz_generated.deepcopy.go
+++ b/apis/appmesh/v1beta2/zz_generated.deepcopy.go
@@ -1894,11 +1894,6 @@ func (in *VirtualGatewaySpec) DeepCopyInto(out *VirtualGatewaySpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.PodSelector != nil {
-		in, out := &in.PodSelector, &out.PodSelector
-		*out = new(v1.LabelSelector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Listeners != nil {
 		in, out := &in.Listeners, &out.Listeners
 		*out = make([]VirtualGatewayListener, len(*in))

--- a/config/crd/bases/appmesh.k8s.aws_virtualgateways.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualgateways.yaml
@@ -343,50 +343,6 @@ spec:
                     are ANDed.
                   type: object
               type: object
-            podSelector:
-              description: PodSelector selects Pods using labels to designate VirtualGateway
-                membership. if unspecified or empty, it selects no pods.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies
-                          to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
-                  type: object
-              type: object
           type: object
         status:
           description: VirtualGatewayStatus defines the observed state of VirtualGateway


### PR DESCRIPTION
*Description of changes:*
In the virtual gateway support, (similar to ECS) a pod will be referenced to a virtual gateway by the user. Therefore, podSelector is not needed in the virtual gateway spec in the current version. In the future, we will be adding support in the controller to instantiate an envoy with virtual gateway for better user experience


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
