### PR TITLE
Add development instructions, align SDK make flags

### DIFF
--- a/appmesh_models_override/setup.sh
+++ b/appmesh_models_override/setup.sh
@@ -8,7 +8,7 @@ SDK_MODEL_SOURCE=https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/mast
 SDK_VENDOR_PATH=./vendor/github.com/aws/aws-sdk-go
 API_VERSION=2019-01-25
 API_PATH=$SDK_VENDOR_PATH/models/apis/appmesh/$API_VERSION
-SERVICE_NAME=$([ "$APPMESH_PREVIEW" == "1" ] && echo "appmesh-preview" || echo "appmesh" )
+SERVICE_NAME=$([ "$APPMESH_PREVIEW" == "y" ] && echo "appmesh-preview" || echo "appmesh" )
 
 # Clone the SDK to the vendor path (removing an old one if necessary)
 rm -rf $SDK_VENDOR_PATH

--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -1,0 +1,40 @@
+# App Mesh Controller Development Guide
+
+## Prerequisites
+
+* [Go 1.13+](https://golang.org/)
+* [Docker](https://www.docker.com/)
+* [Make](https://man7.org/linux/man-pages/man1/make.1.html)
+* [jq](https://stedolan.github.io/jq/)
+
+## Building the Controller
+
+The controller Docker image can be built via:
+
+```bash
+AWS_REGION=<region> AWS_ACCOUNT=<account ID> make docker-build
+```
+
+This command will compile the controller, run unit tests, and generate a Docker image using the ECR repository format (e.g. `<account ID>.dkr.ecr.<region>.amazonaws.com/amazon/appmesh-controller`).
+
+The image can be pushed to your local ECR repository via:
+
+```bash
+AWS_REGION=<region> AWS_ACCOUNT=<account ID> make docker-push
+```
+
+Once the image has been pushed, you can run the following to install the controller and CRDs to your configured cluster (defined in `~/.kube/config`):
+
+```bash
+AWS_REGION=<region> AWS_ACCOUNT=<account ID> make deploy
+```
+
+## Building for App Mesh Preview
+
+**Important**: The preview version of the controller will not work against App Mesh's production environment (and vice versa). App Mesh's endpoint and signing name are chosen during the build process.
+
+When working against the App Mesh Preview environment, the preview SDK models are downloaded and used to generate the AWS SDK for Go dynamically. The steps for building and deploying the controller are the same as above, but with two new variables for the `docker-build` step.
+
+```bash
+AWS_REGION=<region> AWS_ACCOUNT=<account ID> APPMESH_SDK_OVERRIDE=y APPMESH_PREVIEW=y make docker-build
+```


### PR DESCRIPTION
*Description of changes:*

Adds a starter doc for development instructions, and uses `y` instead of `1` for the flag to enable building the controller for App Mesh Preview.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
