### PR TITLE
Enable virtual gateway and gateway route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ IMAGE ?= $(REPO):$(VERSION)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # app mesh aws-sdk-go override in case we need to build against a custom version
-APPMESH_SDK_OVERRIDE ?= "n"
+# TODO(fawadkhaliq/achevuru) remove the override when aws sdk with virtual gateway is released
+APPMESH_SDK_OVERRIDE ?= "y"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
@@ -45,7 +45,7 @@ spec:
           type: object
         spec:
           description: VirtualNodeSpec defines the desired state of VirtualNode refers
-            to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualServiceSpec.html
+            to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualNodeSpec.html
           properties:
             awsName:
               description: AWSName is the AppMesh VirtualNode object's name. If unspecified

--- a/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
@@ -45,6 +45,7 @@ spec:
           type: object
         spec:
           description: VirtualServiceSpec defines the desired state of VirtualService
+            refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_VirtualServiceSpec.html
           properties:
             awsName:
               description: AWSName is the AppMesh VirtualService object's name. If

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
 - bases/appmesh.k8s.aws_virtualservices.yaml
 - bases/appmesh.k8s.aws_virtualnodes.yaml
 - bases/appmesh.k8s.aws_virtualrouters.yaml
-#- bases/appmesh.k8s.aws_virtualgateways.yaml
-#- bases/appmesh.k8s.aws_gatewayroutes.yaml
+- bases/appmesh.k8s.aws_virtualgateways.yaml
+- bases/appmesh.k8s.aws_gatewayroutes.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -53,6 +53,26 @@ rules:
 - apiGroups:
   - appmesh.k8s.aws
   resources:
+  - gatewayroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appmesh.k8s.aws
+  resources:
+  - gatewayroutes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - appmesh.k8s.aws
+  resources:
   - meshes
   verbs:
   - create
@@ -66,6 +86,26 @@ rules:
   - appmesh.k8s.aws
   resources:
   - meshes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - appmesh.k8s.aws
+  resources:
+  - virtualgateways
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appmesh.k8s.aws
+  resources:
+  - virtualgateways/status
   verbs:
   - get
   - patch

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,6 +11,24 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-appmesh-k8s-aws-v1beta2-gatewayroute
+  failurePolicy: Fail
+  name: mgatewayroute.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - appmesh.k8s.aws
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gatewayroutes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-appmesh-k8s-aws-v1beta2-mesh
   failurePolicy: Fail
   name: mmesh.appmesh.k8s.aws
@@ -24,6 +42,24 @@ webhooks:
     - UPDATE
     resources:
     - meshes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-appmesh-k8s-aws-v1beta2-virtualgateway
+  failurePolicy: Fail
+  name: mvirtualgateway.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - appmesh.k8s.aws
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualgateways
 - clientConfig:
     caBundle: Cg==
     service:
@@ -108,6 +144,24 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-appmesh-k8s-aws-v1beta2-gatewayroute
+  failurePolicy: Fail
+  name: vgatewayroute.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - appmesh.k8s.aws
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gatewayroutes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-appmesh-k8s-aws-v1beta2-mesh
   failurePolicy: Fail
   name: vmesh.appmesh.k8s.aws
@@ -121,6 +175,24 @@ webhooks:
     - UPDATE
     resources:
     - meshes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appmesh-k8s-aws-v1beta2-virtualgateway
+  failurePolicy: Fail
+  name: vvirtualgateway.appmesh.k8s.aws
+  rules:
+  - apiGroups:
+    - appmesh.k8s.aws
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualgateways
 - clientConfig:
     caBundle: Cg==
     service:

