### PR TITLE
Add optional resource limits for init and sidecar containers

### DIFF
--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -13,6 +13,8 @@ const (
 	flagSidecarImage               = "sidecar-image"
 	flagSidecarCpuRequests         = "sidecar-cpu-requests"
 	flagSidecarMemoryRequests      = "sidecar-memory-requests"
+	flagSidecarCpuLimits           = "sidecar-cpu-limits"
+	flagSidecarMemoryLimits        = "sidecar-memory-limits"
 	flagPreview                    = "preview"
 	flagLogLevel                   = "sidecar-log-level"
 	flagPreStopDelay               = "prestop-delay"
@@ -43,8 +45,10 @@ type Config struct {
 
 	// Sidecar settings
 	SidecarImage               string
-	SidecarCpu                 string
-	SidecarMemory              string
+	SidecarCpuRequests         string
+	SidecarMemoryRequests      string
+	SidecarCpuLimits           string
+	SidecarMemoryLimits        string
 	Preview                    bool
 	LogLevel                   string
 	PreStopDelay               string
@@ -84,10 +88,14 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		"If enabled, 'appmesh-ecr-secret' secret will be injected in the absence of it within pod imagePullSecrets")
 	fs.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.5.0-prod",
 		"Envoy sidecar container image.")
-	fs.StringVar(&cfg.SidecarCpu, flagSidecarCpuRequests, "10m",
-		"Envoy sidecar CPU resources requests.")
-	fs.StringVar(&cfg.SidecarMemory, flagSidecarMemoryRequests, "32Mi",
-		"Envoy sidecar memory resources requests.")
+	fs.StringVar(&cfg.SidecarCpuRequests, flagSidecarCpuRequests, "10m",
+		"Sidecar CPU resources requests.")
+	fs.StringVar(&cfg.SidecarMemoryRequests, flagSidecarMemoryRequests, "32Mi",
+		"Sidecar memory resources requests.")
+	fs.StringVar(&cfg.SidecarCpuLimits, flagSidecarCpuLimits, "",
+		"Sidecar CPU resources limits.")
+	fs.StringVar(&cfg.SidecarMemoryLimits, flagSidecarMemoryLimits, "",
+		"Sidecar memory resources limits.")
 	fs.BoolVar(&cfg.Preview, flagPreview, false,
 		"Enable preview channel")
 	fs.StringVar(&cfg.LogLevel, flagLogLevel, "info",

--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -6,6 +6,11 @@ const (
 	//AppMeshMemoryRequestAnnotation specifies the memory requests for proxy
 	AppMeshMemoryRequestAnnotation = "appmesh.k8s.aws/memoryRequest"
 
+	//AppMeshCPULimitAnnotation specifies the CPU limits for proxy
+	AppMeshCPULimitAnnotation = "appmesh.k8s.aws/cpuLimit"
+	//AppMeshMemoryLimitAnnotation specifies the memory limits for proxy
+	AppMeshMemoryLimitAnnotation = "appmesh.k8s.aws/memoryLimit"
+
 	// === begin proxy settings annotations ===
 	//AppMeshCNIAnnotation specifies that CNI will be used to configure traffic interception
 	AppMeshCNIAnnotation = "appmesh.k8s.aws/appmeshCNI"

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -101,8 +101,10 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				egressIgnoredIPs: m.config.IgnoredIPs,
 				initProxyMutatorConfig: initProxyMutatorConfig{
 					containerImage: m.config.InitImage,
-					cpuRequests:    m.config.SidecarCpu,
-					memoryRequests: m.config.SidecarMemory,
+					cpuRequests:    m.config.SidecarCpuRequests,
+					memoryRequests: m.config.SidecarMemoryRequests,
+					cpuLimits:      m.config.SidecarCpuLimits,
+					memoryLimits:   m.config.SidecarMemoryLimits,
 				},
 			}, vn),
 			newEnvoyMutator(envoyMutatorConfig{
@@ -114,8 +116,10 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				readinessProbeInitialDelay: m.config.ReadinessProbeInitialDelay,
 				readinessProbePeriod:       m.config.ReadinessProbePeriod,
 				sidecarImage:               m.config.SidecarImage,
-				sidecarCPURequests:         m.config.SidecarCpu,
-				sidecarMemoryRequests:      m.config.SidecarMemory,
+				sidecarCPURequests:         m.config.SidecarCpuRequests,
+				sidecarMemoryRequests:      m.config.SidecarMemoryRequests,
+				sidecarCPULimits:           m.config.SidecarCpuLimits,
+				sidecarMemoryLimits:        m.config.SidecarMemoryLimits,
 				enableXrayTracing:          m.config.EnableXrayTracing,
 				enableJaegerTracing:        m.config.EnableJaegerTracing,
 				enableDatadogTracing:       m.config.EnableDatadogTracing,
@@ -124,8 +128,10 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 			}, ms, vn),
 			newXrayMutator(xrayMutatorConfig{
 				awsRegion:             m.awsRegion,
-				sidecarCPURequests:    m.config.SidecarCpu,
-				sidecarMemoryRequests: m.config.SidecarMemory,
+				sidecarCPURequests:    m.config.SidecarCpuRequests,
+				sidecarMemoryRequests: m.config.SidecarMemoryRequests,
+				sidecarCPULimits:      m.config.SidecarCpuLimits,
+				sidecarMemoryLimits:   m.config.SidecarMemoryLimits,
 				xRayImage:             m.config.XRayImage,
 			}, m.config.EnableXrayTracing),
 			newDatadogMutator(datadogMutatorConfig{
@@ -153,8 +159,10 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 		}, ms, vg),
 			newXrayMutator(xrayMutatorConfig{
 				awsRegion:             m.awsRegion,
-				sidecarCPURequests:    m.config.SidecarCpu,
-				sidecarMemoryRequests: m.config.SidecarMemory,
+				sidecarCPURequests:    m.config.SidecarCpuRequests,
+				sidecarMemoryRequests: m.config.SidecarMemoryRequests,
+				sidecarCPULimits:      m.config.SidecarCpuLimits,
+				sidecarMemoryLimits:   m.config.SidecarMemoryLimits,
 				xRayImage:             m.config.XRayImage,
 			}, m.config.EnableXrayTracing),
 		}

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -19,8 +19,8 @@ func getConfig(fp func(Config) Config) Config {
 		Preview:                     false,
 		SidecarImage:                "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.12.5.0-prod",
 		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
-		SidecarMemory:               "32Mi",
-		SidecarCpu:                  "10m",
+		SidecarMemoryRequests:       "32Mi",
+		SidecarCpuRequests:          "10m",
 		EnableIAMForServiceAccounts: true,
 	}
 	if fp != nil {

--- a/pkg/inject/sidecar_builder.go
+++ b/pkg/inject/sidecar_builder.go
@@ -2,6 +2,7 @@ package inject
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func envoyReadinessProbe(initialDelaySeconds int32, periodSeconds int32) *corev1.Probe {
@@ -19,7 +20,7 @@ func envoyReadinessProbe(initialDelaySeconds int32, periodSeconds int32) *corev1
 			//  }
 			// server_info->state supports the following states: LIVE, DRAINING, PRE_INITIALIZING, and INITIALIZING
 			// LIVE: Server is live and serving traffic
-			// DRAINING:  ⁣Server is draining listeners in response to external health checks failing
+			// DRAINING: Server is draining listeners in response to external health checks failing
 			// PRE_INITIALIZING: Server has not yet completed cluster manager initialization
 			// INITIALIZING: Server is running the cluster manager initialization callbacks
 			Exec: &corev1.ExecAction{Command: []string{
@@ -45,4 +46,56 @@ func envoyReadinessProbe(initialDelaySeconds int32, periodSeconds int32) *corev1
 		// Keeping the failure threshold to 3 to not fail preemptively
 		FailureThreshold: 3,
 	}
+}
+
+func sidecarResources(cpuRequest, memoryRequest, cpuLimit, memoryLimit string) (corev1.ResourceRequirements, error) {
+	resources := corev1.ResourceRequirements{}
+
+	if cpuRequest != "" || memoryRequest != "" {
+		requests := corev1.ResourceList{}
+
+		if cpuRequest != "" {
+			cr, err := resource.ParseQuantity(cpuRequest)
+			if err != nil {
+				return resources, err
+			}
+			requests["cpu"] = cr
+		}
+
+		if memoryRequest != "" {
+			mr, err := resource.ParseQuantity(memoryRequest)
+			if err != nil {
+				return resources, err
+			}
+			requests["memory"] = mr
+		}
+
+		resources.Requests = requests
+
+	}
+
+	if cpuLimit != "" || memoryLimit != "" {
+		limits := corev1.ResourceList{}
+
+		if cpuLimit != "" {
+			cl, err := resource.ParseQuantity(cpuLimit)
+			if err != nil {
+				return resources, err
+			}
+			limits["cpu"] = cl
+		}
+
+		if memoryLimit != "" {
+			ml, err := resource.ParseQuantity(memoryLimit)
+			if err != nil {
+				return resources, err
+			}
+			limits["memory"] = ml
+		}
+
+		resources.Limits = limits
+
+	}
+
+	return resources, nil
 }

--- a/pkg/inject/utils.go
+++ b/pkg/inject/utils.go
@@ -57,6 +57,20 @@ func getSidecarMemoryRequest(defaultMemoryRequest string, pod *corev1.Pod) strin
 	return defaultMemoryRequest
 }
 
+func getSidecarCPULimit(defaultCPULimit string, pod *corev1.Pod) string {
+	if v, ok := pod.ObjectMeta.Annotations[AppMeshCPULimitAnnotation]; ok {
+		return v
+	}
+	return defaultCPULimit
+}
+
+func getSidecarMemoryLimit(defaultMemoryLimit string, pod *corev1.Pod) string {
+	if v, ok := pod.ObjectMeta.Annotations[AppMeshMemoryLimitAnnotation]; ok {
+		return v
+	}
+	return defaultMemoryLimit
+}
+
 // containsEnvoyContainer checks whether pod already contains "envoy" container and return the slice index
 func containsEnvoyContainer(pod *corev1.Pod) (bool, int) {
 	for idx, container := range pod.Spec.Containers {

--- a/pkg/inject/xray_test.go
+++ b/pkg/inject/xray_test.go
@@ -14,6 +14,10 @@ import (
 func Test_xrayMutator_mutate(t *testing.T) {
 	cpuRequests, _ := resource.ParseQuantity("32Mi")
 	memoryRequests, _ := resource.ParseQuantity("10m")
+
+	cpuLimits, _ := resource.ParseQuantity("64Mi")
+	memoryLimits, _ := resource.ParseQuantity("30m")
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "my-ns",
@@ -28,10 +32,39 @@ func Test_xrayMutator_mutate(t *testing.T) {
 			},
 		},
 	}
+
+	annotationCpuRequest, _ := resource.ParseQuantity("128Mi")
+	annotationMemoryRequest, _ := resource.ParseQuantity("20m")
+	annotationCpuLimit, _ := resource.ParseQuantity("256Mi")
+	annotationMemoryLimit, _ := resource.ParseQuantity("80m")
+
+	podWithResourceAnnotations := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-pod",
+			Annotations: map[string]string{
+				AppMeshCPURequestAnnotation:    annotationCpuRequest.String(),
+				AppMeshMemoryRequestAnnotation: annotationMemoryRequest.String(),
+				AppMeshCPULimitAnnotation:      annotationCpuLimit.String(),
+				AppMeshMemoryLimitAnnotation:   annotationMemoryLimit.String(),
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "app/v1",
+				},
+			},
+		},
+	}
+
 	mutatorConfig := xrayMutatorConfig{
 		awsRegion:             "us-west-2",
 		sidecarCPURequests:    cpuRequests.String(),
 		sidecarMemoryRequests: memoryRequests.String(),
+		sidecarCPULimits:      cpuLimits.String(),
+		sidecarMemoryLimits:   memoryLimits.String(),
 		xRayImage:             "amazon/aws-xray-daemon",
 	}
 	type fields struct {
@@ -158,6 +191,70 @@ func Test_xrayMutator_mutate(t *testing.T) {
 								Requests: corev1.ResourceList{
 									"cpu":    cpuRequests,
 									"memory": memoryRequests,
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    cpuLimits,
+									"memory": memoryLimits,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "resource requests and limits annotations",
+			fields: fields{
+				enabled:       true,
+				mutatorConfig: mutatorConfig,
+			},
+			args: args{
+				pod: podWithResourceAnnotations,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+					Annotations: map[string]string{
+						AppMeshCPURequestAnnotation:    annotationCpuRequest.String(),
+						AppMeshMemoryRequestAnnotation: annotationMemoryRequest.String(),
+						AppMeshCPULimitAnnotation:      annotationCpuLimit.String(),
+						AppMeshMemoryLimitAnnotation:   annotationMemoryLimit.String(),
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+						{
+							Name:  "xray-daemon",
+							Image: "amazon/aws-xray-daemon",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: aws.Int64(1337),
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "xray",
+									ContainerPort: 2000,
+									Protocol:      "UDP",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    annotationCpuRequest,
+									"memory": annotationMemoryRequest,
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    annotationCpuLimit,
+									"memory": annotationMemoryLimit,
 								},
 							},
 						},

--- a/pkg/inject/xray_test.go
+++ b/pkg/inject/xray_test.go
@@ -203,6 +203,179 @@ func Test_xrayMutator_mutate(t *testing.T) {
 			},
 		},
 		{
+			name: "no resource limits",
+			fields: fields{
+				enabled: true,
+				mutatorConfig: xrayMutatorConfig{
+					awsRegion:             "us-west-2",
+					sidecarCPURequests:    cpuRequests.String(),
+					sidecarMemoryRequests: memoryRequests.String(),
+					xRayImage:             "amazon/aws-xray-daemon",
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+						{
+							Name:  "xray-daemon",
+							Image: "amazon/aws-xray-daemon",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: aws.Int64(1337),
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "xray",
+									ContainerPort: 2000,
+									Protocol:      "UDP",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    cpuRequests,
+									"memory": memoryRequests,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no cpu limits",
+			fields: fields{
+				enabled: true,
+				mutatorConfig: xrayMutatorConfig{
+					awsRegion:             "us-west-2",
+					sidecarCPURequests:    cpuRequests.String(),
+					sidecarMemoryRequests: memoryRequests.String(),
+					sidecarMemoryLimits:   memoryLimits.String(),
+					xRayImage:             "amazon/aws-xray-daemon",
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+						{
+							Name:  "xray-daemon",
+							Image: "amazon/aws-xray-daemon",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: aws.Int64(1337),
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "xray",
+									ContainerPort: 2000,
+									Protocol:      "UDP",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    cpuRequests,
+									"memory": memoryRequests,
+								},
+								Limits: corev1.ResourceList{
+									"memory": memoryLimits,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no memory limits",
+			fields: fields{
+				enabled: true,
+				mutatorConfig: xrayMutatorConfig{
+					awsRegion:             "us-west-2",
+					sidecarCPURequests:    cpuRequests.String(),
+					sidecarMemoryRequests: memoryRequests.String(),
+					sidecarCPULimits:      cpuLimits.String(),
+					xRayImage:             "amazon/aws-xray-daemon",
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+						{
+							Name:  "xray-daemon",
+							Image: "amazon/aws-xray-daemon",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: aws.Int64(1337),
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "xray",
+									ContainerPort: 2000,
+									Protocol:      "UDP",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    cpuRequests,
+									"memory": memoryRequests,
+								},
+								Limits: corev1.ResourceList{
+									"cpu": cpuLimits,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "resource requests and limits annotations",
 			fields: fields{
 				enabled:       true,

--- a/test/integration/timeout/timeout_stack.go
+++ b/test/integration/timeout/timeout_stack.go
@@ -57,18 +57,18 @@ type TimeoutStack struct {
 	ServiceDiscoveryType manifest.ServiceDiscoveryType
 
 	// ====== runtime variables ======
-	mesh        *appmesh.Mesh
-	namespace   *corev1.Namespace
+	mesh      *appmesh.Mesh
+	namespace *corev1.Namespace
 
-	FrontEndVN  *appmesh.VirtualNode
-	FrontEndDP  *appsv1.Deployment
+	FrontEndVN *appmesh.VirtualNode
+	FrontEndDP *appsv1.Deployment
 
-	BackEndVN   *appmesh.VirtualNode
-	BackEndDP   *appsv1.Deployment
-	BackEndSVC  *corev1.Service
+	BackEndVN  *appmesh.VirtualNode
+	BackEndDP  *appsv1.Deployment
+	BackEndSVC *corev1.Service
 
-	BackEndVS    *appmesh.VirtualService
-	BackEndVR    *appmesh.VirtualRouter
+	BackEndVS *appmesh.VirtualService
+	BackEndVR *appmesh.VirtualRouter
 
 	TimeoutValue int
 }
@@ -251,7 +251,7 @@ func (s *TimeoutStack) createVirtualNodeResourcesForTimeoutStack(ctx context.Con
 		By(fmt.Sprintf("create backend deployment"), func() {
 			env := []corev1.EnvVar{
 				{
-					Name: "SERVER_PORT",
+					Name:  "SERVER_PORT",
 					Value: fmt.Sprintf("%d", AppContainerPort),
 				},
 				{
@@ -410,7 +410,7 @@ func (s *TimeoutStack) createServicesForTimeoutStack(ctx context.Context, f *fra
 			var routes []appmesh.Route
 			var weightedTargets []appmesh.WeightedTarget
 			vrBuilder := &manifest.VRBuilder{
-				Namespace:            timeoutTest,
+				Namespace: timeoutTest,
 			}
 
 			weightedTargets = append(weightedTargets, appmesh.WeightedTarget{
@@ -605,7 +605,7 @@ func (s *TimeoutStack) checkExpectedRouteBehavior(ctx context.Context, f *framew
 			f.Logger.Error("error while reaching out to default endpoint of backend")
 			return err
 		} else {
-			if (!timeoutConfigured && response != timeoutMessage) || (timeoutConfigured && response != expectedBackendResponse)  {
+			if (!timeoutConfigured && response != timeoutMessage) || (timeoutConfigured && response != expectedBackendResponse) {
 				return fmt.Errorf("failed to verify route timeout behavior")
 			}
 		}

--- a/test/integration/timeout/timeout_stack_test.go
+++ b/test/integration/timeout/timeout_stack_test.go
@@ -27,7 +27,7 @@ var _ = Describe("timeout feature test", func() {
 
 		BeforeEach(func() {
 			stackPrototype = timeout.TimeoutStack{
-				TimeoutValue:         45,
+				TimeoutValue: 45,
 			}
 			stacksPendingCleanUp = nil
 		})


### PR DESCRIPTION
*Issue* #289  

*Description of changes:*
Add optional cpu, memory limits for init and sidecar containers.

Resource limits are opt-in for App Mesh users and are *disabled* by default. There are two ways to set resource limits:
1. Cluster wide: by setting `sidecar-cpu-limits` and/or `sidecar-memory-limits` flags on the controller
2. Per pod: by setting pod annotations `appmesh.k8s.aws/cpuLimit` and/or `appmesh.k8s.aws/memoryLimit`. Per pod annotation will override the cluster setting if both are specified.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
