### PR TITLE
Enhance Validation for VirtualNodes and VirtualRouters specs

### DIFF
--- a/webhooks/appmesh/virtualnode_validator.go
+++ b/webhooks/appmesh/virtualnode_validator.go
@@ -3,6 +3,7 @@ package appmesh
 import (
 	"context"
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/references"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/webhook"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,10 +77,12 @@ func (v *virtualNodeValidator) checkVirtualNodeBackendsForDuplicates(vn *appmesh
 
 	for _, backend := range backends {
 		if backend.VirtualService.VirtualServiceRef != nil {
-			if _, ok := backendMap[backend.VirtualService.VirtualServiceRef.Name]; ok {
+			backendNamespacedName := references.ObjectKeyForVirtualServiceReference(vn, *backend.VirtualService.VirtualServiceRef)
+			backendIdentifier := backendNamespacedName.Name + "-" + backendNamespacedName.Namespace
+			if _, ok := backendMap[backendIdentifier]; ok {
 				return errors.Errorf("%s-%s has duplicate VirtualServiceReferences %s", "VirtualNode", vn.Name, backend.VirtualService.VirtualServiceRef.Name)
 			} else {
-				backendMap[backend.VirtualService.VirtualServiceRef.Name] = true
+				backendMap[backendIdentifier] = true
 			}
 		} else if backend.VirtualService.VirtualServiceARN != nil {
 			if _, ok := backendMap[*backend.VirtualService.VirtualServiceARN]; ok {

--- a/webhooks/appmesh/virtualnode_validator_test.go
+++ b/webhooks/appmesh/virtualnode_validator_test.go
@@ -334,6 +334,8 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 
 func Test_virtualNodeValidator_checkVirtualNodeBackendsForDuplicates(t *testing.T) {
 	testARN := "testARN"
+	testPrimaryNamespace := "awesome-ns"
+	testSecondaryNamespace := "secondary-ns"
 	type args struct {
 		vn    *appmesh.VirtualNode
 		oldVN *appmesh.VirtualNode
@@ -366,12 +368,14 @@ func Test_virtualNodeValidator_checkVirtualNodeBackendsForDuplicates(t *testing.
 						Backends: []appmesh.Backend{
 							{VirtualService: appmesh.VirtualServiceBackend{
 								VirtualServiceRef: &appmesh.VirtualServiceReference{
-									Name: "testVS",
+									Name:      "testVS",
+									Namespace: &testPrimaryNamespace,
 								},
 							}},
 							{VirtualService: appmesh.VirtualServiceBackend{
 								VirtualServiceRef: &appmesh.VirtualServiceReference{
-									Name: "testVS",
+									Name:      "testVS",
+									Namespace: &testPrimaryNamespace,
 								},
 							},
 							},
@@ -439,7 +443,47 @@ func Test_virtualNodeValidator_checkVirtualNodeBackendsForDuplicates(t *testing.
 						Backends: []appmesh.Backend{
 							{VirtualService: appmesh.VirtualServiceBackend{
 								VirtualServiceRef: &appmesh.VirtualServiceReference{
-									Name: "testVS",
+									Name:      "testVS",
+									Namespace: &testPrimaryNamespace,
+								},
+							}},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Same VirtualService name across different namespaces",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						ServiceDiscovery: &appmesh.ServiceDiscovery{
+							AWSCloudMap: &appmesh.AWSCloudMapServiceDiscovery{
+								NamespaceName: "cloudmap-ns",
+								ServiceName:   "cloudmap-svc",
+							},
+						},
+						Backends: []appmesh.Backend{
+							{VirtualService: appmesh.VirtualServiceBackend{
+								VirtualServiceRef: &appmesh.VirtualServiceReference{
+									Name:      "testVS",
+									Namespace: &testPrimaryNamespace,
+								},
+							}},
+							{VirtualService: appmesh.VirtualServiceBackend{
+								VirtualServiceRef: &appmesh.VirtualServiceReference{
+									Name:      "testVS",
+									Namespace: &testSecondaryNamespace,
 								},
 							}},
 						},


### PR DESCRIPTION
*Issue #, if available:*
Enhance Validation for VirtualNodes and VirtualRouters specs - #295

*Description of changes:*

- VirtualNode specs will now be validated/checked for the presence for duplicate backend references (VirtualServiceRefs & VirtualServiceARNs)
- VirtualRouter specs will now be validated/checked for the presence for duplicate route entries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