--- a/controllers/appmesh/gatewayroute_controller.go
+++ b/controllers/appmesh/gatewayroute_controller.go
@@ -1,5 +1,3 @@
-// +build preview
-
 /*
 
 
@@ -60,8 +58,8 @@ type gatewayRouteReconciler struct {
 	log                                    logr.Logger
 }
 
-//// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=get;list;watch;create;update;patch;delete
-//// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=gatewayroutes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=gatewayroutes/status,verbs=get;update;patch
 
 func (r *gatewayRouteReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return runtime.HandleReconcileError(r.reconcile(req), r.log)

--- a/controllers/appmesh/virtualgateway_controller.go
+++ b/controllers/appmesh/virtualgateway_controller.go
@@ -1,5 +1,3 @@
-// +build preview
-
 /*
 
 
@@ -61,8 +59,8 @@ type virtualGatewayReconciler struct {
 	log                          logr.Logger
 }
 
-//// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=virtualgateways,verbs=get;list;watch;create;update;patch;delete
-//// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=virtualgateways/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=virtualgateways,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=virtualgateways/status,verbs=get;update;patch
 
 func (r *virtualGatewayReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return runtime.HandleReconcileError(r.reconcile(req), r.log)

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
-github.com/aws/aws-sdk-go v1.30.7 h1:IaXfqtioP6p9SFAnNfsqdNczbR5UNbYqvcZUSsCAdTY=
-github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.32.4 h1:J2OMvipVB5dPIn+VH7L5rOqM4WoTsBxOqv+I06sjYOM=
 github.com/aws/aws-sdk-go v1.32.4/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/main.go
+++ b/main.go
@@ -39,11 +39,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/gatewayroute"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/inject"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/mesh"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualgateway"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualnode"
-	//"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualgateway"
-	//"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/gatewayroute"
 
 	appmeshv1beta2 "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	appmeshcontroller "github.com/aws/aws-app-mesh-controller-for-k8s/controllers/appmesh"
@@ -126,20 +126,20 @@ func main() {
 	referencesIndexer := references.NewDefaultObjectReferenceIndexer(mgr.GetCache(), mgr.GetFieldIndexer())
 	finalizerManager := k8s.NewDefaultFinalizerManager(mgr.GetClient(), ctrl.Log)
 	meshMembersFinalizer := mesh.NewPendingMembersFinalizer(mgr.GetClient(), mgr.GetEventRecorderFor("mesh-members"), ctrl.Log)
-	//vgMembersFinalizer := virtualgateway.NewPendingMembersFinalizer(mgr.GetClient(), mgr.GetEventRecorderFor("virtualgateway-members"), ctrl.Log)
+	vgMembersFinalizer := virtualgateway.NewPendingMembersFinalizer(mgr.GetClient(), mgr.GetEventRecorderFor("virtualgateway-members"), ctrl.Log)
 	referencesResolver := references.NewDefaultResolver(mgr.GetClient(), ctrl.Log)
 	virtualNodeEndpointResolver := cloudmap.NewDefaultVirtualNodeEndpointResolver(mgr.GetClient(), ctrl.Log)
 	cloudMapInstancesReconciler := cloudmap.NewDefaultInstancesReconciler(mgr.GetClient(), cloud.CloudMap(), ctrl.Log, stopChan)
 	meshResManager := mesh.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), cloud.AccountID(), ctrl.Log)
-	//vgResManager := virtualgateway.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
-	//grResManager := gatewayroute.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
+	vgResManager := virtualgateway.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
+	grResManager := gatewayroute.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
 	vnResManager := virtualnode.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
 	vsResManager := virtualservice.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
 	vrResManager := virtualrouter.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
 	cloudMapResManager := cloudmap.NewDefaultResourceManager(mgr.GetClient(), cloud.CloudMap(), referencesResolver, virtualNodeEndpointResolver, cloudMapInstancesReconciler, enableCustomHealthCheck, ctrl.Log)
 	msReconciler := appmeshcontroller.NewMeshReconciler(mgr.GetClient(), finalizerManager, meshMembersFinalizer, meshResManager, ctrl.Log.WithName("controllers").WithName("Mesh"))
-	//vgReconciler := appmeshcontroller.NewVirtualGatewayReconciler(mgr.GetClient(), finalizerManager, vgMembersFinalizer, vgResManager, ctrl.Log.WithName("controllers").WithName("VirtualGateway"))
-	//grReconciler := appmeshcontroller.NewGatewayRouteReconciler(mgr.GetClient(), finalizerManager, grResManager, ctrl.Log.WithName("controllers").WithName("GatewayRoute"))
+	vgReconciler := appmeshcontroller.NewVirtualGatewayReconciler(mgr.GetClient(), finalizerManager, vgMembersFinalizer, vgResManager, ctrl.Log.WithName("controllers").WithName("VirtualGateway"))
+	grReconciler := appmeshcontroller.NewGatewayRouteReconciler(mgr.GetClient(), finalizerManager, grResManager, ctrl.Log.WithName("controllers").WithName("GatewayRoute"))
 	vnReconciler := appmeshcontroller.NewVirtualNodeReconciler(mgr.GetClient(), finalizerManager, vnResManager, ctrl.Log.WithName("controllers").WithName("VirtualNode"))
 	cloudMapReconciler := appmeshcontroller.NewCloudMapReconciler(mgr.GetClient(), finalizerManager, cloudMapResManager, ctrl.Log.WithName("controllers").WithName("CloudMap"))
 	vsReconciler := appmeshcontroller.NewVirtualServiceReconciler(mgr.GetClient(), finalizerManager, referencesIndexer, vsResManager, ctrl.Log.WithName("controllers").WithName("VirtualService"))
@@ -153,16 +153,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	/*
-		if err = vgReconciler.SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "VirtualGateway")
-			os.Exit(1)
-		}
-		if err = grReconciler.SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "GatewayRoute")
-			os.Exit(1)
-		}
-	*/
+	if err = vgReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VirtualGateway")
+		os.Exit(1)
+	}
+	if err = grReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "GatewayRoute")
+		os.Exit(1)
+	}
 
 	if err = vnReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VirtualNode")
