### PR TITLE
Support to configure DNS TTL value of CloudMap services

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 	var logLevel string
 	awsCloudConfig := aws.CloudConfig{ThrottleConfig: throttle.NewDefaultServiceOperationsThrottleConfig()}
 	injectConfig := inject.Config{}
+	cloudMapConfig := cloudmap.Config{}
 	fs := pflag.NewFlagSet("", pflag.ExitOnError)
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Hour, "SyncPeriod determines the minimum frequency at which watched resources are reconciled.")
 	fs.StringVar(&metricsAddr, "metrics-addr", "0.0.0.0:8080", "The address the metric endpoint binds to.")
@@ -83,6 +84,7 @@ func main() {
 	fs.StringVar(&logLevel, "log-level", "info", "Set the controller log level - info(default), debug")
 	awsCloudConfig.BindFlags(fs)
 	injectConfig.BindFlags(fs)
+	cloudMapConfig.BindFlags(fs)
 	if err := fs.Parse(os.Args); err != nil {
 		setupLog.Error(err, "invalid flags")
 		os.Exit(1)
@@ -136,7 +138,7 @@ func main() {
 	vnResManager := virtualnode.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
 	vsResManager := virtualservice.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
 	vrResManager := virtualrouter.NewDefaultResourceManager(mgr.GetClient(), cloud.AppMesh(), referencesResolver, cloud.AccountID(), ctrl.Log)
-	cloudMapResManager := cloudmap.NewDefaultResourceManager(mgr.GetClient(), cloud.CloudMap(), referencesResolver, virtualNodeEndpointResolver, cloudMapInstancesReconciler, enableCustomHealthCheck, ctrl.Log)
+	cloudMapResManager := cloudmap.NewDefaultResourceManager(mgr.GetClient(), cloud.CloudMap(), referencesResolver, virtualNodeEndpointResolver, cloudMapInstancesReconciler, enableCustomHealthCheck, ctrl.Log, cloudMapConfig)
 	msReconciler := appmeshcontroller.NewMeshReconciler(mgr.GetClient(), finalizerManager, meshMembersFinalizer, meshResManager, ctrl.Log.WithName("controllers").WithName("Mesh"))
 	vgReconciler := appmeshcontroller.NewVirtualGatewayReconciler(mgr.GetClient(), finalizerManager, vgMembersFinalizer, vgResManager, ctrl.Log.WithName("controllers").WithName("VirtualGateway"))
 	grReconciler := appmeshcontroller.NewGatewayRouteReconciler(mgr.GetClient(), finalizerManager, grResManager, ctrl.Log.WithName("controllers").WithName("GatewayRoute"))

--- a/pkg/cloudmap/config.go
+++ b/pkg/cloudmap/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	flagSetCloudMapTTL = "cloudmap-ttl"
+	flagSetCloudMapTTL = "cloudmap-dns-ttl"
 )
 
 type Config struct {

--- a/pkg/cloudmap/config.go
+++ b/pkg/cloudmap/config.go
@@ -1,0 +1,27 @@
+package cloudmap
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const (
+	flagSetCloudMapTTL = "cloudmap-ttl"
+)
+
+type Config struct {
+	//Specifies the DNS TTL value to be used while creating CloudMap services.
+	CloudMapServiceTTL int64
+}
+
+func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
+	fs.Int64Var(&cfg.CloudMapServiceTTL, flagSetCloudMapTTL, defaultServiceDNSConfigTTL,
+		`CloudMap Service DNS TTL value`)
+}
+
+func (cfg *Config) BindEnv() error {
+	return nil
+}
+
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/pkg/cloudmap/resource_manager.go
+++ b/pkg/cloudmap/resource_manager.go
@@ -334,7 +334,7 @@ func (m *defaultResourceManager) createCloudMapServiceUnderPrivateDNSNamespace(c
 			DnsRecords: []*servicediscovery.DnsRecord{
 				{
 					Type: awssdk.String(servicediscovery.RecordTypeA),
-					TTL:  &cloudMapTTL,
+					TTL:  awssdk.Int64(cloudMapTTL),
 				},
 			},
 		},

--- a/pkg/cloudmap/resource_manager.go
+++ b/pkg/cloudmap/resource_manager.go
@@ -49,9 +49,11 @@ func NewDefaultResourceManager(
 	virtualNodeEndpointResolver VirtualNodeEndpointResolver,
 	instancesReconciler InstancesReconciler,
 	enableCustomHealthCheck bool,
-	log logr.Logger) ResourceManager {
+	log logr.Logger,
+	cfg Config) ResourceManager {
 
 	return &defaultResourceManager{
+		config:                      cfg,
 		k8sClient:                   k8sClient,
 		cloudMapSDK:                 cloudMapSDK,
 		referencesResolver:          referencesResolver,
@@ -66,6 +68,7 @@ func NewDefaultResourceManager(
 
 // defaultResourceManager implements ResourceManager
 type defaultResourceManager struct {
+	config                      Config
 	k8sClient                   client.Client
 	cloudMapSDK                 services.CloudMap
 	referencesResolver          references.Resolver
@@ -96,7 +99,7 @@ func (m *defaultResourceManager) Reconcile(ctx context.Context, vn *appmesh.Virt
 		return err
 	}
 	if svcSummary == nil {
-		svcSummary, err = m.createCloudMapService(ctx, vn, nsSummary, cloudMapConfig.ServiceName)
+		svcSummary, err = m.createCloudMapService(ctx, vn, nsSummary, cloudMapConfig.ServiceName, m.config.CloudMapServiceTTL)
 		if err != nil {
 			return err
 		}
@@ -252,10 +255,11 @@ func (m *defaultResourceManager) findCloudMapServiceFromAWS(ctx context.Context,
 	return sdkSVCSummary, nil
 }
 
-func (m *defaultResourceManager) createCloudMapService(ctx context.Context, vn *appmesh.VirtualNode, nsSummary *servicediscovery.NamespaceSummary, serviceName string) (*serviceSummary, error) {
+func (m *defaultResourceManager) createCloudMapService(ctx context.Context, vn *appmesh.VirtualNode, nsSummary *servicediscovery.NamespaceSummary, serviceName string,
+	cloudMapTTL int64) (*serviceSummary, error) {
 	switch awssdk.StringValue(nsSummary.Type) {
 	case servicediscovery.NamespaceTypeDnsPrivate:
-		sdkService, err := m.createCloudMapServiceUnderPrivateDNSNamespace(ctx, vn, nsSummary, serviceName)
+		sdkService, err := m.createCloudMapServiceUnderPrivateDNSNamespace(ctx, vn, nsSummary, serviceName, cloudMapTTL)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +323,7 @@ func (m *defaultResourceManager) deleteCloudMapService(ctx context.Context, vn *
 }
 
 func (m *defaultResourceManager) createCloudMapServiceUnderPrivateDNSNamespace(ctx context.Context, vn *appmesh.VirtualNode,
-	nsSummary *servicediscovery.NamespaceSummary, serviceName string) (*servicediscovery.Service, error) {
+	nsSummary *servicediscovery.NamespaceSummary, serviceName string, cloudMapTTL int64) (*servicediscovery.Service, error) {
 	creatorRequestID := string(vn.UID)
 	createServiceInput := &servicediscovery.CreateServiceInput{
 		CreatorRequestId: awssdk.String(creatorRequestID),
@@ -330,7 +334,7 @@ func (m *defaultResourceManager) createCloudMapServiceUnderPrivateDNSNamespace(c
 			DnsRecords: []*servicediscovery.DnsRecord{
 				{
 					Type: awssdk.String(servicediscovery.RecordTypeA),
-					TTL:  awssdk.Int64(defaultServiceDNSConfigTTL),
+					TTL:  &cloudMapTTL,
 				},
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*

Allow modification of AWS Cloud Map DNS record TTL #127

*Description of changes:*
 
-  Support to configure DNS TTL value of CloudMap services. "cloudmap-dns-ttl" value (in seconds) can be assigned/modified based on the requirement.
- If "cloudmap-dns-ttl" value is not provided to controller during bootstrap, a default value of 300s will be used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
