### PR TITLE
Add IAM policies for the controller and envoy

### DIFF
--- a/config/iam/controller-iam-policy.json
+++ b/config/iam/controller-iam-policy.json
@@ -1,0 +1,93 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+		"appmesh:ListVirtualRouters",
+		"appmesh:ListVirtualServices",
+		"appmesh:ListRoutes",
+		"appmesh:ListGatewayRoutes",
+		"appmesh:ListMeshes",
+		"appmesh:ListVirtualNodes",
+		"appmesh:ListVirtualGateways",
+		"appmesh:DescribeMesh",
+		"appmesh:DescribeVirtualRouter",
+		"appmesh:DescribeRoute",
+		"appmesh:DescribeVirtualNode",
+		"appmesh:DescribeVirtualGateway",
+		"appmesh:DescribeGatewayRoute",
+		"appmesh:DescribeVirtualService",
+		"appmesh:CreateMesh",
+		"appmesh:CreateVirtualRouter",
+		"appmesh:CreateVirtualGateway",
+		"appmesh:CreateVirtualService",
+		"appmesh:CreateGatewayRoute",
+		"appmesh:CreateRoute",
+		"appmesh:CreateVirtualNode",
+		"appmesh:UpdateMesh",
+		"appmesh:UpdateRoute",
+		"appmesh:UpdateVirtualGateway",
+		"appmesh:UpdateVirtualRouter",
+		"appmesh:UpdateGatewayRoute",
+		"appmesh:UpdateVirtualService",
+		"appmesh:UpdateVirtualNode",
+		"appmesh:DeleteMesh",
+		"appmesh:DeleteRoute",
+		"appmesh:DeleteVirtualRouter",
+		"appmesh:DeleteGatewayRoute",
+		"appmesh:DeleteVirtualService",
+		"appmesh:DeleteVirtualNode",
+		"appmesh:DeleteVirtualGateway"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "arn:aws:iam::*:role/aws-service-role/appmesh.amazonaws.com/AWSServiceRoleForAppMesh",
+            "Condition": {
+                "StringLike": {
+                    "iam:AWSServiceName": [
+                        "appmesh.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "acm-pca:DescribeCertificateAuthority",
+                "acm-pca:ListCertificateAuthorities"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+		"servicediscovery:CreateService",
+		"servicediscovery:DeleteService",
+		"servicediscovery:GetService",
+		"servicediscovery:GetInstance",
+		"servicediscovery:RegisterInstance",
+		"servicediscovery:DeregisterInstance",
+		"servicediscovery:ListInstances",
+		"servicediscovery:ListNamespaces",
+		"servicediscovery:ListServices",
+		"servicediscovery:GetInstancesHealthStatus",
+		"servicediscovery:UpdateInstanceCustomHealthStatus",
+		"servicediscovery:GetOperation",
+		"route53:GetHealthCheck",
+		"route53:CreateHealthCheck",
+		"route53:UpdateHealthCheck",
+		"route53:ChangeResourceRecordSets",
+		"route53:DeleteHealthCheck"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/config/iam/envoy-iam-policy.json
+++ b/config/iam/envoy-iam-policy.json
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "appmesh:StreamAggregatedResources"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "acm:ExportCertificate",
+                "acm-pca:GetCertificateAuthorityCertificate"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/config/iam/envoy-iam-policy.json
+++ b/config/iam/envoy-iam-policy.json
@@ -7,6 +7,14 @@
                 "appmesh:StreamAggregatedResources"
             ],
             "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "acm:ExportCertificate",
+                "acm-pca:GetCertificateAuthorityCertificate"
+            ],
+            "Resource": "*"
         }
     ]
 }

