### PR TITLE
Fix the account ID flag setup in cloud config

### DIFF
--- a/pkg/aws/cloud_config.go
+++ b/pkg/aws/cloud_config.go
@@ -22,6 +22,6 @@ type CloudConfig struct {
 
 func (cfg *CloudConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.Region, flagAWSRegion, "", "AWS Region for the kubernetes cluster")
-	fs.StringVar(&cfg.Region, flagAWSAccountID, "", "AWS AccountID for the kubernetes cluster")
+	fs.StringVar(&cfg.AccountID, flagAWSAccountID, "", "AWS AccountID for the kubernetes cluster")
 	fs.Var(cfg.ThrottleConfig, flagAWSAPIThrottle, "throttle settings for AWS APIs, format: serviceID1:operationRegex1=rate:burst,serviceID2:operationRegex2=rate:burst")
 }


### PR DESCRIPTION
*Issue* #329 

*Description of changes:*
The account ID setup was pointing to wrong config. This would prevent users from overriding/providing their own account ID. Fixed the account ID flag in the cloud config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
