### PR TITLE
Add config mutator for virtual gateway envoy

### DIFF
--- a/apis/appmesh/v1beta2/virtualgateway_types.go
+++ b/apis/appmesh/v1beta2/virtualgateway_types.go
@@ -244,6 +244,12 @@ type VirtualGatewaySpec struct {
 	// This field follows standard label selector semantics; if present but empty, it selects all namespaces.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
+	// PodSelector selects Pods using labels to designate VirtualGateway membership.
+	// This field follows standard label selector semantics:
+	//	if present but empty, it selects all pods within namespace.
+	// 	if absent, it selects no pod.
+	// +optional
+	PodSelector *metav1.LabelSelector `json:"podSelector,omitempty"`
 	// The listener that the virtual gateway is expected to receive inbound traffic from
 	// +kubebuilder:validation:MinItems=0
 	// +kubebuilder:validation:MaxItems=1

--- a/apis/appmesh/v1beta2/zz_generated.deepcopy.go
+++ b/apis/appmesh/v1beta2/zz_generated.deepcopy.go
@@ -1894,6 +1894,11 @@ func (in *VirtualGatewaySpec) DeepCopyInto(out *VirtualGatewaySpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PodSelector != nil {
+		in, out := &in.PodSelector, &out.PodSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Listeners != nil {
 		in, out := &in.Listeners, &out.Listeners
 		*out = make([]VirtualGatewayListener, len(*in))

--- a/config/crd/bases/appmesh.k8s.aws_virtualgateways.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualgateways.yaml
@@ -343,6 +343,52 @@ spec:
                     are ANDed.
                   type: object
               type: object
+            podSelector:
+              description: "PodSelector selects Pods using labels to designate VirtualGateway
+                membership. This field follows standard label selector semantics:
+                \tif present but empty, it selects all pods within namespace. \tif
+                absent, it selects no pod."
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
           type: object
         status:
           description: VirtualGatewayStatus defines the observed state of VirtualGateway

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 	meshMembershipDesignator := mesh.NewMembershipDesignator(mgr.GetClient())
 	vgMembershipDesignator := virtualgateway.NewMembershipDesignator(mgr.GetClient())
 	vnMembershipDesignator := virtualnode.NewMembershipDesignator(mgr.GetClient())
-	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.AccountID(), cloud.Region(), mgr.GetClient(), referencesResolver, vnMembershipDesignator)
+	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.AccountID(), cloud.Region(), mgr.GetClient(), referencesResolver, vnMembershipDesignator, vgMembershipDesignator)
 	appmeshwebhook.NewMeshMutator().SetupWithManager(mgr)
 	appmeshwebhook.NewMeshValidator().SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualGatewayMutator(meshMembershipDesignator).SetupWithManager(mgr)

--- a/pkg/inject/envoy.go
+++ b/pkg/inject/envoy.go
@@ -123,7 +123,7 @@ type envoyMutator struct {
 }
 
 func (m *envoyMutator) mutate(pod *corev1.Pod) error {
-	if containsEnvoyContainer(pod) {
+	if ok, _ := containsEnvoyContainer(pod); ok {
 		return nil
 	}
 	secretMounts, err := m.getSecretMounts(pod)
@@ -221,16 +221,6 @@ func (m *envoyMutator) getSecretMounts(pod *corev1.Pod) (map[string]string, erro
 		}
 	}
 	return secretMounts, nil
-}
-
-// containsEnvoyContainer checks whether pod already contains "envoy" container
-func containsEnvoyContainer(pod *corev1.Pod) bool {
-	for _, container := range pod.Spec.Containers {
-		if container.Name == envoyContainerName {
-			return true
-		}
-	}
-	return false
 }
 
 // containsEnvoyTracingConfigVolume checks whether pod already contains "envoy-tracing-config" volume

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -876,54 +876,6 @@ func Test_envoyMutator_getPreview(t *testing.T) {
 	}
 }
 
-func Test_containsEnvoyContainer(t *testing.T) {
-	type args struct {
-		pod *corev1.Pod
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "contains envoy container",
-			args: args{
-				pod: &corev1.Pod{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name: "envoy",
-							},
-						},
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "doesn't contains envoy container",
-			args: args{
-				pod: &corev1.Pod{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name: "other",
-							},
-						},
-					},
-				},
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := containsEnvoyContainer(tt.args.pod)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func Test_containsEnvoyTracingConfigVolume(t *testing.T) {
 	type args struct {
 		pod *corev1.Pod

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -137,7 +137,7 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 		}
 	} else if vg != nil {
 		mutators = []PodMutator{newVirtualGatewayEnvoyConfig(virtualGatwayEnvoyConfig{
-			accountID:             m.accountID,
+			accountID:    m.accountID,
 			awsRegion:    m.awsRegion,
 			preview:      m.config.Preview,
 			logLevel:     m.config.LogLevel,

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualgateway"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -24,19 +25,22 @@ type SidecarInjector struct {
 	awsRegion              string
 	k8sClient              client.Client
 	referenceResolver      references.Resolver
+	vgMembershipDesignator virtualgateway.MembershipDesignator
 	vnMembershipDesignator virtualnode.MembershipDesignator
 }
 
 func NewSidecarInjector(cfg Config, accountID string, awsRegion string,
 	k8sClient client.Client,
 	referenceResolver references.Resolver,
-	vnMembershipDesignator virtualnode.MembershipDesignator) *SidecarInjector {
+	vnMembershipDesignator virtualnode.MembershipDesignator,
+	vgMembershipDesignator virtualgateway.MembershipDesignator) *SidecarInjector {
 	return &SidecarInjector{
 		config:                 cfg,
 		accountID:              accountID,
 		awsRegion:              awsRegion,
 		k8sClient:              k8sClient,
 		referenceResolver:      referenceResolver,
+		vgMembershipDesignator: vgMembershipDesignator,
 		vnMembershipDesignator: vnMembershipDesignator,
 	}
 }
@@ -54,60 +58,92 @@ func (m *SidecarInjector) Inject(ctx context.Context, pod *corev1.Pod) error {
 		return err
 	}
 
-	if vn == nil || vn.Spec.MeshRef == nil {
-		if injectMode == sidecarInjectModeEnabled {
-			return errors.New("sidecarInject enabled but no matching VirtualNode found")
-		}
-		return nil
-	}
-	ms, err := m.referenceResolver.ResolveMeshReference(ctx, *vn.Spec.MeshRef)
+	vg, err := m.vgMembershipDesignator.DesignateForPod(ctx, pod)
 	if err != nil {
 		return err
 	}
-	return m.injectAppMeshPatches(ms, vn, pod)
+
+	if vn != nil && vg != nil {
+		return errors.Errorf("sidecarInject enabled for both virtualNode %s and virtualGateway %s on pod %s. Please use podSelector on one", vn.Name, vg.Name, pod.Name)
+	}
+
+	if (vn == nil || vn.Spec.MeshRef == nil) && (vg == nil || vg.Spec.MeshRef == nil) {
+		if injectMode == sidecarInjectModeEnabled {
+			return errors.New("sidecarInject enabled but no matching VirtualNode or VirtualGateway found")
+		}
+		return nil
+	}
+
+	var msRef *appmesh.MeshReference
+	if vn != nil {
+		msRef = vn.Spec.MeshRef
+	} else if vg != nil {
+		msRef = vg.Spec.MeshRef
+	} else {
+		return errors.New("No matching VirtualNode or VirtualGateway found to resolve Mesh reference")
+	}
+
+	ms, err := m.referenceResolver.ResolveMeshReference(ctx, *msRef)
+	if err != nil {
+		return err
+	}
+	return m.injectAppMeshPatches(ms, vn, vg, pod)
 }
 
-func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.VirtualNode, pod *corev1.Pod) error {
+func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.VirtualNode, vg *appmesh.VirtualGateway, pod *corev1.Pod) error {
 	// List out all the mutators in sequence
-	var mutators = []PodMutator{
-		newProxyMutator(proxyMutatorConfig{
-			egressIgnoredIPs: m.config.IgnoredIPs,
-			initProxyMutatorConfig: initProxyMutatorConfig{
-				containerImage: m.config.InitImage,
-				cpuRequests:    m.config.SidecarCpu,
-				memoryRequests: m.config.SidecarMemory,
-			},
-		}, vn),
-		newEnvoyMutator(envoyMutatorConfig{
+	var mutators []PodMutator
+
+	if vn != nil {
+		mutators = []PodMutator{
+			newProxyMutator(proxyMutatorConfig{
+				egressIgnoredIPs: m.config.IgnoredIPs,
+				initProxyMutatorConfig: initProxyMutatorConfig{
+					containerImage: m.config.InitImage,
+					cpuRequests:    m.config.SidecarCpu,
+					memoryRequests: m.config.SidecarMemory,
+				},
+			}, vn),
+			newEnvoyMutator(envoyMutatorConfig{
+				accountID:             m.accountID,
+				awsRegion:             m.awsRegion,
+				preview:               m.config.Preview,
+				logLevel:              m.config.LogLevel,
+				sidecarImage:          m.config.SidecarImage,
+				sidecarCPURequests:    m.config.SidecarCpu,
+				sidecarMemoryRequests: m.config.SidecarMemory,
+				enableXrayTracing:     m.config.EnableXrayTracing,
+				enableJaegerTracing:   m.config.EnableJaegerTracing,
+				enableDatadogTracing:  m.config.EnableDatadogTracing,
+				enableStatsTags:       m.config.EnableStatsTags,
+				enableStatsD:          m.config.EnableStatsD,
+			}, ms, vn),
+			newXrayMutator(xrayMutatorConfig{
+				awsRegion:             m.awsRegion,
+				sidecarCPURequests:    m.config.SidecarCpu,
+				sidecarMemoryRequests: m.config.SidecarMemory,
+			}, m.config.EnableXrayTracing),
+			newDatadogMutator(datadogMutatorConfig{
+				datadogAddress: m.config.DatadogAddress,
+				datadogPort:    m.config.DatadogPort,
+			}, m.config.EnableDatadogTracing),
+			newJaegerMutator(jaegerMutatorConfig{
+				jaegerAddress: m.config.JaegerAddress,
+				jaegerPort:    m.config.JaegerPort,
+			}, m.config.EnableJaegerTracing),
+			newCloudMapHealthyReadinessGate(vn),
+			newIAMForServiceAccountsMutator(m.config.EnableIAMForServiceAccounts),
+			newECRSecretMutator(m.config.EnableECRSecret),
+		}
+	} else if vg != nil {
+		mutators = []PodMutator{newVirtualGatewayEnvoyConfig(virtualGatwayEnvoyConfig{
 			accountID:             m.accountID,
-			awsRegion:             m.awsRegion,
-			preview:               m.config.Preview,
-			logLevel:              m.config.LogLevel,
-			sidecarImage:          m.config.SidecarImage,
-			sidecarCPURequests:    m.config.SidecarCpu,
-			sidecarMemoryRequests: m.config.SidecarMemory,
-			enableXrayTracing:     m.config.EnableXrayTracing,
-			enableJaegerTracing:   m.config.EnableJaegerTracing,
-			enableDatadogTracing:  m.config.EnableDatadogTracing,
-			enableStatsTags:       m.config.EnableStatsTags,
-			enableStatsD:          m.config.EnableStatsD,
-		}, ms, vn),
-		newXrayMutator(xrayMutatorConfig{
-			awsRegion:             m.awsRegion,
-			sidecarCPURequests:    m.config.SidecarCpu,
-			sidecarMemoryRequests: m.config.SidecarMemory,
-		}, m.config.EnableXrayTracing),
-		newDatadogMutator(datadogMutatorConfig{
-			datadogAddress: m.config.DatadogAddress,
-			datadogPort:    m.config.DatadogPort,
-		}, m.config.EnableDatadogTracing),
-		newJaegerMutator(jaegerMutatorConfig{
-			jaegerAddress: m.config.JaegerAddress,
-			jaegerPort:    m.config.JaegerPort,
-		}, m.config.EnableJaegerTracing),
-		newCloudMapHealthyReadinessGate(vn),
-		newIAMForServiceAccountsMutator(m.config.EnableIAMForServiceAccounts),
-		newECRSecretMutator(m.config.EnableECRSecret),
+			awsRegion:    m.awsRegion,
+			preview:      m.config.Preview,
+			logLevel:     m.config.LogLevel,
+			sidecarImage: m.config.SidecarImage,
+		}, ms, vg),
+		}
 	}
 
 	for _, mutator := range mutators {

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -224,9 +224,9 @@ func Test_InjectEnvoyContainer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inj := NewSidecarInjector(tt.conf, "000000000000", "us-west-2", nil, nil, nil)
+			inj := NewSidecarInjector(tt.conf, "000000000000", "us-west-2", nil, nil, nil, nil)
 			pod := tt.args.pod
-			inj.injectAppMeshPatches(tt.args.ms, tt.args.vn, pod)
+			inj.injectAppMeshPatches(tt.args.ms, tt.args.vn, nil, pod)
 			assert.Equal(t, tt.want.init, len(pod.Spec.InitContainers), "Numbers of init containers mismatch")
 			assert.Equal(t, tt.want.containers, len(pod.Spec.Containers), "Numbers of containers mismatch")
 			if tt.want.xray {

--- a/pkg/inject/utils.go
+++ b/pkg/inject/utils.go
@@ -56,3 +56,13 @@ func getSidecarMemoryRequest(defaultMemoryRequest string, pod *corev1.Pod) strin
 	}
 	return defaultMemoryRequest
 }
+
+// containsEnvoyContainer checks whether pod already contains "envoy" container and return the slice index
+func containsEnvoyContainer(pod *corev1.Pod) (bool, int) {
+	for idx, container := range pod.Spec.Containers {
+		if container.Name == envoyContainerName {
+			return true, idx
+		}
+	}
+	return false, -1
+}

--- a/pkg/inject/utils_test.go
+++ b/pkg/inject/utils_test.go
@@ -1,0 +1,55 @@
+package inject
+
+import (
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func Test_containsEnvoyContainer(t *testing.T) {
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "contains envoy container",
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "envoy",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "doesn't contains envoy container",
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "other",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := containsEnvoyContainer(tt.args.pod)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -1,0 +1,121 @@
+package inject
+
+import (
+	"encoding/json"
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+const envoyImageStub = "injector-envoy-image"
+const envoyVirtualGatewayEnvMap = `
+{
+  "APPMESH_VIRTUAL_NODE_NAME": "mesh/{{ .MeshName }}/virtualGateway/{{ .VirtualGatewayName }}",
+  "APPMESH_PREVIEW": "{{ .Preview }}",
+  "ENVOY_LOG_LEVEL": "{{ .LogLevel }}",
+  "AWS_REGION": "{{ .AWSRegion }}"
+}
+`
+
+type VirtualGatewayEnvoyVariables struct {
+	AWSRegion          string
+	MeshName           string
+	VirtualGatewayName string
+	Preview            string
+	LogLevel           string
+}
+
+type virtualGatwayEnvoyConfig struct {
+	awsRegion    string
+	preview      bool
+	logLevel     string
+	sidecarImage string
+}
+
+// newVirtualGatewayEnvoyConfig constructs new newVirtualGatewayEnvoyConfig
+func newVirtualGatewayEnvoyConfig(mutatorConfig virtualGatwayEnvoyConfig, ms *appmesh.Mesh, vg *appmesh.VirtualGateway) *virtualGatewayEnvoyConfig {
+	return &virtualGatewayEnvoyConfig{
+		ms:            ms,
+		mutatorConfig: mutatorConfig,
+		vg:            vg,
+	}
+}
+
+var _ PodMutator = &virtualGatewayEnvoyConfig{}
+
+// mutator adding a virtualgateway config to envoy pod
+type virtualGatewayEnvoyConfig struct {
+	vg            *appmesh.VirtualGateway
+	ms            *appmesh.Mesh
+	mutatorConfig virtualGatwayEnvoyConfig
+}
+
+func (m *virtualGatewayEnvoyConfig) mutate(pod *corev1.Pod) error {
+	ok, envoyIdx := containsEnvoyContainer(pod)
+	if !ok {
+		return nil
+	}
+
+	variables := m.buildTemplateVariables(pod)
+	envoyEnv, err := renderTemplate("vgenvoy", envoyVirtualGatewayEnvMap, variables)
+	if err != nil {
+		return err
+	}
+
+	newEnvMap := map[string]string{}
+	err = json.Unmarshal([]byte(envoyEnv), &newEnvMap)
+	if err != nil {
+		return err
+	}
+
+	//we override the image to latest Envoy so customers do not have to manually manage
+	// envoy versions and let controller handle consistency versions across the mesh
+	if pod.Spec.Containers[envoyIdx].Image == envoyImageStub || pod.Spec.Containers[envoyIdx].Image == m.mutatorConfig.sidecarImage {
+		pod.Spec.Containers[envoyIdx].Image = m.mutatorConfig.sidecarImage
+	} else {
+		return errors.Errorf("invalid envoy image name for injection %s, expected name: %s", pod.Spec.Containers[envoyIdx].Image, envoyImageStub)
+	}
+
+	for idx, env := range pod.Spec.Containers[envoyIdx].Env {
+		if val, ok := newEnvMap[env.Name]; ok {
+			if val != env.Value {
+				pod.Spec.Containers[envoyIdx].Env[idx].Value = val
+			}
+			delete(newEnvMap, env.Name)
+		}
+	}
+
+	for name, value := range newEnvMap {
+		e := corev1.EnvVar{Name: name,
+			Value: value}
+		pod.Spec.Containers[envoyIdx].Env = append(pod.Spec.Containers[envoyIdx].Env, e)
+	}
+	return nil
+}
+
+func (m *virtualGatewayEnvoyConfig) buildTemplateVariables(pod *corev1.Pod) VirtualGatewayEnvoyVariables {
+	meshName := aws.StringValue(m.ms.Spec.AWSName)
+	virtualGatewayName := aws.StringValue(m.vg.Spec.AWSName)
+	preview := m.getPreview(pod)
+
+	return VirtualGatewayEnvoyVariables{
+		AWSRegion:          m.mutatorConfig.awsRegion,
+		MeshName:           meshName,
+		VirtualGatewayName: virtualGatewayName,
+		Preview:            preview,
+		LogLevel:           m.mutatorConfig.logLevel,
+	}
+}
+
+func (m *virtualGatewayEnvoyConfig) getPreview(pod *corev1.Pod) string {
+	preview := m.mutatorConfig.preview
+	if v, ok := pod.ObjectMeta.Annotations[AppMeshPreviewAnnotation]; ok {
+		preview = strings.ToLower(v) == "true"
+	}
+	if preview {
+		return "1"
+	}
+	return "0"
+}

--- a/pkg/inject/virtualgateway_envoy_test.go
+++ b/pkg/inject/virtualgateway_envoy_test.go
@@ -1,0 +1,442 @@
+package inject
+
+import (
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
+	ms := &appmesh.Mesh{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mesh",
+		},
+		Spec: appmesh.MeshSpec{
+			AWSName: aws.String("my-mesh"),
+		},
+	}
+	vg := &appmesh.VirtualGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-vg",
+		},
+		Spec: appmesh.VirtualGatewaySpec{
+			AWSName: aws.String("my-vg_my-ns"),
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-pod",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "envoy",
+					Image: "envoy:v2",
+				},
+			},
+		},
+	}
+
+	podMultipleContainers := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-pod",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "app1",
+					Image: "app1:v2",
+				},
+				{
+					Name:  "envoy",
+					Image: "envoy:v2",
+				},
+				{
+					Name:  "app2",
+					Image: "app2:v1",
+				},
+			},
+		},
+	}
+
+	podExistingEnv := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-pod",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "envoy",
+					Image: "envoy:v2",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "TEST_ENV",
+							Value: "test_val",
+						}},
+				},
+			},
+		},
+	}
+
+	podWithImageStub := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-pod",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "envoy",
+					Image: "injector-envoy-image",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "TEST_ENV",
+							Value: "test_val",
+						}},
+				},
+			},
+		},
+	}
+
+	podDuplicateEnv := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-pod",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "envoy",
+					Image: "envoy:v2",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "TEST_ENV",
+							Value: "test_val",
+						},
+						{
+							Name:  "APPMESH_VIRTUAL_NODE_NAME",
+							Value: "incorrect_node_name",
+						},
+						{
+							Name:  "APPMESH_PREVIEW",
+							Value: "1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	type fields struct {
+		vg            *appmesh.VirtualGateway
+		ms            *appmesh.Mesh
+		mutatorConfig virtualGatwayEnvoyConfig
+	}
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantPod *corev1.Pod
+		wantErr error
+	}{
+		{
+			name: "env append",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:    "us-west-2",
+					preview:      false,
+					logLevel:     "debug",
+					sidecarImage: "envoy:v2",
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod multiple containers",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:    "us-west-2",
+					preview:      false,
+					logLevel:     "debug",
+					sidecarImage: "envoy:v2",
+				},
+			},
+			args: args{
+				pod: podMultipleContainers,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app1",
+							Image: "app1:v2",
+						},
+						{
+							Name:  "app2",
+							Image: "app2:v1",
+						},
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod with existing env and image override",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:    "us-west-2",
+					preview:      false,
+					logLevel:     "debug",
+					sidecarImage: "envoy:v3",
+				},
+			},
+			args: args{
+				pod: podExistingEnv,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v3",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "TEST_ENV",
+									Value: "test_val",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid envoy image name for injection envoy:v2, expected name: injector-envoy-image"),
+		},
+		{
+			name: "pod with image stub",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:    "us-west-2",
+					preview:      false,
+					logLevel:     "debug",
+					sidecarImage: "envoy:v3",
+				},
+			},
+			args: args{
+				pod: podWithImageStub,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v3",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "TEST_ENV",
+									Value: "test_val",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod with duplicate env",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:    "us-west-2",
+					preview:      false,
+					logLevel:     "debug",
+					sidecarImage: "envoy:v2",
+				},
+			},
+			args: args{
+				pod: podDuplicateEnv,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "TEST_ENV",
+									Value: "test_val",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &virtualGatewayEnvoyConfig{
+				vg:            tt.fields.vg,
+				ms:            tt.fields.ms,
+				mutatorConfig: tt.fields.mutatorConfig,
+			}
+			pod := tt.args.pod.DeepCopy()
+			err := m.mutate(pod)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opts := cmp.Options{
+					cmpopts.SortSlices(func(lhs corev1.EnvVar, rhs corev1.EnvVar) bool {
+						return lhs.Name < rhs.Name
+					}),
+					cmpopts.SortSlices(func(lhs corev1.Container, rhs corev1.Container) bool {
+						return lhs.Name < rhs.Name
+					}),
+				}
+				assert.True(t, cmp.Equal(tt.wantPod, pod, opts), "diff", cmp.Diff(tt.wantPod, pod, opts))
+			}
+		})
+	}
+}

