### PR TITLE
Fix for Jaeger tracing with Envoy v1.15.0

### DIFF
--- a/pkg/inject/datadog.go
+++ b/pkg/inject/datadog.go
@@ -17,8 +17,8 @@ static_resources:
   clusters:
   - name: datadog_agent
     connect_timeout: 1s
-    type: strict_dns
-    lb_policy: round_robin
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: datadog_agent
       endpoints:

--- a/pkg/inject/datadog_test.go
+++ b/pkg/inject/datadog_test.go
@@ -116,8 +116,8 @@ static_resources:
   clusters:
   - name: datadog_agent
     connect_timeout: 1s
-    type: strict_dns
-    lb_policy: round_robin
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: datadog_agent
       endpoints:

--- a/pkg/inject/envoy.go
+++ b/pkg/inject/envoy.go
@@ -51,7 +51,7 @@ const envoyContainerTemplate = `
       "value": "{{ .LogLevel }}"
     }{{ if or .EnableJaegerTracing .EnableDatadogTracing }},
     {
-      "name": "ENVOY_STATS_CONFIG_FILE",
+      "name": "ENVOY_TRACING_CFG_FILE",
       "value": "/tmp/envoy/envoyconf.yaml"
     }{{ end }},
     {

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -466,7 +466,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "debug",
 								},
 								{
-									Name:  "ENVOY_STATS_CONFIG_FILE",
+									Name:  "ENVOY_TRACING_CFG_FILE",
 									Value: "/tmp/envoy/envoyconf.yaml",
 								},
 								{
@@ -571,7 +571,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "debug",
 								},
 								{
-									Name:  "ENVOY_STATS_CONFIG_FILE",
+									Name:  "ENVOY_TRACING_CFG_FILE",
 									Value: "/tmp/envoy/envoyconf.yaml",
 								},
 								{

--- a/pkg/inject/jaeger.go
+++ b/pkg/inject/jaeger.go
@@ -13,13 +13,14 @@ tracing:
    "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
    collector_cluster: jaeger
    collector_endpoint: "/api/v1/spans"
+   collector_endpoint_version: HTTP_JSON
    shared_span_context: false
 static_resources:
   clusters:
   - name: jaeger
     connect_timeout: 1s
-    type: strict_dns
-    lb_policy: round_robin
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: jaeger
       endpoints:

--- a/pkg/inject/jaeger_test.go
+++ b/pkg/inject/jaeger_test.go
@@ -113,13 +113,14 @@ tracing:
    "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
    collector_cluster: jaeger
    collector_endpoint: "/api/v1/spans"
+   collector_endpoint_version: HTTP_JSON
    shared_span_context: false
 static_resources:
   clusters:
   - name: jaeger
     connect_timeout: 1s
-    type: strict_dns
-    lb_policy: round_robin
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: jaeger
       endpoints:


### PR DESCRIPTION
*Issue #, if available:*
#353

*Description of changes:*

Envoy v1.15.0 is expecting the Jaeger tracing config file to be specified under the env variable 'ENVOY_TRACING_CFG_FILE' while K8S controller currently specifies the config through the env variable 'ENVOY_STATS_CONFIG_FILE'. This commit addresses it along with some changes required for the Jaeger config file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
