### PR TITLE
feat(inject): expose configuration for x-ray sidecar image (#287)

### DIFF
--- a/docs/guide/tracing.md
+++ b/docs/guide/tracing.md
@@ -9,7 +9,13 @@ AppMesh controller supports integration with multiple tracing solutions for data
         --set tracing.enabled=true \
         --set tracing.provider=x-ray
     ```
-    The above configuration will inject the AWS X-Ray daemon sidecar in each pod scheduled to run on the mesh. 
+    The above configuration will inject the AWS X-Ray daemon sidecar in each pod scheduled to run on the mesh.
+
+    You can optionally use a specific X-Ray image by setting the following flags in addition to the above:
+    ```sh
+        --set xray.image.repository=amazon/aws-xray-daemon \
+        --set xray.image.tag=3.2.0
+    ```
 
 **Note**: You should restart all pods running inside the mesh after enabling tracing.
 

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -2,6 +2,7 @@ package inject
 
 import (
 	"errors"
+
 	"github.com/spf13/pflag"
 )
 
@@ -27,6 +28,7 @@ const (
 	flagEnableXrayTracing    = "enable-xray-tracing"
 	flagEnableStatsTags      = "enable-stats-tags"
 	flagEnableStatsD         = "enable-statsd"
+	flagXRayImage            = "xray-image"
 )
 
 type Config struct {
@@ -57,6 +59,7 @@ type Config struct {
 	EnableXrayTracing    bool
 	EnableStatsTags      bool
 	EnableStatsD         bool
+	XRayImage            string
 }
 
 // MultipleTracer checks if more than one tracer is configured.
@@ -101,6 +104,8 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		"Datadog Agent tracing port")
 	fs.BoolVar(&cfg.EnableXrayTracing, flagEnableXrayTracing, false,
 		"Enable Envoy X-Ray tracing integration and injects xray-daemon as sidecar")
+	fs.StringVar(&cfg.XRayImage, flagXRayImage, "amazon/aws-xray-daemon",
+		"X-Ray daemon container image")
 	fs.BoolVar(&cfg.EnableStatsTags, flagEnableStatsTags, false,
 		"Enable Envoy to tag stats")
 	fs.BoolVar(&cfg.EnableStatsD, flagEnableStatsD, false,

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -2,6 +2,8 @@ package inject
 
 import (
 	"context"
+	"strings"
+
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/virtualgateway"
@@ -10,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 var injectLogger = ctrl.Log.WithName("appmesh_inject")
@@ -122,6 +123,7 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				awsRegion:             m.awsRegion,
 				sidecarCPURequests:    m.config.SidecarCpu,
 				sidecarMemoryRequests: m.config.SidecarMemory,
+				xRayImage:             m.config.XRayImage,
 			}, m.config.EnableXrayTracing),
 			newDatadogMutator(datadogMutatorConfig{
 				datadogAddress: m.config.DatadogAddress,
@@ -148,6 +150,7 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				awsRegion:             m.awsRegion,
 				sidecarCPURequests:    m.config.SidecarCpu,
 				sidecarMemoryRequests: m.config.SidecarMemory,
+				xRayImage:             m.config.XRayImage,
 			}, m.config.EnableXrayTracing),
 		}
 	}

--- a/pkg/inject/xray.go
+++ b/pkg/inject/xray.go
@@ -2,6 +2,7 @@ package inject
 
 import (
 	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -9,7 +10,7 @@ const xrayDaemonContainerName = "xray-daemon"
 const xrayDaemonContainerTemplate = `
 {
   "name": "xray-daemon",
-  "image": "amazon/aws-xray-daemon",
+  "image": "{{ .XRayImage }}",
   "securityContext": {
     "runAsUser": 1337
   },
@@ -39,12 +40,14 @@ type XrayTemplateVariables struct {
 	AWSRegion             string
 	SidecarCPURequests    string
 	SidecarMemoryRequests string
+	XRayImage             string
 }
 
 type xrayMutatorConfig struct {
 	awsRegion             string
 	sidecarCPURequests    string
 	sidecarMemoryRequests string
+	xRayImage             string
 }
 
 func newXrayMutator(mutatorConfig xrayMutatorConfig, enabled bool) *xrayMutator {
@@ -85,6 +88,7 @@ func (m *xrayMutator) buildTemplateVariables(pod *corev1.Pod) XrayTemplateVariab
 		AWSRegion:             m.mutatorConfig.awsRegion,
 		SidecarCPURequests:    getSidecarCPURequest(m.mutatorConfig.sidecarCPURequests, pod),
 		SidecarMemoryRequests: getSidecarMemoryRequest(m.mutatorConfig.sidecarMemoryRequests, pod),
+		XRayImage:             m.mutatorConfig.xRayImage,
 	}
 }
 

--- a/pkg/inject/xray_test.go
+++ b/pkg/inject/xray_test.go
@@ -1,13 +1,14 @@
 package inject
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func Test_xrayMutator_mutate(t *testing.T) {
@@ -31,6 +32,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 		awsRegion:             "us-west-2",
 		sidecarCPURequests:    cpuRequests.String(),
 		sidecarMemoryRequests: memoryRequests.String(),
+		xRayImage:             "amazon/aws-xray-daemon",
 	}
 	type fields struct {
 		enabled       bool


### PR DESCRIPTION
*Issue #, if available:*
287

*Description of changes:*
Expose configuration for x-ray images

## Manual testing

### With a custom X-Ray image

#### Installation

```
helm install appmesh-controller appmesh-controller \
--namespace appmesh-system \
--set region=us-west-2 \
--set serviceAccount.create=false \
--set serviceAccount.name=appmesh-controller \
--set tracing.enabled=true \
--set tracing.provider=x-ray \
--set xray.image.repository=562935646554.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-xray-daemon \
--set xray.image.tag=287
# ...
# AWS App Mesh controller installed!

# verify the dev controller is being used
kubectl get deployment appmesh-controller \
    -n appmesh-system \
    -o json  | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'
# 287
```

#### Pod details

A pod with the configured x-ray side car injected:
```
k describe -n pokemon pod/pokedex-6694b56cf4-h27vq
Name:                 pokedex-6694b56cf4-h27vq
Namespace:            pokemon
Priority:             2000001000
Priority Class Name:  system-node-critical
Node:                 fargate-ip-192-168-191-248.us-west-2.compute.internal/192.168.191.248
Start Time:           Mon, 13 Jul 2020 22:28:36 -0700
Labels:               app=pokedex
                      eks.amazonaws.com/fargate-profile=pokemon
                      pod-template-hash=6694b56cf4
Annotations:          appmesh.k8s.aws/egressIgnoredIPs: 169.254.169.254
                      appmesh.k8s.aws/egressIgnoredPorts: 22
                      appmesh.k8s.aws/ignoredUID: 1337
                      appmesh.k8s.aws/ports: 80
                      appmesh.k8s.aws/proxyEgressPort: 15001
                      appmesh.k8s.aws/proxyIngressPort: 15000
                      appmesh.k8s.aws/sidecarInjectorWebhook: enabled
                      kubernetes.io/psp: eks.privileged
Status:               Running
IP:                   192.168.191.248
IPs:                  <none>
Controlled By:        ReplicaSet/pokedex-6694b56cf4
Containers:
  nginx:
    Container ID:   containerd://3104d98cbdc3893af768d76e4755f0ad5a0cd280ec52110549d9e92ef3bd8068
    Image:          nginx:1.19.0
    Image ID:       docker.io/library/nginx@sha256:21f32f6c08406306d822a0e6e8b7dc81f53f336570e852e25fbe1e3e3d0d0133
    Port:           80/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Mon, 13 Jul 2020 22:28:44 -0700
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-ggnjb (ro)
  envoy:
    Container ID:   containerd://35c6f573a26c59c2c3fe72eb7c8a7b5ee4626399c3dfbb1afe081da8167e0570
    Image:          840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.4.0-prod
    Image ID:       840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy@sha256:e593db1b7579d118b69e71c75cfeadcebb45299d07867a545b2e05682589c62a
    Port:           9901/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Mon, 13 Jul 2020 22:28:59 -0700
    Ready:          True
    Restart Count:  0
    Requests:
      cpu:     10m
      memory:  32Mi
    Environment:
      APPMESH_VIRTUAL_NODE_NAME:  mesh/poke-mesh/virtualNode/pokedex_pokemon
      APPMESH_PREVIEW:            0
      ENVOY_LOG_LEVEL:            info
      AWS_REGION:                 us-west-2
      ENABLE_ENVOY_XRAY_TRACING:  1
    Mounts:                       <none>
  xray-daemon:
    Container ID:   containerd://b905aa04e9995580f6466fb4831b0657c98614a9eeca1815b68a0d16a04e46da
    Image:          562935646554.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-xray-daemon:287
    Image ID:       562935646554.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-xray-daemon@sha256:116ff3c63ccec0e8d9a8db1b091e69df93aea47f48c082e0bd63e6074b38759a
    Port:           2000/UDP
    Host Port:      0/UDP
    State:          Running
      Started:      Mon, 13 Jul 2020 22:29:26 -0700
    Ready:          True
    Restart Count:  0
    Requests:
      cpu:     10m
      memory:  32Mi
    Environment:
      AWS_REGION:  us-west-2
    Mounts:        <none>
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  default-token-ggnjb:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-ggnjb
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type    Reason     Age        From                                                            Message
  ----    ------     ----       ----                                                            -------
  Normal  Scheduled  <unknown>  fargate-scheduler                                               Successfully assigned pokemon/pokedex-6694b56cf4-h27vq to fargate-ip-192-168-191-248.us-west-2.compute.internal
  Normal  Pulling    5m38s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Pulling image "nginx:1.19.0"
  Normal  Pulled     5m32s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Successfully pulled image "nginx:1.19.0"
  Normal  Created    5m32s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Created container nginx
  Normal  Started    5m32s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Started container nginx
  Normal  Pulling    5m32s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Pulling image "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.4.0-prod"
  Normal  Pulled     5m17s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Successfully pulled image "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.4.0-prod"
  Normal  Created    5m17s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Created container envoy
  Normal  Started    5m17s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Started container envoy
  Normal  Pulling    5m17s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Pulling image "562935646554.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-xray-daemon:287"
  Normal  Pulled     4m51s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Successfully pulled image "562935646554.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-xray-daemon:287"
  Normal  Created    4m51s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Created container xray-daemon
  Normal  Started    4m50s      kubelet, fargate-ip-192-168-191-248.us-west-2.compute.internal  Started container xray-daemon
```

#### X-Ray sidecar logs

```
k logs pod/pokedex-6694b56cf4-h27vq xray-daemon -n pokemon
2020-07-14T05:29:26Z [Info] Initializing AWS X-Ray daemon 3.2.0
2020-07-14T05:29:26Z [Info] Using buffer memory limit of 39 MB
2020-07-14T05:29:26Z [Info] 624 segment buffers allocated
2020-07-14T05:29:26Z [Info] Using region: us-west-2
2020-07-14T05:30:27Z [Error] Get instance id metadata failed: RequestError: send request failed
caused by: Get http://169.254.169.254/latest/meta-data/instance-id: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
2020-07-14T05:30:27Z [Info] HTTP Proxy server using X-Ray Endpoint : https://xray.us-west-2.amazonaws.com
2020-07-14T05:30:27Z [Info] Starting proxy http server on 0.0.0.0:2000
```

### Without a custom XRay image

#### Installation

```
helm install appmesh-controller appmesh-controller \
--namespace appmesh-system \
--set region=us-west-2 \
--set serviceAccount.create=false \
--set serviceAccount.name=appmesh-controller \
--set tracing.enabled=true \
--set tracing.provider=x-ray
# ...
# AWS App Mesh controller installed!

# verify the dev controller is being used
kubectl get deployment appmesh-controller \
    -n appmesh-system \
    -o json  | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'
# 287
```

#### Pod details

```
k describe po pokedex-6694b56cf4-47kpl -n pokemon
Name:                 pokedex-6694b56cf4-47kpl
Namespace:            pokemon
Priority:             2000001000
Priority Class Name:  system-node-critical
Node:                 <none>
Labels:               app=pokedex
                      eks.amazonaws.com/fargate-profile=pokemon
                      pod-template-hash=6694b56cf4
Annotations:          appmesh.k8s.aws/egressIgnoredIPs: 169.254.169.254
                      appmesh.k8s.aws/egressIgnoredPorts: 22
                      appmesh.k8s.aws/ignoredUID: 1337
                      appmesh.k8s.aws/ports: 80
                      appmesh.k8s.aws/proxyEgressPort: 15001
                      appmesh.k8s.aws/proxyIngressPort: 15000
                      appmesh.k8s.aws/sidecarInjectorWebhook: enabled
                      kubernetes.io/psp: eks.privileged
Status:               Pending
IP:
IPs:                  <none>
Controlled By:        ReplicaSet/pokedex-6694b56cf4
NominatedNodeName:    0126d4a3b3-7305fde2605a4fd29dc214187462b0f0
Containers:
  nginx:
    Image:        nginx:1.19.0
    Port:         80/TCP
    Host Port:    0/TCP
    Environment:  <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-ggnjb (ro)
  envoy:
    Image:      840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.4.0-prod
    Port:       9901/TCP
    Host Port:  0/TCP
    Requests:
      cpu:     10m
      memory:  32Mi
    Environment:
      APPMESH_VIRTUAL_NODE_NAME:  mesh/poke-mesh/virtualNode/pokedex_pokemon
      APPMESH_PREVIEW:            0
      ENVOY_LOG_LEVEL:            info
      AWS_REGION:                 us-west-2
      ENABLE_ENVOY_XRAY_TRACING:  1
    Mounts:                       <none>
  xray-daemon:
    Image:      amazon/aws-xray-daemon:latest
    Port:       2000/UDP
    Host Port:  0/UDP
    Requests:
      cpu:     10m
      memory:  32Mi
    Environment:
      AWS_REGION:  us-west-2
    Mounts:        <none>
Volumes:
  default-token-ggnjb:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-ggnjb
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:          <none>
```

#### X-Ray sidecar logs

```
k logs pokedex-6694b56cf4-47kpl xray-daemon -n pokemon
2020-07-14T05:46:01Z [Info] Initializing AWS X-Ray daemon 3.2.0
2020-07-14T05:46:01Z [Info] Using buffer memory limit of 39 MB
2020-07-14T05:46:01Z [Info] 624 segment buffers allocated
2020-07-14T05:46:01Z [Info] Using region: us-west-2
2020-07-14T05:47:02Z [Error] Get instance id metadata failed: RequestError: send request failed
caused by: Get http://169.254.169.254/latest/meta-data/instance-id: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
2020-07-14T05:47:02Z [Info] HTTP Proxy server using X-Ray Endpoint : https://xray.us-west-2.amazonaws.com
2020-07-14T05:47:02Z [Info] Starting proxy http server on 0.0.0.0:2000
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