@@ -178,15 +176,15 @@ func main() {
 	}
 
 	meshMembershipDesignator := mesh.NewMembershipDesignator(mgr.GetClient())
-	//vgMembershipDesignator := virtualgateway.NewMembershipDesignator(mgr.GetClient())
+	vgMembershipDesignator := virtualgateway.NewMembershipDesignator(mgr.GetClient())
 	vnMembershipDesignator := virtualnode.NewMembershipDesignator(mgr.GetClient())
-	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.AccountID(), cloud.Region(), mgr.GetClient(), referencesResolver, vnMembershipDesignator)
+	sidecarInjector := inject.NewSidecarInjector(injectConfig, cloud.AccountID(), cloud.Region(), mgr.GetClient(), referencesResolver, vnMembershipDesignator, vgMembershipDesignator)
 	appmeshwebhook.NewMeshMutator().SetupWithManager(mgr)
 	appmeshwebhook.NewMeshValidator().SetupWithManager(mgr)
-	//appmeshwebhook.NewVirtualGatewayMutator(meshMembershipDesignator).SetupWithManager(mgr)
-	//appmeshwebhook.NewVirtualGatewayValidator().SetupWithManager(mgr)
-	//appmeshwebhook.NewGatewayRouteMutator(meshMembershipDesignator, vgMembershipDesignator).SetupWithManager(mgr)
-	//appmeshwebhook.NewGatewayRouteValidator().SetupWithManager(mgr)
+	appmeshwebhook.NewVirtualGatewayMutator(meshMembershipDesignator).SetupWithManager(mgr)
+	appmeshwebhook.NewVirtualGatewayValidator().SetupWithManager(mgr)
+	appmeshwebhook.NewGatewayRouteMutator(meshMembershipDesignator, vgMembershipDesignator).SetupWithManager(mgr)
+	appmeshwebhook.NewGatewayRouteValidator().SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualNodeMutator(meshMembershipDesignator).SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualNodeValidator().SetupWithManager(mgr)
 	appmeshwebhook.NewVirtualServiceMutator(meshMembershipDesignator).SetupWithManager(mgr)

