### PR TITLE
Controller gets stuck in a crash loop

### DIFF
--- a/controllers/appmesh/cloudmap_controller.go
+++ b/controllers/appmesh/cloudmap_controller.go
@@ -97,8 +97,6 @@ func (r *cloudMapReconciler) reconcileVirtualNodeWithCloudMap(ctx context.Contex
 
 func (r *cloudMapReconciler) cleanupCloudMapResources(ctx context.Context, vNode *appmesh.VirtualNode) error {
 	if k8s.HasFinalizer(vNode, k8s.FinalizerAWSCloudMapResources) {
-		// TODO: choose one of the approach in https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/305#issuecomment-654374069
-		// to completely fix the issue
 		if vNode.Spec.ServiceDiscovery != nil && vNode.Spec.ServiceDiscovery.AWSCloudMap != nil {
 			if err := r.cloudMapResourceManager.Cleanup(ctx, vNode); err != nil {
 				return err

--- a/webhooks/appmesh/virtualnode_validator.go
+++ b/webhooks/appmesh/virtualnode_validator.go
@@ -54,6 +54,9 @@ func (v *virtualNodeValidator) enforceFieldsImmutability(vn *appmesh.VirtualNode
 	if !reflect.DeepEqual(vn.Spec.MeshRef, oldVN.Spec.MeshRef) {
 		changedImmutableFields = append(changedImmutableFields, "spec.meshRef")
 	}
+	if !reflect.DeepEqual(vn.Spec.ServiceDiscovery.AWSCloudMap, oldVN.Spec.ServiceDiscovery.AWSCloudMap) {
+		changedImmutableFields = append(changedImmutableFields, "spec.serviceDiscovery.awsCloudMap")
+	}
 	if len(changedImmutableFields) != 0 {
 		return errors.Errorf("%s update may not change these fields: %s", "VirtualNode", strings.Join(changedImmutableFields, ","))
 	}

--- a/webhooks/appmesh/virtualnode_validator.go
+++ b/webhooks/appmesh/virtualnode_validator.go
@@ -54,7 +54,7 @@ func (v *virtualNodeValidator) enforceFieldsImmutability(vn *appmesh.VirtualNode
 	if !reflect.DeepEqual(vn.Spec.MeshRef, oldVN.Spec.MeshRef) {
 		changedImmutableFields = append(changedImmutableFields, "spec.meshRef")
 	}
-	if !reflect.DeepEqual(vn.Spec.ServiceDiscovery.AWSCloudMap, oldVN.Spec.ServiceDiscovery.AWSCloudMap) {
+	if oldVN.Spec.ServiceDiscovery.AWSCloudMap != nil && !reflect.DeepEqual(vn.Spec.ServiceDiscovery.AWSCloudMap, oldVN.Spec.ServiceDiscovery.AWSCloudMap) {
 		changedImmutableFields = append(changedImmutableFields, "spec.serviceDiscovery.awsCloudMap")
 	}
 	if len(changedImmutableFields) != 0 {

--- a/webhooks/appmesh/virtualnode_validator_test.go
+++ b/webhooks/appmesh/virtualnode_validator_test.go
@@ -33,6 +33,12 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 							Name: "my-mesh",
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
 						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
+						},
 					},
 				},
 				oldVN: &appmesh.VirtualNode{
@@ -45,6 +51,12 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 						MeshRef: &appmesh.MeshReference{
 							Name: "my-mesh",
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
 						},
 					},
 				},
@@ -65,6 +77,12 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 							Name: "my-mesh",
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
 						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
+						},
 					},
 				},
 				oldVN: &appmesh.VirtualNode{
@@ -77,6 +95,12 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 						MeshRef: &appmesh.MeshReference{
 							Name: "my-mesh",
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
 						},
 					},
 				},
@@ -97,6 +121,12 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 							Name: "another-mesh",
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
 						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
+						},
 					},
 				},
 				oldVN: &appmesh.VirtualNode{
@@ -110,13 +140,63 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 							Name: "my-mesh",
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
 						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
+						},
 					},
 				},
 			},
 			wantErr: errors.New("VirtualNode update may not change these fields: spec.meshRef"),
 		},
 		{
-			name: "VirtualNode fields awsName and meshRef changed",
+			name: "VirtualNode field awsCloudMap changed",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "new-cloudmap-ns",
+								ServiceName:   "new-cloudmap-svc",
+							},
+						},
+					},
+				},
+				oldVN: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("VirtualNode update may not change these fields: spec.serviceDiscovery.awsCloudMap"),
+		},
+		{
+			name: "VirtualNode fields awsName, meshRef and awsCloudMap changed",
 			args: args{
 				vn: &appmesh.VirtualNode{
 					ObjectMeta: metav1.ObjectMeta{
@@ -129,6 +209,12 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 							Name: "another-mesh",
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
 						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
+						},
 					},
 				},
 				oldVN: &appmesh.VirtualNode{
@@ -142,10 +228,16 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 							Name: "my-mesh",
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
 						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "new-cloudmap-ns",
+								ServiceName:   "new-cloudmap-svc",
+							},
+						},
 					},
 				},
 			},
