### PR TITLE
change leaderElectionID to appmesh-manager-leader-election

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "f4abe831.k8s.aws",
+		LeaderElectionID:   "appmesh-manager-leader-election",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
change the leaderElectionID from auto-generated `f4abe831.k8s.aws` to more meanful `appmesh-manager-leader-election`. 
Note: this leaderElectionID will be the configmap name of leaderElection configmap

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