--- a/pkg/virtualgateway/membership_designator.go
+++ b/pkg/virtualgateway/membership_designator.go
@@ -3,6 +3,7 @@ package virtualgateway
 import (
 	"context"
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/k8s"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +17,8 @@ import (
 type MembershipDesignator interface {
 	// DesignateForGatewayRoute will choose a VirtualGateway for given namespaced GatewayRoute CR.
 	DesignateForGatewayRoute(ctx context.Context, obj *appmesh.GatewayRoute) (*appmesh.VirtualGateway, error)
+	// DesignateForPod will choose a VirtualGateway for given pod.
+	DesignateForPod(ctx context.Context, pod *corev1.Pod) (*appmesh.VirtualGateway, error)
 }
 
 // NewMembershipDesignator creates new MembershipDesignator.
@@ -28,6 +31,38 @@ var _ MembershipDesignator = &membershipDesignator{}
 // virtualGatewaySelectorDesignator designates VirtualGateway membership based on selectors on VirtualGateway.
 type membershipDesignator struct {
 	k8sClient client.Client
+}
+
+// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=virtualgateways,verbs=get;list;watch
+
+func (d *membershipDesignator) DesignateForPod(ctx context.Context, pod *corev1.Pod) (*appmesh.VirtualGateway, error) {
+	vgList := appmesh.VirtualGatewayList{}
+	if err := d.k8sClient.List(ctx, &vgList, client.InNamespace(pod.Namespace)); err != nil {
+		return nil, errors.Wrap(err, "failed to list VirtualGateways in cluster")
+	}
+
+	var vgCandidates []*appmesh.VirtualGateway
+	for _, vgObj := range vgList.Items {
+		selector, err := metav1.LabelSelectorAsSelector(vgObj.Spec.PodSelector)
+		if err != nil {
+			return nil, err
+		}
+		if selector.Matches(labels.Set(pod.Labels)) {
+			vgCandidates = append(vgCandidates, vgObj.DeepCopy())
+		}
+	}
+	if len(vgCandidates) == 0 {
+		return nil, nil
+	}
+	if len(vgCandidates) > 1 {
+		var vgCandidatesNames []string
+		for _, vg := range vgCandidates {
+			vgCandidatesNames = append(vgCandidatesNames, k8s.NamespacedName(vg).String())
+		}
+		return nil, errors.Errorf("found multiple matching VirtualGateways for pod %s: %s",
+			k8s.NamespacedName(pod).String(), strings.Join(vgCandidatesNames, ","))
+	}
+	return vgCandidates[0], nil
 }
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch

--- a/pkg/virtualgateway/membership_designator_test.go
+++ b/pkg/virtualgateway/membership_designator_test.go
@@ -499,3 +499,414 @@ func Test_virtualGatewayMembershipDesignator_DesignateForGatewayRoute(t *testing
 		})
 	}
 }
