### PR TITLE
Fix VirtualNode's ServiceDiscovery Validation Logic

### DIFF
--- a/apis/appmesh/v1beta2/virtualnode_types.go
+++ b/apis/appmesh/v1beta2/virtualnode_types.go
@@ -332,7 +332,8 @@ type VirtualNodeSpec struct {
 	// +kubebuilder:validation:MaxItems=1
 	// +optional
 	Listeners []Listener `json:"listeners,omitempty"`
-	// The service discovery information for the virtual node.
+	// The service discovery information for the virtual node. Optional if there is no
+	// inbound traffic(no listeners). Mandatory if a listener is specified.
 	// +optional
 	ServiceDiscovery *ServiceDiscovery `json:"serviceDiscovery,omitempty"`
 	// The backends that the virtual node is expected to send outbound traffic to.

--- a/webhooks/appmesh/virtualnode_validator_test.go
+++ b/webhooks/appmesh/virtualnode_validator_test.go
@@ -64,6 +64,38 @@ func Test_virtualNodeValidator_enforceFieldsImmutability(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "VirtualNode Optional ServiceDiscovery scenario",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+				oldVN: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
 			name: "VirtualNode DNS Servicediscovery change is allowed",
 			args: args{
 				vn: &appmesh.VirtualNode{
@@ -498,6 +530,89 @@ func Test_virtualNodeValidator_checkVirtualNodeBackendsForDuplicates(t *testing.
 		t.Run(tt.name, func(t *testing.T) {
 			v := &virtualNodeValidator{}
 			err := v.checkVirtualNodeBackendsForDuplicates(tt.args.vn)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_virtualNodeValidator_checkRequiredFields(t *testing.T) {
+	testARN := "testARN"
+	type args struct {
+		vn    *appmesh.VirtualNode
+		oldVN *appmesh.VirtualNode
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "ServiceDiscovery is Optional if listeners are not specified",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "my-vn",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						Backends: []appmesh.Backend{
+							{VirtualService: appmesh.VirtualServiceBackend{
+								VirtualServiceARN: &testARN,
+							},
+							},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ServiceDiscovery is Mandatory if listeners are specified",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "TestVN",
+					},
+					Spec: appmesh.VirtualNodeSpec{
+						AWSName: aws.String("my-vn_awesome-ns"),
+						MeshRef: &appmesh.MeshReference{
+							Name: "my-mesh",
+							UID:  "408d3036-7dec-11ea-b156-0e30aabe1ca8",
+						},
+						Listeners: []appmesh.Listener{
+							{
+								PortMapping: appmesh.PortMapping{
+									Port:     8080,
+									Protocol: "http",
+								},
+							},
+						},
+						Backends: []appmesh.Backend{
+							{VirtualService: appmesh.VirtualServiceBackend{
+								VirtualServiceARN: &testARN,
+							},
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("ServiceDiscovery missing for VirtualNode-TestVN. ServiceDiscovery must be specified when a listener is specified."),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &virtualNodeValidator{}
+			err := v.checkForRequiredFields(tt.args.vn)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {


### PR DESCRIPTION
*Issue #, if available:*
#361

*Description of changes:*

Corrects an issue with recently introduced VirtualNode validation logic to make ServiceDiscovery optional when listeners are not specified. Also, included an additional check in the VirtualNode Validation flow to make sure ServiceDiscovery is specified when a listener is present in the VirtualNode spec.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
