### PR TITLE
Support for Timeout Integration tests

### DIFF
--- a/test/framework/manifest/core_resources.go
+++ b/test/framework/manifest/core_resources.go
@@ -1,0 +1,120 @@
+package manifest
+
+import (
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type ManifestBuilder struct {
+	Namespace            string
+	ServiceDiscoveryType ServiceDiscoveryType
+
+	// required when serviceDiscoveryType == CloudMapServiceDiscovery
+	CloudMapNamespace string
+}
+
+func (b *ManifestBuilder) BuildDeployment(instanceName string, replicas int32, appImage string, containerPort int32) *appsv1.Deployment {
+	labels := b.buildNodeSelectors(instanceName)
+	dpName := b.buildNodeName(instanceName)
+	dp := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: b.Namespace,
+			Name:      dpName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: appImage,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: containerPort,
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "SERVER_PORT",
+									Value: fmt.Sprintf("%d", containerPort),
+								},
+								{
+									Name:  "COLOR",
+									Value: instanceName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return dp
+}
+
+func (b *ManifestBuilder) BuildServiceWithSelector(instanceName string, containerPort int32, targetPort int) *corev1.Service {
+	labels := b.buildNodeSelectors(instanceName)
+	svcName := b.buildNodeName(instanceName)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: b.Namespace,
+			Name:      svcName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: labels,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       containerPort,
+					TargetPort: intstr.FromInt(targetPort),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	return svc
+}
+
+func (b *ManifestBuilder) BuildServiceWithoutSelector(instanceName string, containerPort int32, targetPort int) *corev1.Service {
+	svcName := b.buildServiceName(instanceName)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: b.Namespace,
+			Name:      svcName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       containerPort,
+					TargetPort: intstr.FromInt(targetPort),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	return svc
+}
+
+func (b *ManifestBuilder) buildNodeSelectors(instanceName string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":     "timeout-app",
+		"app.kubernetes.io/instance": instanceName,
+	}
+}
+
+func (b *ManifestBuilder) buildNodeName(instanceName string) string {
+	return instanceName
+}
+
+func (b *ManifestBuilder) buildServiceName(instanceName string) string {
+	return instanceName
+}

--- a/test/framework/manifest/core_resources.go
+++ b/test/framework/manifest/core_resources.go
@@ -1,7 +1,6 @@
 package manifest
 
 import (
-	"fmt"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +15,8 @@ type ManifestBuilder struct {
 	CloudMapNamespace string
 }
 
-func (b *ManifestBuilder) BuildDeployment(instanceName string, replicas int32, appImage string, containerPort int32) *appsv1.Deployment {
+func (b *ManifestBuilder) BuildDeployment(instanceName string, replicas int32, appImage string, containerPort int32,
+	env []corev1.EnvVar) *appsv1.Deployment {
 	labels := b.buildNodeSelectors(instanceName)
 	dpName := b.buildNodeName(instanceName)
 	dp := &appsv1.Deployment{
@@ -41,16 +41,7 @@ func (b *ManifestBuilder) BuildDeployment(instanceName string, replicas int32, a
 									ContainerPort: containerPort,
 								},
 							},
-							Env: []corev1.EnvVar{
-								{
-									Name:  "SERVER_PORT",
-									Value: fmt.Sprintf("%d", containerPort),
-								},
-								{
-									Name:  "COLOR",
-									Value: instanceName,
-								},
-							},
+							Env: env,
 						},
 					},
 				},

--- a/test/framework/manifest/virtualnode.go
+++ b/test/framework/manifest/virtualnode.go
@@ -71,7 +71,24 @@ func (b *VNBuilder) BuildListener(protocol appmesh.PortProtocol, port appmesh.Po
 			Protocol: protocol,
 		},
 	}
+}
 
+func (b *VNBuilder) BuildListenerWithTimeout(protocol appmesh.PortProtocol, port appmesh.PortNumber, timeout int64, unit appmesh.DurationUnit) appmesh.Listener {
+	return appmesh.Listener{
+		PortMapping: appmesh.PortMapping{
+			Port:     port,
+			Protocol: protocol,
+		},
+		Timeout: &appmesh.ListenerTimeout{
+			HTTP: &appmesh.HTTPTimeout{
+				PerRequest: &appmesh.Duration{
+					Unit:  unit,
+					Value: timeout,
+				},
+				Idle: nil,
+			},
+		},
+	}
 }
 
 func (b *VNBuilder) buildDNSServiceDiscovery(instanceName string) *appmesh.ServiceDiscovery {
@@ -96,7 +113,6 @@ func (b *VNBuilder) buildCloudMapServiceDiscovery(instanceName string) *appmesh.
 
 func (b *VNBuilder) buildSelectors(instanceName string) map[string]string {
 	return map[string]string{
-		"app.kubernetes.io/name":     "virtualnode-integration-tests",
 		"app.kubernetes.io/instance": instanceName,
 	}
 }

--- a/test/integration/timeout/timeout_app/backend/Dockerfile
+++ b/test/integration/timeout/timeout_app/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:alpine
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT 8080
+
+CMD ["gunicorn", "app:app", "--config=config.py"]

--- a/test/integration/timeout/timeout_app/backend/app.py
+++ b/test/integration/timeout/timeout_app/backend/app.py
@@ -1,0 +1,35 @@
+import os
+import config
+import time
+from flask import Flask, request
+from aws_xray_sdk.core import patch_all, xray_recorder
+from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
+
+app = Flask(__name__)
+
+xray_recorder.configure(
+    context_missing='LOG_ERROR',
+    service=config.XRAY_APP_NAME,
+)
+patch_all()
+
+XRayMiddleware(app, xray_recorder)
+
+@app.route('/defaultroute')
+def default():
+    print('----------------')
+    print(request.headers)
+    print('----------------')
+    time.sleep(config.TIMEOUT_VALUE)
+    return config.WHO_AM_I
+
+@app.route('/timeoutroute')
+def timeout():
+    print('----------------')
+    print(request.headers)
+    print('----------------')
+    time.sleep(config.TIMEOUT_VALUE)
+    return config.WHO_AM_I
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=config.PORT, debug=config.DEBUG_MODE)

