### PR TITLE
Change annotation value from true to enabled

### DIFF
--- a/pkg/inject/envoy.go
+++ b/pkg/inject/envoy.go
@@ -179,7 +179,7 @@ func (m *envoyMutator) getAugmentedMeshName() string {
 func (m *envoyMutator) getPreview(pod *corev1.Pod) string {
 	preview := m.mutatorConfig.preview
 	if v, ok := pod.ObjectMeta.Annotations[AppMeshPreviewAnnotation]; ok {
-		preview = strings.ToLower(v) == "true"
+		preview = strings.ToLower(v) == "enabled"
 	}
 	if preview {
 		return "1"

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -811,7 +811,7 @@ func Test_envoyMutator_getPreview(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"appmesh.k8s.aws/preview": "true",
+							"appmesh.k8s.aws/preview": "enabled",
 						},
 					},
 				},
@@ -829,7 +829,7 @@ func Test_envoyMutator_getPreview(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"appmesh.k8s.aws/preview": "false",
+							"appmesh.k8s.aws/preview": "disabled",
 						},
 					},
 				},

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -142,9 +142,9 @@ func (m *virtualGatewayEnvoyConfig) virtualGatewayImageOverride(pod *corev1.Pod)
 	}
 
 	switch strings.ToLower(imageOverrideAnnotation) {
-	case "enabled":
+	case gatewayImageOverrideModeEnabled:
 		return false
-	case "disabled":
+	case gatewayImageOverrideModeDisabled:
 		return true
 	default:
 		return true

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -129,9 +129,9 @@ func (m *virtualGatewayEnvoyConfig) getAugmentedMeshName() string {
 
 const (
 	// when enabled, a virtual gateway image will not be overriden
-	gatewayImageOverrideModeEnabled = "enabled"
+	gatewayImageSkipOverrideModeEnabled = "enabled"
 	// when disabled, a virtual gateway image will be overriden. This is also the default behavior
-	gatewayImageOverrideModeDisabled = "disabled"
+	gatewayImageSkipOverrideModeDisabled = "disabled"
 )
 
 func (m *virtualGatewayEnvoyConfig) virtualGatewayImageOverride(pod *corev1.Pod) bool {
@@ -142,9 +142,9 @@ func (m *virtualGatewayEnvoyConfig) virtualGatewayImageOverride(pod *corev1.Pod)
 	}
 
 	switch strings.ToLower(imageOverrideAnnotation) {
-	case gatewayImageOverrideModeEnabled:
+	case gatewayImageSkipOverrideModeEnabled:
 		return false
-	case gatewayImageOverrideModeDisabled:
+	case gatewayImageSkipOverrideModeDisabled:
 		return true
 	default:
 		return true

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -111,7 +111,7 @@ func (m *virtualGatewayEnvoyConfig) buildTemplateVariables(pod *corev1.Pod) Virt
 func (m *virtualGatewayEnvoyConfig) getPreview(pod *corev1.Pod) string {
 	preview := m.mutatorConfig.preview
 	if v, ok := pod.ObjectMeta.Annotations[AppMeshPreviewAnnotation]; ok {
-		preview = strings.ToLower(v) == "true"
+		preview = strings.ToLower(v) == "enabled"
 	}
 	if preview {
 		return "1"
@@ -127,12 +127,27 @@ func (m *virtualGatewayEnvoyConfig) getAugmentedMeshName() string {
 	return meshName
 }
 
+const (
+	// when enabled, a virtual gateway image will not be overriden
+	gatewayImageOverrideModeEnabled = "enabled"
+	// when disabled, a virtual gateway image will be overriden. This is also the default behavior
+	gatewayImageOverrideModeDisabled = "disabled"
+)
+
 func (m *virtualGatewayEnvoyConfig) virtualGatewayImageOverride(pod *corev1.Pod) bool {
 
+	var imageOverrideAnnotation string
 	if v, ok := pod.ObjectMeta.Annotations[AppMeshGatewaySkipImageOverride]; ok {
-		if v == "true" {
-			return false
-		}
+		imageOverrideAnnotation = v
 	}
-	return true
+
+	switch strings.ToLower(imageOverrideAnnotation) {
+	case "enabled":
+		return false
+	case "disabled":
+		return true
+	default:
+		return true
+	}
+
 }

--- a/pkg/inject/virtualgateway_envoy_test.go
+++ b/pkg/inject/virtualgateway_envoy_test.go
@@ -49,7 +49,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 			Namespace: "my-ns",
 			Name:      "my-pod",
 			Annotations: map[string]string{
-				"appmesh.k8s.aws/virtualGatewaySkipImageOverride": "true",
+				"appmesh.k8s.aws/virtualGatewaySkipImageOverride": "enabled",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -237,7 +237,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 					Namespace: "my-ns",
 					Name:      "my-pod",
 					Annotations: map[string]string{
-						"appmesh.k8s.aws/virtualGatewaySkipImageOverride": "true",
+						"appmesh.k8s.aws/virtualGatewaySkipImageOverride": "enabled",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
*Description of changes:*
Two of the annotations used "true" as a value. This would require extra quotes in the YAML and unquoted value would mess up the YAML. This change uses a better name for annotation values `appmesh.k8s.aws/preview` and `appmesh.k8s.aws/virtualGatewaySkipImageOverride`.

After this change, the annotations for App Mesh preview and Virtual Gateway skip image override will be:

```
annotations:
  appmesh.k8s.aws/preview: enabled
  appmesh.k8s.aws/virtualGatewaySkipImageOverride: enabled
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
