### PR TITLE
fix virtualnode envoy environment in cross account mesh

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 	meshMembershipDesignator := mesh.NewMembershipDesignator(mgr.GetClient())
 	vgMembershipDesignator := virtualgateway.NewMembershipDesignator(mgr.GetClient())
 	vnMembershipDesignator := virtualnode.NewMembershipDesignator(mgr.GetClient())
-	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.Region(), mgr.GetClient(), referencesResolver, vnMembershipDesignator)
+	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.AccountID(), cloud.Region(), mgr.GetClient(), referencesResolver, vnMembershipDesignator)
 	appmeshwebhook.NewMeshMutator().SetupWithManager(mgr)
 	appmeshwebhook.NewMeshValidator().SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualGatewayMutator(meshMembershipDesignator).SetupWithManager(mgr)

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -20,18 +20,20 @@ type PodMutator interface {
 
 type SidecarInjector struct {
 	config                 Config
+	accountID              string
 	awsRegion              string
 	k8sClient              client.Client
 	referenceResolver      references.Resolver
 	vnMembershipDesignator virtualnode.MembershipDesignator
 }
 
-func NewSidecarInjector(cfg Config, awsRegion string,
+func NewSidecarInjector(cfg Config, accountID string, awsRegion string,
 	k8sClient client.Client,
 	referenceResolver references.Resolver,
 	vnMembershipDesignator virtualnode.MembershipDesignator) *SidecarInjector {
 	return &SidecarInjector{
 		config:                 cfg,
+		accountID:              accountID,
 		awsRegion:              awsRegion,
 		k8sClient:              k8sClient,
 		referenceResolver:      referenceResolver,
@@ -77,6 +79,7 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 			},
 		}, vn),
 		newEnvoyMutator(envoyMutatorConfig{
+			accountID:             m.accountID,
 			awsRegion:             m.awsRegion,
 			preview:               m.config.Preview,
 			logLevel:              m.config.LogLevel,

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -224,7 +224,7 @@ func Test_InjectEnvoyContainer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inj := NewSidecarInjector(tt.conf, "us-west-2", nil, nil, nil)
+			inj := NewSidecarInjector(tt.conf, "000000000000", "us-west-2", nil, nil, nil)
 			pod := tt.args.pod
 			inj.injectAppMeshPatches(tt.args.ms, tt.args.vn, pod)
 			assert.Equal(t, tt.want.init, len(pod.Spec.InitContainers), "Numbers of init containers mismatch")


### PR DESCRIPTION
fix virtualnode envoy environment in cross account mesh


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
