### PR TITLE
Revert "Add STS endpoint resolver to override the default"

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
+github.com/aws/aws-sdk-go v1.32.4 h1:J2OMvipVB5dPIn+VH7L5rOqM4WoTsBxOqv+I06sjYOM=
+github.com/aws/aws-sdk-go v1.32.4/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.5 h1:p2fr1ryvNTU6avUWLI+/H7FGv0TBIjzVM5WDgXBBv4U=
 github.com/aws/aws-sdk-go v1.33.5/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/aws/cloud_config.go
+++ b/pkg/aws/cloud_config.go
@@ -9,7 +9,6 @@ const (
 	flagAWSRegion      = "aws-region"
 	flagAWSAccountID   = "aws-account-id"
 	flagAWSAPIThrottle = "aws-api-throttle"
-	flagAWSSTSEndpoint = "aws-sts-endpoint"
 )
 
 type CloudConfig struct {
@@ -17,8 +16,6 @@ type CloudConfig struct {
 	Region string
 	// AccountID for the kubernetes cluster
 	AccountID string
-	// AWS STS Endpoint override for the controller
-	STSEndpoint string
 	// Throttle settings for aws APIs
 	ThrottleConfig *throttle.ServiceOperationsThrottleConfig
 }
@@ -26,6 +23,5 @@ type CloudConfig struct {
 func (cfg *CloudConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.Region, flagAWSRegion, "", "AWS Region for the kubernetes cluster")
 	fs.StringVar(&cfg.AccountID, flagAWSAccountID, "", "AWS AccountID for the kubernetes cluster")
-	fs.StringVar(&cfg.STSEndpoint, flagAWSSTSEndpoint, "", "AWS STS endpoint override for the controller")
 	fs.Var(cfg.ThrottleConfig, flagAWSAPIThrottle, "throttle settings for AWS APIs, format: serviceID1:operationRegex1=rate:burst,serviceID2:operationRegex2=rate:burst")
 }


### PR DESCRIPTION
Original Issue #328 

Reverts aws/aws-app-mesh-controller-for-k8s#339

The original issue #330 in the chain wasn't the reason to reach the global STS endpoint. And this change was added to provide a way to override the STS endpoint of choice, however, this can also be achieved using PrivateLink, where it will set the dns for public STS endpoint in the VPC. We will recommend going with the latter approach and rely on PrivateLink endpoints that should match the same DNS names as the public regional endpoints, therefore reverting this.

#339 offers flexibility to add an endpoint however, we will not allow it for now. If the issue with global STS endpoint persists even after the accountID, please report an issue to us and we will address it