--- a/pkg/conversions/gatewayroute_types_conversion.go
+++ b/pkg/conversions/gatewayroute_types_conversion.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package conversions
 
 import (

--- a/pkg/conversions/gatewayroute_types_conversion_test.go
+++ b/pkg/conversions/gatewayroute_types_conversion_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package conversions
 
 import (

--- a/pkg/conversions/virtualgateway_types_conversion.go
+++ b/pkg/conversions/virtualgateway_types_conversion.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package conversions
 
 import (

--- a/pkg/conversions/virtualgateway_types_conversion_test.go
+++ b/pkg/conversions/virtualgateway_types_conversion_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package conversions
 
 import (

--- a/pkg/equality/virtualgateway_types_equality.go
+++ b/pkg/equality/virtualgateway_types_equality.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package equality
 
 import (

--- a/pkg/equality/virtualgateway_types_equality_test.go
+++ b/pkg/equality/virtualgateway_types_equality_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package equality
 
 import (

--- a/pkg/gatewayroute/conditions.go
+++ b/pkg/gatewayroute/conditions.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/conditions_test.go
+++ b/pkg/gatewayroute/conditions_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/enqueue_requests_for_mesh_events.go
+++ b/pkg/gatewayroute/enqueue_requests_for_mesh_events.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/enqueue_requests_for_mesh_events_test.go
+++ b/pkg/gatewayroute/enqueue_requests_for_mesh_events_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/enqueue_requests_for_virtualgateway_events.go
+++ b/pkg/gatewayroute/enqueue_requests_for_virtualgateway_events.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/enqueue_requests_for_virtualgateway_events_test.go
+++ b/pkg/gatewayroute/enqueue_requests_for_virtualgateway_events_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/references.go
+++ b/pkg/gatewayroute/references.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/references_test.go
+++ b/pkg/gatewayroute/references_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/resource_manager.go
+++ b/pkg/gatewayroute/resource_manager.go
@@ -1,7 +1,4 @@
-// +build preview
-
 package gatewayroute
-
 
 import (
 	"context"

--- a/pkg/gatewayroute/resource_manager_test.go
+++ b/pkg/gatewayroute/resource_manager_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/utils.go
+++ b/pkg/gatewayroute/utils.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/gatewayroute/utils_test.go
+++ b/pkg/gatewayroute/utils_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package gatewayroute
 
 import (

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -224,7 +224,7 @@ func Test_InjectEnvoyContainer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inj := NewSidecarInjector(tt.conf, "000000000000", "us-west-2", nil, nil, nil)
+			inj := NewSidecarInjector(tt.conf, "000000000000", "us-west-2", nil, nil, nil, nil)
 			pod := tt.args.pod
 			inj.injectAppMeshPatches(tt.args.ms, tt.args.vn, nil, pod)
 			assert.Equal(t, tt.want.init, len(pod.Spec.InitContainers), "Numbers of init containers mismatch")

--- a/pkg/mesh/members_finalizer_test.go
+++ b/pkg/mesh/members_finalizer_test.go
@@ -23,6 +23,8 @@ func Test_pendingMembersFinalizer_buildPendingMembersEventMessage(t *testing.T) 
 		vsMembers []*appmesh.VirtualService
 		vrMembers []*appmesh.VirtualRouter
 		vnMembers []*appmesh.VirtualNode
+		vgMembers []*appmesh.VirtualGateway
+		grMembers []*appmesh.GatewayRoute
 	}
 	tests := []struct {
 		name string
@@ -111,6 +113,54 @@ func Test_pendingMembersFinalizer_buildPendingMembersEventMessage(t *testing.T) 
 			},
 			want: "objects belong to this mesh exists, please delete them to proceed. virtualService: 1, virtualNode: 1",
 		},
+		{
+			name: "two virtualGateway pending",
+			args: args{
+				vgMembers: []*appmesh.VirtualGateway{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-1",
+							Name:      "vg-1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-2",
+							Name:      "vg-2",
+						},
+					},
+				},
+			},
+			want: "objects belong to this mesh exists, please delete them to proceed. virtualGateway: 2",
+		},
+		{
+			name: "2 gatewayRoutes and 1 virtualnode pending",
+			args: args{
+				grMembers: []*appmesh.GatewayRoute{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-1",
+							Name:      "gr-1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-2",
+							Name:      "gr-2",
+						},
+					},
+				},
+				vnMembers: []*appmesh.VirtualNode{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ns-1",
+							Name:      "vn-1",
+						},
+					},
+				},
+			},
+			want: "objects belong to this mesh exists, please delete them to proceed. virtualNode: 1, gatewayRoute: 2",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -125,7 +175,8 @@ func Test_pendingMembersFinalizer_buildPendingMembersEventMessage(t *testing.T) 
 				eventRecorder: eventRecorder,
 				log:           &log.NullLogger{},
 			}
