### PR TITLE
Extract object namespace information from object request context

### DIFF
--- a/pkg/virtualgateway/membership_designator.go
+++ b/pkg/virtualgateway/membership_designator.go
@@ -40,13 +40,8 @@ func (d *membershipDesignator) DesignateForPod(ctx context.Context, pod *corev1.
 
 	// see https://github.com/kubernetes/kubernetes/issues/88282 and https://github.com/kubernetes/kubernetes/issues/76680
 	req := webhook.ContextGetAdmissionRequest(ctx)
-	podNS := &corev1.Namespace{}
-	if err := d.k8sClient.Get(ctx, types.NamespacedName{Name: req.Namespace}, podNS); err != nil {
-		return nil, err
-	}
-
 	vgList := appmesh.VirtualGatewayList{}
-	if err := d.k8sClient.List(ctx, &vgList, client.InNamespace(podNS.Name)); err != nil {
+	if err := d.k8sClient.List(ctx, &vgList, client.InNamespace(req.Namespace)); err != nil {
 		return nil, errors.Wrap(err, "failed to list VirtualGateways in cluster")
 	}
 

--- a/pkg/virtualgateway/membership_designator_test.go
+++ b/pkg/virtualgateway/membership_designator_test.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/equality"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/webhook"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"testing"
 )
 
@@ -488,7 +491,11 @@ func Test_virtualGatewayMembershipDesignator_DesignateForGatewayRoute(t *testing
 				assert.NoError(t, err)
 			}
 
-			got, err := designator.DesignateForGatewayRoute(context.Background(), tt.args.obj)
+			ctx = webhook.ContextWithAdmissionRequest(ctx, admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{Namespace: "awesome-ns"},
+			})
+
+			got, err := designator.DesignateForGatewayRoute(ctx, tt.args.obj)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
@@ -899,7 +906,11 @@ func Test_virtualGatewayMembershipDesignator_DesignateForPod(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			got, err := designator.DesignateForPod(context.Background(), tt.args.pod)
+			ctx = webhook.ContextWithAdmissionRequest(ctx, admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{Namespace: "awesome-ns"},
+			})
+
+			got, err := designator.DesignateForPod(ctx, tt.args.pod)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {

--- a/pkg/virtualnode/membership_designator.go
+++ b/pkg/virtualnode/membership_designator.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 )
@@ -38,12 +37,8 @@ func (d *membershipDesignator) Designate(ctx context.Context, pod *corev1.Pod) (
 
 	// see https://github.com/kubernetes/kubernetes/issues/88282 and https://github.com/kubernetes/kubernetes/issues/76680
 	req := webhook.ContextGetAdmissionRequest(ctx)
-	podNS := &corev1.Namespace{}
-	if err := d.k8sClient.Get(ctx, types.NamespacedName{Name: req.Namespace}, podNS); err != nil {
-		return nil, err
-	}
 	vnList := appmesh.VirtualNodeList{}
-	if err := d.k8sClient.List(ctx, &vnList, client.InNamespace(podNS.Name)); err != nil {
+	if err := d.k8sClient.List(ctx, &vnList, client.InNamespace(req.Namespace)); err != nil {
 		return nil, errors.Wrap(err, "failed to list VirtualNodes in cluster")
 	}
 


### PR DESCRIPTION
*Description of changes:*
Namespace of submitted objects is not trustworthy in Mutating Webhooks, and may be blank in Validation Webhooks. The namespace needs to always be read out of the AdmissionReview object. See https://github.com/kubernetes/kubernetes/issues/88282

Changed the VirtualNode and VirtualGateway designators to extract namespace information from the admission attributes in the create request


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