+
+func Test_virtualGatewayMembershipDesignator_DesignateForPod(t *testing.T) {
+	testNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "awesome-ns",
+		},
+		Spec: corev1.NamespaceSpec{},
+	}
+
+	secondTestNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "awesome-ns2",
+		},
+		Spec: corev1.NamespaceSpec{},
+	}
+
+	vgWithNilPodSelector := &appmesh.VirtualGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS.Name,
+			Name:      "vg-with-nil-pod-selector",
+		},
+		Spec: appmesh.VirtualGatewaySpec{
+			PodSelector: nil,
+		},
+	}
+	vgWithEmptyPodSelector := &appmesh.VirtualGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS.Name,
+			Name:      "vg-with-empty-pod-selector",
+		},
+		Spec:   appmesh.VirtualGatewaySpec{},
+		Status: appmesh.VirtualGatewayStatus{},
+	}
+	vgWithPodSelectorPodX := &appmesh.VirtualGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS.Name,
+			Name:      "vg-with-pod-selector-pod-x",
+		},
+		Spec: appmesh.VirtualGatewaySpec{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"pod-x": "true",
+				},
+			},
+		},
+	}
+	vgWithPodSelectorPodXSecondNs := &appmesh.VirtualGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secondTestNS.Name,
+			Name:      "vg-with-pod-selector-pod-x",
+		},
+		Spec: appmesh.VirtualGatewaySpec{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"pod-x": "true",
+				},
+			},
+		},
+	}
+	vgWithPodSelectorPodY := &appmesh.VirtualGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS.Name,
+			Name:      "vg-with-pod-selector-pod-y",
+		},
+		Spec: appmesh.VirtualGatewaySpec{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"pod-y": "true",
+				},
+			},
+		},
+	}
+
+	type env struct {
+		namespaces      []*corev1.Namespace
+		virtualGateways []*appmesh.VirtualGateway
+	}
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		want    *appmesh.VirtualGateway
+		wantErr error
+	}{
+		{
+			name: "[a single virtuaGateway with empty pod selector] pod without labels cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithEmptyPodSelector,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+		{
+			name: "[a single virtualGateway with empty pod selector] pod with labels cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithEmptyPodSelector,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"any-key": "any-value",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+		{
+			name: "[a single virtualGateway with nil pod selector] pod without labels cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithNilPodSelector,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+		{
+			name: "[a single virtualGateway with nil pod selector] pod with labels cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithNilPodSelector,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"any-key": "any-value",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+		{
+			name: "[a single virtualGateway selects pod with specific labels] pod with matching labels can be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"pod-x": "true",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    vgWithPodSelectorPodX,
+			wantErr: nil,
+		},
+		{
+			name: "[a single virtualGateway selects pod with specific labels] pod without labels cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+		{
+			name: "[a single virtualGateway selects pod with specific labels] pod with non-matching labels cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"some-key": "some-value",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+		{
+			name: "[multiple virtualGateways - both select namespace with different labels] pod with matching labels for one virtualGateway can be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+					vgWithPodSelectorPodY,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"pod-x": "true",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    vgWithPodSelectorPodX,
+			wantErr: nil,
+		},
+		{
+			name: "[multiple virtualGateways - both select namespace with different labels] pod with matching labels for another virtualGateway can be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+					vgWithPodSelectorPodY,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"pod-y": "true",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    vgWithPodSelectorPodY,
+			wantErr: nil,
+		},
+		{
+			name: "[multiple virtualGateways - both select namespace with different labels] pod with matching labels for both virtualGateways cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+					vgWithPodSelectorPodY,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"pod-x": "true",
+							"pod-y": "true",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("found multiple matching VirtualGateways for pod awesome-ns/my-pod: awesome-ns/vg-with-pod-selector-pod-x,awesome-ns/vg-with-pod-selector-pod-y"),
+		},
+		{
+			name: "[multiple virtualGateways - both select namespace with different labels] pod without labels cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+					vgWithPodSelectorPodY,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+		{
+			name: "[multiple virtualGateways - both select namespace with different labels] pod with non-matching labels cannot be selected",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+					vgWithPodSelectorPodY,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"some-key": "some-value",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+		{
+			name: "[multiple virtualGateways different namespaces with same name ] only the virtualGateway for pod namespaces will be listed and used",
+			env: env{
+				namespaces: []*corev1.Namespace{testNS, secondTestNS},
+				virtualGateways: []*appmesh.VirtualGateway{
+					vgWithPodSelectorPodX,
+					vgWithPodSelectorPodXSecondNs,
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNS.Name,
+						Name:      "my-pod",
+						Labels: map[string]string{
+							"pod-x": "true",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+			want:    vgWithPodSelectorPodX,
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			appmesh.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			designator := NewMembershipDesignator(k8sClient)
+
+			for _, ns := range tt.env.namespaces {
+				err := k8sClient.Create(ctx, ns.DeepCopy())
+				assert.NoError(t, err)
+			}
+			for _, vg := range tt.env.virtualGateways {
+				err := k8sClient.Create(ctx, vg.DeepCopy())
+				assert.NoError(t, err)
+			}
+
+			got, err := designator.DesignateForPod(context.Background(), tt.args.pod)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opts := equality.IgnoreFakeClientPopulatedFields()
+				assert.True(t, cmp.Equal(tt.want, got, opts), "diff", cmp.Diff(tt.want, got, opts))
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Add config mutator for virtual gateway envoy.

If a virtual gateway podSelecter matches on a pod that is not marked for virtual node already, it will inject virtual gateway config to it. The mutated config is added as `env` for the pod and it includes reference to the virtualGateway resources in App Mesh

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
