### PR TITLE
Allow skipping image override for virtual gateway sidecar

### DIFF
--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -31,6 +31,9 @@ const (
 	AppMeshSidecarInjectAnnotation = "appmesh.k8s.aws/sidecarInjectorWebhook"
 	//AppMeshSecretMountsAnnotation specifies the list of Secret that need to be mounted to the proxy as a volume
 	AppMeshSecretMountsAnnotation = "appmesh.k8s.aws/secretMounts"
+	//AppMeshGatewaySkipImageOverride specifies if Virtual Gateway sidecar image override needs to be skipped for customers to
+	//for customers to use their own sidecare image for Virtual Gateway
+	AppMeshGatewaySkipImageOverride = "appmesh.k8s.aws/virtualGatewaySkipImageOverride"
 
 	//Pod Labels
 

--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -31,8 +31,8 @@ const (
 	AppMeshSidecarInjectAnnotation = "appmesh.k8s.aws/sidecarInjectorWebhook"
 	//AppMeshSecretMountsAnnotation specifies the list of Secret that need to be mounted to the proxy as a volume
 	AppMeshSecretMountsAnnotation = "appmesh.k8s.aws/secretMounts"
-	//AppMeshGatewaySkipImageOverride specifies if Virtual Gateway sidecar image override needs to be skipped for customers to
-	//for customers to use their own sidecare image for Virtual Gateway
+	//AppMeshGatewaySkipImageOverride specifies if Virtual Gateway sidecar image override needs to be skipped for customers
+	//to use their own sidecare image for Virtual Gateway
 	AppMeshGatewaySkipImageOverride = "appmesh.k8s.aws/virtualGatewaySkipImageOverride"
 
 	//Pod Labels


### PR DESCRIPTION
*Description of changes:*
There may be a case https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/262#discussion_r438472079 where virtual gateway sidecars need to be custom. This change adds an annotation to skip override of virtual gateway sidecar image. The image override is enabled by default and custom image option is there for customers who would prefer this option


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