--- a/test/integration/timeout/timeout_app/backend/config.py
+++ b/test/integration/timeout/timeout_app/backend/config.py
@@ -1,0 +1,13 @@
+from os import environ as env
+import multiprocessing
+
+PORT = int(env.get("PORT", 8080))
+DEBUG_MODE = int(env.get("DEBUG_MODE", 0))
+XRAY_APP_NAME = env.get('XRAY_APP_NAME', 'feapp')
+WHO_AM_I = env.get('WHO_AM_I', 'backend')
+TIMEOUT_VALUE = int(env.get("TIMEOUT_VALUE", 45))
+
+# Gunicorn config
+bind = ":" + str(PORT)
+workers = multiprocessing.cpu_count() * 2 + 1
+threads = 2 * multiprocessing.cpu_count()

--- a/test/integration/timeout/timeout_app/backend/requirements.txt
+++ b/test/integration/timeout/timeout_app/backend/requirements.txt
@@ -1,0 +1,3 @@
+flask
+aws-xray-sdk
+gunicorn==19.9.0

--- a/test/integration/timeout/timeout_app/frontend/Dockerfile
+++ b/test/integration/timeout/timeout_app/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:alpine
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT 8080
+
+CMD ["gunicorn", "app:app", "--config=config.py"]

--- a/test/integration/timeout/timeout_app/frontend/app.py
+++ b/test/integration/timeout/timeout_app/frontend/app.py
@@ -1,0 +1,30 @@
+import os
+import requests
+import config
+from flask import Flask, request
+from aws_xray_sdk.core import xray_recorder, patch_all
+from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
+
+app = Flask(__name__)
+
+xray_recorder.configure(
+    context_missing='LOG_ERROR',
+    service=config.XRAY_APP_NAME,
+)
+patch_all()
+XRayMiddleware(app, xray_recorder)
+
+@app.route('/defaultroute')
+def default():
+    print(request.headers)
+    response = requests.get(f'http://backend.timeout-e2e.svc.cluster.local:8080/defaultroute')
+    return response.text
+
+@app.route('/timeoutroute')
+def timeout():
+    print(request.headers)
+    response = requests.get(f'http://backend.timeout-e2e.svc.cluster.local:8080/timeoutroute')
+    return response.text
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=config.PORT, debug=config.DEBUG_MODE)

--- a/test/integration/timeout/timeout_app/frontend/config.py
+++ b/test/integration/timeout/timeout_app/frontend/config.py
@@ -1,0 +1,12 @@
+from os import environ as env
+import multiprocessing
+
+PORT = int(env.get("PORT", 8080))
+DEBUG_MODE = int(env.get("DEBUG_MODE", 0))
+XRAY_APP_NAME = env.get('XRAY_APP_NAME', 'frontend')
+BACKEND_HOST = env.get('BACKEND_HOST', 'backend.timeout-e2e.svc.cluster.local:8080')
+
+# Gunicorn config
+bind = ":" + str(PORT)
+workers = multiprocessing.cpu_count() * 2 + 1
+threads = 2 * multiprocessing.cpu_count()

--- a/test/integration/timeout/timeout_app/frontend/requirements.txt
+++ b/test/integration/timeout/timeout_app/frontend/requirements.txt
@@ -1,0 +1,4 @@
+flask
+requests
+aws-xray-sdk
+gunicorn==19.9.0

--- a/test/integration/timeout/timeout_app_suite_test.go
+++ b/test/integration/timeout/timeout_app_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestFishApp(t *testing.T) {
+func TestTimeoutApp(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "FishApp Suite")
+	RunSpecs(t, "Timeout Suite")
 }

--- a/test/integration/timeout/timeout_app_suite_test.go
+++ b/test/integration/timeout/timeout_app_suite_test.go
@@ -1,0 +1,13 @@
+package timeout_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFishApp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FishApp Suite")
+}