-			got := m.buildPendingMembersEventMessage(ctx, tt.args.vsMembers, tt.args.vrMembers, tt.args.vnMembers)
+			got := m.buildPendingMembersEventMessage(ctx, tt.args.vsMembers, tt.args.vrMembers, tt.args.vnMembers,
+				tt.args.vgMembers, tt.args.grMembers)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -797,6 +848,18 @@ func Test_pendingMembersFinalizer_Finalize(t *testing.T) {
 			},
 		},
 	}
+	vg := &appmesh.VirtualGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "vg-1",
+		},
+		Spec: appmesh.VirtualGatewaySpec{
+			MeshRef: &appmesh.MeshReference{
+				Name: "my-mesh",
+				UID:  "uid-1",
+			},
+		},
+	}
 	vr := &appmesh.VirtualRouter{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "my-ns",
@@ -816,6 +879,7 @@ func Test_pendingMembersFinalizer_Finalize(t *testing.T) {
 		virtualServices []*appmesh.VirtualService
 		virtualNodes    []*appmesh.VirtualNode
 		virtualRouters  []*appmesh.VirtualRouter
+		virtualGateways []*appmesh.VirtualGateway
 	}
 	type args struct {
 		ms *appmesh.Mesh
@@ -851,6 +915,14 @@ func Test_pendingMembersFinalizer_Finalize(t *testing.T) {
 			wantErr: errors.New("pending members deletion"),
 		},
 		{
+			name: "when pending virtualGateway deletion",
+			env: env{
+				virtualGateways: []*appmesh.VirtualGateway{vg},
+			},
+			args:    args{ms: ms},
+			wantErr: errors.New("pending members deletion"),
+		},
+		{
 			name:    "when pending no member deletion",
 			env:     env{},
 			args:    args{ms: ms},
@@ -881,6 +953,10 @@ func Test_pendingMembersFinalizer_Finalize(t *testing.T) {
 			}
 			for _, vn := range tt.env.virtualNodes {
 				err := k8sClient.Create(ctx, vn)
+				assert.NoError(t, err)
+			}
+			for _, vg := range tt.env.virtualGateways {
+				err := k8sClient.Create(ctx, vg)
 				assert.NoError(t, err)
 			}
 

--- a/pkg/virtualgateway/conditions.go
+++ b/pkg/virtualgateway/conditions.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/conditions_test.go
+++ b/pkg/virtualgateway/conditions_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/enqueue_requests_for_mesh_events.go
+++ b/pkg/virtualgateway/enqueue_requests_for_mesh_events.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/enqueue_requests_for_mesh_events_test.go
+++ b/pkg/virtualgateway/enqueue_requests_for_mesh_events_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/members_finalizer.go
+++ b/pkg/virtualgateway/members_finalizer.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (
@@ -24,7 +22,7 @@ type MembersFinalizer interface {
 	Finalize(ctx context.Context, vg *appmesh.VirtualGateway) error
 }
 
-//// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
 
 func NewPendingMembersFinalizer(k8sClient client.Client, eventRecorder record.EventRecorder, log logr.Logger) MembersFinalizer {
 	return &pendingMembersFinalizer{

--- a/pkg/virtualgateway/members_finalizer_test.go
+++ b/pkg/virtualgateway/members_finalizer_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/membership_designator.go
+++ b/pkg/virtualgateway/membership_designator.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (
@@ -36,7 +34,7 @@ type membershipDesignator struct {
 	k8sClient client.Client
 }
 
-//// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=virtualgateways,verbs=get;list;watch
+// +kubebuilder:rbac:groups=appmesh.k8s.aws,resources=virtualgateways,verbs=get;list;watch
 
 func (d *membershipDesignator) DesignateForPod(ctx context.Context, pod *corev1.Pod) (*appmesh.VirtualGateway, error) {
 
@@ -71,7 +69,7 @@ func (d *membershipDesignator) DesignateForPod(ctx context.Context, pod *corev1.
 	return vgCandidates[0], nil
 }
 
-//// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 func (d *membershipDesignator) DesignateForGatewayRoute(ctx context.Context, obj *appmesh.GatewayRoute) (*appmesh.VirtualGateway, error) {
 

--- a/pkg/virtualgateway/membership_designator_test.go
+++ b/pkg/virtualgateway/membership_designator_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/resource_manager.go
+++ b/pkg/virtualgateway/resource_manager.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/resource_manager_test.go
+++ b/pkg/virtualgateway/resource_manager_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/utils.go
+++ b/pkg/virtualgateway/utils.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/pkg/virtualgateway/utils_test.go
+++ b/pkg/virtualgateway/utils_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package virtualgateway
 
 import (

--- a/webhooks/appmesh/gatewayroute_mutator.go
+++ b/webhooks/appmesh/gatewayroute_mutator.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package appmesh
 
 import (
@@ -100,7 +98,7 @@ func (m *gatewayRouteMutator) designateVirtualGatewayMembership(ctx context.Cont
 	return virtualGateway, nil
 }
 
-//// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-gatewayroute,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=create;update,versions=v1beta2,name=mgatewayroute.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-gatewayroute,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=create;update,versions=v1beta2,name=mgatewayroute.appmesh.k8s.aws
 
 func (m *gatewayRouteMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutateAppMeshGatewayRoute, webhook.MutatingWebhookForMutator(m))

--- a/webhooks/appmesh/gatewayroute_mutator_test.go
+++ b/webhooks/appmesh/gatewayroute_mutator_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package appmesh
 
 import (

--- a/webhooks/appmesh/gatewayroute_validator.go
+++ b/webhooks/appmesh/gatewayroute_validator.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package appmesh
 
 import (
@@ -65,7 +63,7 @@ func (v *gatewayRouteValidator) enforceFieldsImmutability(newGR *appmesh.Gateway
 	return nil
 }
 
-//// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-gatewayroute,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=create;update,versions=v1beta2,name=vgatewayroute.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-gatewayroute,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=create;update,versions=v1beta2,name=vgatewayroute.appmesh.k8s.aws
 
 func (v *gatewayRouteValidator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathValidateAppMeshGatewayRoute, webhook.ValidatingWebhookForValidator(v))

--- a/webhooks/appmesh/gatewayroute_validator_test.go
+++ b/webhooks/appmesh/gatewayroute_validator_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package appmesh
 
 import (

--- a/webhooks/appmesh/virtualgateway_mutator.go
+++ b/webhooks/appmesh/virtualgateway_mutator.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package appmesh
 
 import (
@@ -72,7 +70,7 @@ func (m *virtualGatewayMutator) designateMeshMembership(ctx context.Context, vg 
 	return nil
 }
 
-//// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=mvirtualgateway.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=mvirtualgateway.appmesh.k8s.aws
 
 func (m *virtualGatewayMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutateAppMeshVirtualGateway, webhook.MutatingWebhookForMutator(m))

--- a/webhooks/appmesh/virtualgateway_mutator_test.go
+++ b/webhooks/appmesh/virtualgateway_mutator_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package appmesh
 
 import (

--- a/webhooks/appmesh/virtualgateway_validator.go
+++ b/webhooks/appmesh/virtualgateway_validator.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package appmesh
 
 import (
@@ -62,7 +60,7 @@ func (v *virtualGatewayValidator) enforceFieldsImmutability(newVGateway *appmesh
 	return nil
 }
 
-//// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=vvirtualgateway.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=vvirtualgateway.appmesh.k8s.aws
 
 func (v *virtualGatewayValidator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathValidateAppMeshVirtualGateway, webhook.ValidatingWebhookForValidator(v))

--- a/webhooks/appmesh/virtualgateway_validator_test.go
+++ b/webhooks/appmesh/virtualgateway_validator_test.go
@@ -1,5 +1,3 @@
-// +build preview
-
 package appmesh
 
 import (


### PR DESCRIPTION
*Description of changes:*
Virtual Gateway and Gateway Route features are [preview](https://docs.aws.amazon.com/app-mesh/latest/userguide/preview.html) only for v1.0.0 release and were disabled (https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/277) previously. These features will be available in AWS App Mesh in the v1.1.0 release of App Mesh controller. This PR enables them for the next release and: 
- Removes the preview tag from virtual gateway and gateway route source (tags were added here https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/281)
- Generates the CRDs and enable the controllers (were disabled here https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/277)
- Overrides the `aws-sdk-go` to use the schema [here](https://github.com/aws/aws-app-mesh-roadmap/tree/master/appmesh-preview/sdk)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
