### PR TITLE
Change deployment name to appmesh-manager

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -26,7 +26,7 @@ bases:
 
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
-  # If you want your controller-manager to expose the /metrics
+  # If you want your manager to expose the /metrics
   # endpoint w/o any authn/z, please comment the following line.
 #- manager_auth_proxy_patch.yaml
 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,25 +2,25 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: manager
   name: system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: manager
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,8 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-monitor
+    control-plane: manager
+  name: manager-metrics-monitor
   namespace: system
 spec:
   endpoints:
@@ -13,4 +13,4 @@ spec:
       port: https
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-service
+    control-plane: manager
+  name: manager-metrics-service
   namespace: system
 spec:
   ports:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: manager

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -9,4 +9,4 @@ spec:
     - port: 443
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    control-plane: manager


### PR DESCRIPTION
*Description of changes:*
[EKS chart](https://github.com/aws/eks-charts/tree/master/stable/appmesh-manager) and [App Mesh examples](https://github.com/aws/aws-app-mesh-examples/blob/master/walkthroughs/howto-k8s-http-headers/deploy.sh#L58) both use the name `appmesh-manager` for the controller deployment. This change makes the name consistent with the dependencies

*Testing:*
1. Verified installation
```
make install
make deploy

kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.s
pec.containers[].image" | cut -f2 -d ':'|tail -n1
v1beta2-dev2
```
2. Verified an end to end example with resources and traffic






By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