--- a/test/integration/timeout/timeout_stack.go
+++ b/test/integration/timeout/timeout_stack.go
@@ -1,0 +1,666 @@
+package timeout
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework/manifest"
+	"io/ioutil"
+	"net/http"
+
+	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/algorithm"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework/k8s"
+	"github.com/aws/aws-sdk-go/aws"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultFrontEndImage = "928111597794.dkr.ecr.us-west-2.amazonaws.com/amazon/timeout-e2e:feapp-final"
+	defaultBackEndImage  = "928111597794.dkr.ecr.us-west-2.amazonaws.com/amazon/timeout-e2e:colorapp-final-1"
+
+	timeoutTest      = "timeout-e2e"
+	AppContainerPort = 8080
+
+	timeoutMessage          = "upstream request timeout"
+	expectedBackendResponse = "backend"
+)
+
+// Timeout stack is setup as below
+//	FrontEnd ->
+//        - Exposes two endpoints "/default" and "/timeout" and reaches out to backend for both the endpoints
+//        - Refers to "backend" VirtualService which in turn refers to "backend" VirtualRouter
+//
+//  Backend ->
+//        - Exposes "/default" and "/timeout" with a configured 45 seconds delay
+//        - "backend" VN is configured with a Listener timeout of 60 seconds
+//        - "backend" VR has two routes "/default" and "/timeout"
+//        - "/default" path uses default timeout of 15s and "/timeout" path is configured with 60s timeout
+//
+//  We then validate the timeout feature.
+//       - Call to "/default" from frontend pod should timeout with "upstream request timeout"
+//       - Call to "/timeout" from frontend pod should get a valid response which will be "backend"(config.WHO_AM_I)
+
+type TimeoutStack struct {
+	// service discovery type
+	ServiceDiscoveryType manifest.ServiceDiscoveryType
+
+	// ====== runtime variables ======
+	mesh      *appmesh.Mesh
+	namespace *corev1.Namespace
+
+	FrontEndVN *appmesh.VirtualNode
+	FrontEndDP *appsv1.Deployment
+
+	BackEndVN  *appmesh.VirtualNode
+	BackEndDP  *appsv1.Deployment
+	BackEndSVC *corev1.Service
+
+	BackEndVS *appmesh.VirtualService
+	BackEndVR *appmesh.VirtualRouter
+}
+
+func (s *TimeoutStack) DeployTimeoutStack(ctx context.Context, f *framework.Framework) {
+	s.createTimeoutStackMeshAndNamespace(ctx, f)
+
+	s.ServiceDiscoveryType = manifest.DNSServiceDiscovery
+	mb := &manifest.ManifestBuilder{
+		Namespace:            s.namespace.Name,
+		ServiceDiscoveryType: s.ServiceDiscoveryType,
+	}
+	s.createVirtualNodeResourcesForTimeoutStack(ctx, f, mb)
+	s.createServicesForTimeoutStack(ctx, f)
+	s.assignBackendVSToFrontEndVN(ctx, f)
+}
+
+func (s *TimeoutStack) CleanupTimeoutStack(ctx context.Context, f *framework.Framework) {
+	var deletionErrors []error
+	if errs := s.revokeVirtualNodeBackendAccessForTimeoutStack(ctx, f); len(errs) != 0 {
+		deletionErrors = append(deletionErrors, errs...)
+	}
+	if errs := s.deleteResourcesForTimeoutStackServices(ctx, f); len(errs) != 0 {
+		deletionErrors = append(deletionErrors, errs...)
+	}
+	if errs := s.deleteResourcesForTimeoutStackNodes(ctx, f); len(errs) != 0 {
+		deletionErrors = append(deletionErrors, errs...)
+	}
+	if errs := s.deleteTimeoutMeshAndNamespace(ctx, f); len(errs) != 0 {
+		deletionErrors = append(deletionErrors, errs...)
+	}
+	for _, err := range deletionErrors {
+		f.Logger.Error("clean up failed", zap.Error(err))
+	}
+	Expect(len(deletionErrors)).To(BeZero())
+}
+
+//Check Timeout behavior with and with timeout configured
+func (s *TimeoutStack) CheckTimeoutBehavior(ctx context.Context, f *framework.Framework) {
+	By(fmt.Sprintf("verify route timesout if it takes more than default 15s w/o listener timeout configured"), func() {
+		err := s.checkDefaultBackendRouteTimesout(ctx, f, s.FrontEndDP)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	By(fmt.Sprintf("verify the timeout behaviour with configured timeout value"), func() {
+		err := s.checkBehaviorOfRouteConfiguredWithTimeout(ctx, f, s.FrontEndDP)
+		Expect(err).NotTo(HaveOccurred())
+	})
+}
+
+func (s *TimeoutStack) createTimeoutStackMeshAndNamespace(ctx context.Context, f *framework.Framework) {
+	By("create a mesh", func() {
+		meshName := timeoutTest
+		mesh := &appmesh.Mesh{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: meshName,
+			},
+			Spec: appmesh.MeshSpec{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"mesh": meshName,
+					},
+				},
+			},
+		}
+		err := f.K8sClient.Create(ctx, mesh)
+		Expect(err).NotTo(HaveOccurred())
+		s.mesh = mesh
+	})
+
+	By(fmt.Sprintf("wait for mesh %s become active", s.mesh.Name), func() {
+		mesh, err := f.MeshManager.WaitUntilMeshActive(ctx, s.mesh)
+		Expect(err).NotTo(HaveOccurred())
+		s.mesh = mesh
+	})
+
+	By("allocate test namespace", func() {
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: timeoutTest,
+			},
+		}
+		err := f.K8sClient.Create(ctx, namespace)
+		Expect(err).NotTo(HaveOccurred())
+		s.namespace = namespace
+	})
+
+	By("label namespace with appMesh inject", func() {
+		oldNS := s.namespace.DeepCopy()
+		s.namespace.Labels = algorithm.MergeStringMap(map[string]string{
+			"appmesh.k8s.aws/sidecarInjectorWebhook": "enabled",
+			"mesh":                                   s.mesh.Name,
+		}, s.namespace.Labels)
+		err := f.K8sClient.Patch(ctx, s.namespace, client.MergeFrom(oldNS))
+		Expect(err).NotTo(HaveOccurred())
+	})
+}
+
+func (s *TimeoutStack) deleteTimeoutMeshAndNamespace(ctx context.Context, f *framework.Framework) []error {
+	var deletionErrors []error
+	if s.namespace != nil {
+		By(fmt.Sprintf("delete namespace: %s", s.namespace.Name), func() {
+			if err := f.K8sClient.Delete(ctx, s.namespace,
+				client.PropagationPolicy(metav1.DeletePropagationForeground), client.GracePeriodSeconds(0)); err != nil {
+				f.Logger.Error("failed to delete namespace",
+					zap.String("namespace", s.namespace.Name),
+					zap.Error(err))
+				deletionErrors = append(deletionErrors, err)
+				return
+			}
+
+			By(fmt.Sprintf("wait namespace to be deleted: %s", s.namespace.Namespace), func() {
+				if err := f.NSManager.WaitUntilNamespaceDeleted(ctx, s.namespace); err != nil {
+					f.Logger.Error("failed to wait namespace deletion",
+						zap.String("namespace", s.namespace.Name),
+						zap.Error(err))
+					deletionErrors = append(deletionErrors, err)
+				}
+			})
+		})
+	}
+
+	if s.mesh != nil {
+		By(fmt.Sprintf("delete mesh %s", s.mesh.Name), func() {
+			if err := f.K8sClient.Delete(ctx, s.mesh,
+				client.PropagationPolicy(metav1.DeletePropagationForeground), client.GracePeriodSeconds(0)); err != nil {
+				f.Logger.Error("failed to delete mesh",
+					zap.String("mesh", s.mesh.Name),
+					zap.Error(err))
+				deletionErrors = append(deletionErrors, err)
+				return
+			}
+
+			By(fmt.Sprintf("wait mesh to be deleted: %s", s.mesh.Name), func() {
+				if err := f.MeshManager.WaitUntilMeshDeleted(ctx, s.mesh); err != nil {
+					f.Logger.Error("failed to wait mesh deletion",
+						zap.String("mesh", s.mesh.Name),
+						zap.Error(err))
+					deletionErrors = append(deletionErrors, err)
+				}
+			})
+		})
+	}
+
+	return deletionErrors
+}
+
+func (s *TimeoutStack) createVirtualNodeResourcesForTimeoutStack(ctx context.Context, f *framework.Framework, mb *manifest.ManifestBuilder) {
+	By("create virtualNode resources", func() {
+		vnBuilder := &manifest.VNBuilder{
+			ServiceDiscoveryType: manifest.DNSServiceDiscovery,
+			Namespace:            timeoutTest,
+		}
+
+		By(fmt.Sprintf("create frontend virtualNode with default timeout"), func() {
+			listeners := []appmesh.Listener{vnBuilder.BuildListener("http", 8080)}
+			backends := []types.NamespacedName{}
+			vn := vnBuilder.BuildVirtualNode("frontend", backends, listeners)
+			err := f.K8sClient.Create(ctx, vn)
+			Expect(err).NotTo(HaveOccurred())
+			s.FrontEndVN = vn
+		})
+
+		By(fmt.Sprintf("create frontend deployment"), func() {
+			dp := mb.BuildDeployment("frontend", 1, defaultFrontEndImage, AppContainerPort)
+			err := f.K8sClient.Create(ctx, dp)
+			Expect(err).NotTo(HaveOccurred())
+			s.FrontEndDP = dp
+		})
+
+		By(fmt.Sprintf("create backend virtualNode with non default timeout"), func() {
+			listeners := []appmesh.Listener{vnBuilder.BuildListenerWithTimeout("http", 8080, 60, appmesh.DurationUnitS)}
+			backends := []types.NamespacedName{}
+			vn := vnBuilder.BuildVirtualNode("backend", backends, listeners)
+			err := f.K8sClient.Create(ctx, vn)
+			Expect(err).NotTo(HaveOccurred())
+			s.BackEndVN = vn
+		})
+
+		By(fmt.Sprintf("create backend deployment"), func() {
+			dp := mb.BuildDeployment("backend", 1, defaultBackEndImage, AppContainerPort)
+			err := f.K8sClient.Create(ctx, dp)
+			Expect(err).NotTo(HaveOccurred())
+			s.BackEndDP = dp
+		})
+
+		By(fmt.Sprintf("create service for backend virtualnode"), func() {
+			svc := mb.BuildServiceWithSelector("backend", AppContainerPort, AppContainerPort)
+			err := f.K8sClient.Create(ctx, svc)
+			Expect(err).NotTo(HaveOccurred())
+			s.BackEndSVC = svc
+		})
+
+		By("wait until all VirtualNodes become active", func() {
+			_, err := f.VNManager.WaitUntilVirtualNodeActive(ctx, s.FrontEndVN)
+			if err != nil {
+				f.Logger.Error("failed to wait all VirtualNode become deleted", zap.Error(err))
+				return
+			}
+			_, err = f.VNManager.WaitUntilVirtualNodeActive(ctx, s.BackEndVN)
+			if err != nil {
+				f.Logger.Error("failed to wait all VirtualNode become deleted", zap.Error(err))
+				return
+			}
+		})
+
+		By("wait all deployments become ready", func() {
+			_, err := f.DPManager.WaitUntilDeploymentReady(ctx, s.FrontEndDP)
+			if err != nil {
+				f.Logger.Error("failed while waiting for Frontend VirtualNode to become active", zap.Error(err))
+				return
+			}
+			_, err = f.DPManager.WaitUntilDeploymentReady(ctx, s.BackEndDP)
+			if err != nil {
+				f.Logger.Error("failed while waiting for Backend VirtualNode to become active", zap.Error(err))
+				return
+			}
+		})
+
+		By("check all VirtualNode in aws", func() {
+			err := f.VNManager.CheckVirtualNodeInAWS(ctx, s.mesh, s.FrontEndVN)
+			if err != nil {
+				f.Logger.Error("failed while validating Frontend VirtualNode aws resource", zap.Error(err))
+				return
+			}
+			err = f.VNManager.CheckVirtualNodeInAWS(ctx, s.mesh, s.BackEndVN)
+			if err != nil {
+				f.Logger.Error("failed while validating Backend VirtualNode aws resource", zap.Error(err))
+				return
+			}
+		})
+	})
+}
+
+func (s *TimeoutStack) deleteResourcesForTimeoutStackNodes(ctx context.Context, f *framework.Framework) []error {
+	var deletionErrors []error
+	By("delete all resources for nodes", func() {
+		By(fmt.Sprintf("delete Backend Service"), func() {
+			if err := f.K8sClient.Delete(ctx, s.BackEndSVC); err != nil {
+				f.Logger.Error("failed to delete Service",
+					zap.String("namespace", s.BackEndSVC.Namespace),
+					zap.String("name", s.BackEndSVC.Name),
+					zap.Error(err),
+				)
+				deletionErrors = append(deletionErrors, err)
+			}
+		})
+
+		By(fmt.Sprintf("delete Frontend Deployment"), func() {
+			if err := f.K8sClient.Delete(ctx, s.FrontEndDP,
+				client.PropagationPolicy(metav1.DeletePropagationForeground), client.GracePeriodSeconds(0)); err != nil {
+				f.Logger.Error("failed to delete Deployment",
+					zap.String("namespace", s.FrontEndDP.Namespace),
+					zap.String("name", s.FrontEndDP.Name),
+					zap.Error(err),
+				)
+				deletionErrors = append(deletionErrors, err)
+			}
+		})
+
+		By(fmt.Sprintf("delete Backend Deployment"), func() {
+			if err := f.K8sClient.Delete(ctx, s.BackEndDP,
+				client.PropagationPolicy(metav1.DeletePropagationForeground), client.GracePeriodSeconds(0)); err != nil {
+				f.Logger.Error("failed to delete Deployment",
+					zap.String("namespace", s.BackEndDP.Namespace),
+					zap.String("name", s.BackEndDP.Name),
+					zap.Error(err),
+				)
+				deletionErrors = append(deletionErrors, err)
+			}
+		})
+
+		By(fmt.Sprintf("delete Frontend VirtualNode for node"), func() {
+			if err := f.K8sClient.Delete(ctx, s.FrontEndVN); err != nil {
+				f.Logger.Error("failed to delete VirtualNode",
+					zap.String("namespace", s.FrontEndVN.Namespace),
+					zap.String("name", s.FrontEndVN.Name),
+					zap.Error(err),
+				)
+				deletionErrors = append(deletionErrors, err)
+			}
+		})
+
+		By(fmt.Sprintf("delete Backend VirtualNode"), func() {
+			if err := f.K8sClient.Delete(ctx, s.BackEndVN); err != nil {
+				f.Logger.Error("failed to delete VirtualNode",
+					zap.String("namespace", s.BackEndVN.Namespace),
+					zap.String("name", s.BackEndVN.Name),
+					zap.Error(err),
+				)
+				deletionErrors = append(deletionErrors, err)
+			}
+		})
+
+		By("wait all deployments become deleted", func() {
+			if err := f.DPManager.WaitUntilDeploymentDeleted(ctx, s.FrontEndDP); err != nil {
+				f.Logger.Error("failed while waiting for Frontend deployment to be deleted", zap.Error(err))
+				return
+			}
+
+			if err := f.DPManager.WaitUntilDeploymentDeleted(ctx, s.BackEndDP); err != nil {
+				f.Logger.Error("failed while waiting for Backend deployment to be deleted", zap.Error(err))
+				return
+			}
+		})
+
+		By("wait all VirtualNodes become deleted", func() {
+			if err := f.VNManager.WaitUntilVirtualNodeDeleted(ctx, s.FrontEndVN); err != nil {
+				f.Logger.Error("failed while waiting for Frontend VN to be deleted", zap.Error(err))
+				return
+			}
+			if err := f.VNManager.WaitUntilVirtualNodeDeleted(ctx, s.BackEndVN); err != nil {
+				f.Logger.Error("failed while waiting for Backend VN to be deleted", zap.Error(err))
+				return
+			}
+		})
+	})
+	return deletionErrors
+}
+
+func (s *TimeoutStack) createServicesForTimeoutStack(ctx context.Context, f *framework.Framework) {
+	By("create all resources for services", func() {
+		testNameSpace := timeoutTest
+		By(fmt.Sprintf("Create VirtualRouter for backend service"), func() {
+			var routes []appmesh.Route
+			var weightedTargets []appmesh.WeightedTarget
+
+			weightedTargets = append(weightedTargets, appmesh.WeightedTarget{
+				VirtualNodeRef: &appmesh.VirtualNodeReference{
+					Namespace: &testNameSpace,
+					Name:      "backend",
+				},
+				Weight: 1,
+			})
+
+			//route with a configured timeout value of 60s
+			routes = append(routes, appmesh.Route{
+				Name: "Timeout",
+				HTTPRoute: &appmesh.HTTPRoute{
+					Match: appmesh.HTTPRouteMatch{
+						Prefix: "/timeout",
+					},
+					Action: appmesh.HTTPRouteAction{
+						WeightedTargets: weightedTargets,
+					},
+					Timeout: &appmesh.HTTPTimeout{
+						PerRequest: &appmesh.Duration{
+							Unit:  "s",
+							Value: 60,
+						},
+					},
+				},
+			})
+
+			//route using default timeout value
+			routes = append(routes, appmesh.Route{
+				Name: "No-Timeout",
+				HTTPRoute: &appmesh.HTTPRoute{
+					Match: appmesh.HTTPRouteMatch{
+						Prefix: "/default",
+					},
+					Action: appmesh.HTTPRouteAction{
+						WeightedTargets: weightedTargets,
+					},
+				},
+			})
+
+			vr := &appmesh.VirtualRouter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "timeout-e2e",
+					Name:      "backend",
+				},
+				Spec: appmesh.VirtualRouterSpec{
+					Listeners: []appmesh.VirtualRouterListener{
+						{
+							PortMapping: appmesh.PortMapping{
+								Port:     AppContainerPort,
+								Protocol: "http",
+							},
+						},
+					},
+					Routes: routes,
+				},
+			}
+			err := f.K8sClient.Create(ctx, vr)
+			Expect(err).NotTo(HaveOccurred())
+			s.BackEndVR = vr
+		})
+
+		By(fmt.Sprintf("create VirtualService for backend"), func() {
+			vsDNS := fmt.Sprintf("%s.%s.svc.cluster.local", "backend", timeoutTest)
+			vs := &appmesh.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNameSpace,
+					Name:      "backend",
+				},
+				Spec: appmesh.VirtualServiceSpec{
+					AWSName: aws.String(vsDNS),
+					Provider: &appmesh.VirtualServiceProvider{
+						VirtualRouter: &appmesh.VirtualRouterServiceProvider{
+							VirtualRouterRef: &appmesh.VirtualRouterReference{
+								Namespace: &testNameSpace,
+								Name:      "backend",
+							},
+						},
+					},
+				},
+			}
+			err := f.K8sClient.Create(ctx, vs)
+			Expect(err).NotTo(HaveOccurred())
+			s.BackEndVS = vs
+		})
+
+		By("check backend VirtualRouter in AWS", func() {
+			err := f.VRManager.CheckVirtualRouterInAWS(ctx, s.mesh, s.BackEndVR)
+			if err != nil {
+				f.Logger.Error("failed to check backend VirtualRouter in AWS", zap.Error(err))
+				return
+			}
+		})
+
+		By("check backend VirtualService in AWS", func() {
+			err := f.VSManager.CheckVirtualServiceInAWS(ctx, s.mesh, s.BackEndVS)
+			if err != nil {
+				f.Logger.Error("failed to check backend VirtualService in AWS", zap.Error(err))
+				return
+			}
+		})
+	})
+}
+
+func (s *TimeoutStack) deleteResourcesForTimeoutStackServices(ctx context.Context, f *framework.Framework) []error {
+	var deletionErrors []error
+	By("delete all resources for services", func() {
+		By(fmt.Sprintf("Delete backend VirtualService"), func() {
+			if err := f.K8sClient.Delete(ctx, s.BackEndVS); err != nil {
+				f.Logger.Error("failed to delete VirtualService",
+					zap.String("namespace", s.BackEndVS.Namespace),
+					zap.String("name", s.BackEndVS.Name),
+					zap.Error(err),
+				)
+				deletionErrors = append(deletionErrors, err)
+			}
+		})
+
+		By(fmt.Sprintf("Delete backend VirtualRouter"), func() {
+			if err := f.K8sClient.Delete(ctx, s.BackEndVR); err != nil {
+				f.Logger.Error("failed to delete VirtualRouter",
+					zap.String("namespace", s.BackEndVR.Namespace),
+					zap.String("name", s.BackEndVR.Name),
+					zap.Error(err),
+				)
+				deletionErrors = append(deletionErrors, err)
+			}
+		})
+
+		By("Wait for backend VirtualService to be deleted", func() {
+			if err := f.VSManager.WaitUntilVirtualServiceDeleted(ctx, s.BackEndVS); err != nil {
+				f.Logger.Error("failed to delete backend VirtualService", zap.Error(err))
+				return
+			}
+		})
+		By("Wait for backend VirtualRouter to be deleted", func() {
+			if err := f.VRManager.WaitUntilVirtualRouterDeleted(ctx, s.BackEndVR); err != nil {
+				f.Logger.Error("failed to delete backend VirtualRouter", zap.Error(err))
+				return
+			}
+		})
+	})
+	return deletionErrors
+}
+
+func (s *TimeoutStack) assignBackendVSToFrontEndVN(ctx context.Context, f *framework.Framework) {
+	By("granting VirtualNodes backend access", func() {
+		By(fmt.Sprintf("assigning backend VS to frontend VN"), func() {
+			var vnBackends []appmesh.Backend
+			vs := s.BackEndVS
+			vnBackends = append(vnBackends, appmesh.Backend{
+				VirtualService: appmesh.VirtualServiceBackend{
+					VirtualServiceRef: &appmesh.VirtualServiceReference{
+						Namespace: aws.String(vs.Namespace),
+						Name:      vs.Name,
+					},
+				},
+			})
+
+			vnNew := s.FrontEndVN.DeepCopy()
+			vnNew.Spec.Backends = vnBackends
+			err := f.K8sClient.Patch(ctx, vnNew, client.MergeFrom(s.FrontEndVN))
+			Expect(err).NotTo(HaveOccurred())
+			s.FrontEndVN = vnNew
+		})
+	})
+}
+
+func (s *TimeoutStack) revokeVirtualNodeBackendAccessForTimeoutStack(ctx context.Context, f *framework.Framework) []error {
+	var deletionErrors []error
+	By("revoking VirtualNodes backend access", func() {
+		By(fmt.Sprintf("revoking Frontend VirtualNode access to backend"), func() {
+			vnNew := s.FrontEndVN.DeepCopy()
+			vnNew.Spec.Backends = nil
+
+			err := f.K8sClient.Patch(ctx, vnNew, client.MergeFrom(s.FrontEndVN))
+			if err != nil {
+				f.Logger.Error("failed to revoke VirtualNode backend access",
+					zap.String("namespace", s.FrontEndVN.Namespace),
+					zap.String("name", s.FrontEndVN.Name),
+					zap.Error(err),
+				)
+				deletionErrors = append(deletionErrors, err)
+			}
+		})
+	})
+	return deletionErrors
+}
+
+func (s *TimeoutStack) checkDefaultBackendRouteTimesout(ctx context.Context, f *framework.Framework,
+	dp *appsv1.Deployment) error {
+	sel := labels.Set(dp.Spec.Selector.MatchLabels)
+	podList := &corev1.PodList{}
+	err := f.K8sClient.List(ctx, podList, client.InNamespace(dp.Namespace), client.MatchingLabelsSelector{Selector: sel.AsSelector()})
+	if err != nil {
+		return errors.Wrapf(err, "failed to get pods for Deployment: %v", k8s.NamespacedName(dp).String())
+	}
+	if len(podList.Items) == 0 {
+		return errors.Wrapf(err, "Deployment have zero pods: %v", k8s.NamespacedName(dp).String())
+	}
+
+	for i := range podList.Items {
+		pod := podList.Items[i].DeepCopy()
+		if response, err := s.verifyFrontEndPodToRouteConnectivity(ctx, f, pod, "default"); err != nil {
+			f.Logger.Error("error while reaching out to default endpoint of backend")
+			return err
+		} else {
+			if response != timeoutMessage {
+				return fmt.Errorf("failed to verify route timeout behavior")
+			}
+		}
+	}
+	return nil
+}
+
+func (s *TimeoutStack) checkBehaviorOfRouteConfiguredWithTimeout(ctx context.Context, f *framework.Framework,
+	dp *appsv1.Deployment) error {
+	sel := labels.Set(dp.Spec.Selector.MatchLabels)
+	podList := &corev1.PodList{}
+	err := f.K8sClient.List(ctx, podList, client.InNamespace(dp.Namespace), client.MatchingLabelsSelector{Selector: sel.AsSelector()})
+	if err != nil {
+		return errors.Wrapf(err, "failed to get pods for Deployment: %v", k8s.NamespacedName(dp).String())
+	}
+	if len(podList.Items) == 0 {
+		return errors.Wrapf(err, "Deployment have zero pods: %v", k8s.NamespacedName(dp).String())
+	}
+
+	for i := range podList.Items {
+		pod := podList.Items[i].DeepCopy()
+		if response, err := s.verifyFrontEndPodToRouteConnectivity(ctx, f, pod, "timeout"); err != nil {
+			f.Logger.Warn("error while reaching out to timeout endpoint of backend")
+			return err
+		} else {
+			if response != expectedBackendResponse {
+				return fmt.Errorf("failed to verify route timeout behavior")
+			}
+		}
+	}
+	return nil
+}
+
+func (s *TimeoutStack) verifyFrontEndPodToRouteConnectivity(ctx context.Context, f *framework.Framework,
+	pod *corev1.Pod, path string) (response string, err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pfErrChan := make(chan error)
+	pfReadyChan := make(chan struct{})
+	portForwarder, err := k8s.NewPortForwarder(ctx, f.RestCfg, pod, []string{fmt.Sprintf("%d:%d", AppContainerPort, AppContainerPort)}, pfReadyChan)
+	if err != nil {
+		return response, err
+	}
+	go func() {
+		pfErrChan <- portForwarder.ForwardPorts()
+	}()
+
+	podURL := fmt.Sprintf("http://localhost:%d/%s", AppContainerPort, path)
+	<-pfReadyChan
+	resp, err := http.Get(podURL)
+	if err != nil {
+		f.Logger.Error("failed to check backend VirtualService in AWS", zap.Error(err))
+		return response, err
+	}
+	respPayload, err := ioutil.ReadAll(resp.Body)
+	response = string(respPayload)
+	if err != nil {
+		return response, err
+	}
+	f.Logger.Warn("Received Response: ", zap.String("Response: ", response), zap.Int("StatusCode: ", resp.StatusCode))
+	cancel()
+	return response, <-pfErrChan
+}

