### PR TITLE
Add STS endpoint resolver to override the default

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
-github.com/aws/aws-sdk-go v1.32.4 h1:J2OMvipVB5dPIn+VH7L5rOqM4WoTsBxOqv+I06sjYOM=
-github.com/aws/aws-sdk-go v1.32.4/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.5 h1:p2fr1ryvNTU6avUWLI+/H7FGv0TBIjzVM5WDgXBBv4U=
 github.com/aws/aws-sdk-go v1.33.5/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -23,6 +23,9 @@ type Cloud interface {
 
 	// Region for the kubernetes cluster
 	Region() string
+
+	// AWS STS Endpoint override for the controller
+	STSEndpoint() string
 }
 
 // NewCloud constructs new Cloud implementation.
@@ -50,7 +53,25 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 		cfg.Region = region
 	}
 
-	awsCfg := aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)
+	var awsCfg *aws.Config
+	if len(cfg.STSEndpoint) == 0 {
+		awsCfg = aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)
+	} else {
+
+		stsEndpointOverride := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+			if service == endpoints.StsServiceID {
+				return endpoints.ResolvedEndpoint{
+					URL:           cfg.STSEndpoint,
+					SigningRegion: cfg.Region,
+				}, nil
+			}
+
+			return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
+		}
+
+		awsCfg = aws.NewConfig().WithEndpointResolver(endpoints.ResolverFunc(stsEndpointOverride)).WithRegion(cfg.Region)
+	}
+
 	sess = sess.Copy(awsCfg)
 	if len(cfg.AccountID) == 0 {
 		sts := services.NewSTS(sess)
@@ -90,4 +111,8 @@ func (c *defaultCloud) AccountID() string {
 
 func (c *defaultCloud) Region() string {
 	return c.cfg.Region
+}
+
+func (c *defaultCloud) STSEndpoint() string {
+	return c.cfg.STSEndpoint
 }

--- a/pkg/aws/cloud_config.go
+++ b/pkg/aws/cloud_config.go
@@ -9,6 +9,7 @@ const (
 	flagAWSRegion      = "aws-region"
 	flagAWSAccountID   = "aws-account-id"
 	flagAWSAPIThrottle = "aws-api-throttle"
+	flagAWSSTSEndpoint = "aws-sts-endpoint"
 )
 
 type CloudConfig struct {
@@ -16,6 +17,8 @@ type CloudConfig struct {
 	Region string
 	// AccountID for the kubernetes cluster
 	AccountID string
+	// AWS STS Endpoint override for the controller
+	STSEndpoint string
 	// Throttle settings for aws APIs
 	ThrottleConfig *throttle.ServiceOperationsThrottleConfig
 }
@@ -23,5 +26,6 @@ type CloudConfig struct {
 func (cfg *CloudConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.Region, flagAWSRegion, "", "AWS Region for the kubernetes cluster")
 	fs.StringVar(&cfg.AccountID, flagAWSAccountID, "", "AWS AccountID for the kubernetes cluster")
+	fs.StringVar(&cfg.STSEndpoint, flagAWSSTSEndpoint, "", "AWS STS endpoint override for the controller")
 	fs.Var(cfg.ThrottleConfig, flagAWSAPIThrottle, "throttle settings for AWS APIs, format: serviceID1:operationRegex1=rate:burst,serviceID2:operationRegex2=rate:burst")
 }


### PR DESCRIPTION
*Issue* #328 

*Description of changes:*
Add the support to override the default STS endpoint. 

Verified endpoint can be overridden, incorrect endpoint leads to controller throwing error, region mismatch leads to valid errors, when nothing is specified, default endpoints are used. In addition, all the subsequent API calls work fine for AppMesh and CloudMap.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