-			wantErr: errors.New("VirtualNode update may not change these fields: spec.awsName,spec.meshRef"),
+			wantErr: errors.New("VirtualNode update may not change these fields: spec.awsName,spec.meshRef,spec.serviceDiscovery.awsCloudMap"),
 		},
 	}
 	for _, tt := range tests {

--- a/webhooks/appmesh/virtualnode_validator_test.go
+++ b/webhooks/appmesh/virtualnode_validator_test.go
@@ -78,7 +78,7 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
 						},
 						ServiceDiscovery: &appmesh.ServiceDiscovery{
-							DNS: &appmesh.DNSServiceDiscovery{Hostname: "dns-hostname"},
+							DNS: &appmesh.DNSServiceDiscovery{Hostname: "dns-new-hostname"},
 						},
 					},
 				},
@@ -94,7 +94,48 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
 						},
 						ServiceDiscovery: &appmesh.ServiceDiscovery{
-							DNS: &appmesh.DNSServiceDiscovery{Hostname: "dns-new-hostname"},
+							DNS: &appmesh.DNSServiceDiscovery{Hostname: "dns-hostname"},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "VirtualNode Servicediscovery mode change from DNS to CloudMap is allowed",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
+						},
+					},
+				},
+				oldVN: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							DNS: &appmesh.DNSServiceDiscovery{Hostname: "dns-hostname"},
 						},
 					},
 				},
@@ -249,8 +290,8 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 						},
 						ServiceDiscovery: &appmesh.ServiceDiscovery{
 							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
-								NamespaceName: "cloudmap-ns",
-								ServiceName:   "cloudmap-svc",
+								NamespaceName: "new-cloudmap-ns",
+								ServiceName:   "new-cloudmap-svc",
 							},
 						},
 					},
@@ -268,8 +309,8 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 						},
 						ServiceDiscovery: &appmesh.ServiceDiscovery{
 							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
-								NamespaceName: "new-cloudmap-ns",
-								ServiceName:   "new-cloudmap-svc",
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
 							},
 						},
 					},

--- a/webhooks/appmesh/virtualnode_validator_test.go
+++ b/webhooks/appmesh/virtualnode_validator_test.go
@@ -64,6 +64,44 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "VirtualNode DNS Servicediscovery change is allowed",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							DNS: &appmesh.DNSServiceDiscovery{Hostname: "dns-hostname"},
+						},
+					},
+				},
+				oldVN: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							DNS: &appmesh.DNSServiceDiscovery{Hostname: "dns-new-hostname"},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
 			name: "VirtualNode field awsName changed",
 			args: args{
 				vn: &appmesh.VirtualNode{


### PR DESCRIPTION
*Issue #, if available:*
#305 
*Description of changes:*

 AWSCloudMap config of VirtualNode Spec is made immutable.  Controller will allow ServiceDiscovery to be dynamically changed from DNS to CloudMap but not vice versa.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