--- a/test/integration/timeout/timeout_stack_test.go
+++ b/test/integration/timeout/timeout_stack_test.go
@@ -1,0 +1,60 @@
+package timeout_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework/manifest"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/test/integration/timeout"
+	. "github.com/onsi/ginkgo"
+	"time"
+)
+
+var _ = Describe("timeout feature test", func() {
+	var (
+		ctx context.Context
+		f   *framework.Framework
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		f = framework.New(framework.GlobalOptions)
+	})
+
+	Context("timeout default test dimensions", func() {
+		var stackPrototype timeout.TimeoutStack
+		var stacksPendingCleanUp []*timeout.TimeoutStack
+
+		BeforeEach(func() {
+			stacksPendingCleanUp = nil
+		})
+
+		AfterEach(func() {
+			for _, stack := range stacksPendingCleanUp {
+				stack.CleanupTimeoutStack(ctx, f)
+			}
+		})
+
+		for _, sdType := range []manifest.ServiceDiscoveryType{manifest.DNSServiceDiscovery} {
+			func(sdType manifest.ServiceDiscoveryType) {
+				It(fmt.Sprintf("Should behave correctly with and without timeout configured"), func() {
+					stackPrototype.ServiceDiscoveryType = sdType
+					stackDefault := stackPrototype
+
+					By("deploy timeout stack into cluster", func() {
+						stacksPendingCleanUp = append(stacksPendingCleanUp, &stackDefault)
+						stackDefault.DeployTimeoutStack(ctx, f)
+					})
+
+					By("sleep 30 seconds for Envoys to be configured", func() {
+						time.Sleep(30 * time.Second)
+					})
+
+					By("check timeout behavior", func() {
+						stackDefault.CheckTimeoutBehavior(ctx, f)
+					})
+				})
+			}(sdType)
+		}
+	})
+})

--- a/test/integration/timeout/timeout_stack_test.go
+++ b/test/integration/timeout/timeout_stack_test.go
@@ -26,6 +26,9 @@ var _ = Describe("timeout feature test", func() {
 		var stacksPendingCleanUp []*timeout.TimeoutStack
 
 		BeforeEach(func() {
+			stackPrototype = timeout.TimeoutStack{
+				TimeoutValue:         45,
+			}
 			stacksPendingCleanUp = nil
 		})
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Support for Timeout Integration tests. Adds a test suite to verify appmesh's timeout feature.
 - Verifies that the request times out if it takes more than the default 15s without timeout configured.
 - Verifies that the same request goes  through fine with appropriate timeout value configured.


Test Output:

STEP: verify route timesout if it takes more than default 15s w/o listener timeout configured
{"level":"warn","ts":1596217978.377368,"msg":"Received Response: ","Response: ":"upstream request timeout","StatusCode: ":200}
STEP: verify the timeout behaviour with configured timeout value
{"level":"warn","ts":1596218023.717762,"msg":"Received Response: ","Response: ":"backend","StatusCode: ":200}

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
