### PR TITLE
Enable aws-sdk-go override for master branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,9 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
-
-# By default app mesh aws-sdk-go override is disabled for master
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-ifeq ($(GIT_BRANCH), master)
-APPMESH_SDK_OVERRIDE := "n"
-else
-APPMESH_SDK_OVERRIDE := "y"
-endif
+# app mesh aws-sdk-go override in case we need to build against a custom version
+# TODO(fawadkhaliq) disable this when App Mesh preview SDK is released
+APPMESH_SDK_OVERRIDE ?= "y"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
*Description of changes:*
Enable aws-sdk-go override for the master branch. 

CircleCI is failing because it cannot locate the correct aws-sdk-go dependencies. This is because override was disabled for `master` branch originally. Since `v1beta2` branch is now the new `master`, we don't need to check for different branches anymore. Override is enabled by default until aws-sdk-go with App Mesh preview features is released


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