--- a/config/iam/preview/preview-controller-iam-policy.json
+++ b/config/iam/preview/preview-controller-iam-policy.json
@@ -1,0 +1,93 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+		"appmesh-preview:ListVirtualRouters",
+		"appmesh-preview:ListVirtualServices",
+		"appmesh-preview:ListRoutes",
+		"appmesh-preview:ListGatewayRoutes",
+		"appmesh-preview:ListMeshes",
+		"appmesh-preview:ListVirtualNodes",
+		"appmesh-preview:ListVirtualGateways",
+		"appmesh-preview:DescribeMesh",
+		"appmesh-preview:DescribeVirtualRouter",
+		"appmesh-preview:DescribeRoute",
+		"appmesh-preview:DescribeVirtualNode",
+		"appmesh-preview:DescribeVirtualGateway",
+		"appmesh-preview:DescribeGatewayRoute",
+		"appmesh-preview:DescribeVirtualService",
+		"appmesh-preview:CreateMesh",
+		"appmesh-preview:CreateVirtualRouter",
+		"appmesh-preview:CreateVirtualGateway",
+		"appmesh-preview:CreateVirtualService",
+		"appmesh-preview:CreateGatewayRoute",
+		"appmesh-preview:CreateRoute",
+		"appmesh-preview:CreateVirtualNode",
+		"appmesh-preview:UpdateMesh",
+		"appmesh-preview:UpdateRoute",
+		"appmesh-preview:UpdateVirtualGateway",
+		"appmesh-preview:UpdateVirtualRouter",
+		"appmesh-preview:UpdateGatewayRoute",
+		"appmesh-preview:UpdateVirtualService",
+		"appmesh-preview:UpdateVirtualNode",
+		"appmesh-preview:DeleteMesh",
+		"appmesh-preview:DeleteRoute",
+		"appmesh-preview:DeleteVirtualRouter",
+		"appmesh-preview:DeleteGatewayRoute",
+		"appmesh-preview:DeleteVirtualService",
+		"appmesh-preview:DeleteVirtualNode",
+		"appmesh-preview:DeleteVirtualGateway"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "arn:aws:iam::*:role/aws-service-role/appmesh-preview.amazonaws.com/AWSServiceRoleForAppMesh",
+            "Condition": {
+                "StringLike": {
+                    "iam:AWSServiceName": [
+                        "appmesh-preview.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "acm-pca:DescribeCertificateAuthority",
+                "acm-pca:ListCertificateAuthorities"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+		"servicediscovery:CreateService",
+		"servicediscovery:DeleteService",
+		"servicediscovery:GetService",
+		"servicediscovery:GetInstance",
+		"servicediscovery:RegisterInstance",
+		"servicediscovery:DeregisterInstance",
+		"servicediscovery:ListInstances",
+		"servicediscovery:ListNamespaces",
+		"servicediscovery:ListServices",
+		"servicediscovery:GetInstancesHealthStatus",
+		"servicediscovery:UpdateInstanceCustomHealthStatus",
+		"servicediscovery:GetOperation",
+		"route53:GetHealthCheck",
+		"route53:CreateHealthCheck",
+		"route53:UpdateHealthCheck",
+		"route53:ChangeResourceRecordSets",
+		"route53:DeleteHealthCheck"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/config/iam/preview/preview-envoy-iam-policy.json
+++ b/config/iam/preview/preview-envoy-iam-policy.json
@@ -4,7 +4,7 @@
         {
             "Effect": "Allow",
             "Action": [
-                "appmesh:StreamAggregatedResources"
+                "appmesh-preview:StreamAggregatedResources"
             ],
             "Resource": "*"
         }

--- a/config/iam/preview/preview-envoy-iam-policy.json
+++ b/config/iam/preview/preview-envoy-iam-policy.json
@@ -7,6 +7,14 @@
                 "appmesh-preview:StreamAggregatedResources"
             ],
             "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "acm:ExportCertificate",
+                "acm-pca:GetCertificateAuthorityCertificate"
+            ],
+            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
**Description of changes**
Added IAM policies for the controller and envoy proxies

Instead of using the managed policies `AWSAppMeshFullAccess`, `AWSCloudMapFullAccess`, this change adds the IAM permissions for the controller. Also, previously, we using the same IAM policies for the controller and Envoy proxies. This change also separates the Envoy IAM policy from the controller IAM policy. Helm charts will refer to these IAM policies in the installation steps.

**Testing done**
- Integration tests
- e2e tests
- App Mesh on EKS + Fargate


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
