### PR TITLE
Add virtual gateway to tutorial ref and readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 
 ## AWS App Mesh Controller For K8s
 
-AWS App Mesh Controller For K8s is a controller to help manage [App Mesh](https://aws.amazon.com/app-mesh/) resources for a Kubernetes cluster and injecting sidecars to Kubernetes [Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod/).  The controller watches custom resources for changes and reflects those changes into the [App Mesh API](https://docs.aws.amazon.com/app-mesh/latest/APIReference/Welcome.html). The controller maintains the custom resources ([CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)): meshes, virtualnodes, virtualrouters and virtualservices.  The custom resources map to App Mesh API objects.
+AWS App Mesh Controller For K8s is a controller to help manage [App Mesh](https://aws.amazon.com/app-mesh/) resources for a Kubernetes cluster and injecting sidecars to Kubernetes [Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod/).  The controller watches custom resources for changes and reflects those changes into the [App Mesh API](https://docs.aws.amazon.com/app-mesh/latest/APIReference/Welcome.html). The controller maintains the custom resources ([CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)): meshes, virtualnodes, virtualrouters, virtualservices, virtualgateways and gatewayroutes.  The custom resources map to App Mesh API objects.
 
 Note: For v0.5.0 or older versions of the controller, please refer to [legacy-controller branch](https://github.com/aws/aws-app-mesh-controller-for-k8s/tree/legacy-controller)
 

--- a/docs/tutorials/walkthroughs.md
+++ b/docs/tutorials/walkthroughs.md
@@ -7,4 +7,5 @@
 * [howto-k8s-http-headers](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-http-headers): This example shows how http routes can use headers for matching incoming requests.
 * [howto-k8s-http2](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-http2): This example shows how to manage HTTP/2 routes in App Mesh using Kubernetes deployments
 * [howto-k8s-retry-policy](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-retry-policy): This example shows how retry-policies can be used to for Kubernetes applications within the context of App Mesh.
+* [howto-k8s-ingress-gateway](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-ingress-gateway): This example shows how to use App Mesh Virtual Gateways for ingress connectivity towards Kubernetes applications.
 


### PR DESCRIPTION
*Description of changes:*
Add virtualgateway and gatewayroute to the README and [howto-k8s-ingress-gateway](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-ingress-gateway) example to the walkthrough tutorial reference


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
