### PR TITLE
Adjusted RBAC permissions for the controller

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -9,17 +9,15 @@ rules:
   resources:
   - configmaps
   verbs:
-  - get
   - list
   - watch
   - create
-  - update
-  - patch
-  - delete
 - apiGroups:
   - ""
   resources:
-  - configmaps/status
+  - configmaps
+  resourceNames:
+  - appmesh-controller-leader-election
   verbs:
   - get
   - update
@@ -30,3 +28,4 @@ rules:
   - events
   verbs:
   - create
+  - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,12 +12,7 @@ rules:
   - events
   verbs:
   - create
-  - delete
-  - get
-  - list
   - patch
-  - update
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/pkg/mesh/members_finalizer.go
+++ b/pkg/mesh/members_finalizer.go
@@ -22,7 +22,7 @@ type MembersFinalizer interface {
 	Finalize(ctx context.Context, ms *appmesh.Mesh) error
 }
 
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func NewPendingMembersFinalizer(k8sClient client.Client, eventRecorder record.EventRecorder, log logr.Logger) MembersFinalizer {
 	return &pendingMembersFinalizer{

--- a/pkg/virtualgateway/members_finalizer.go
+++ b/pkg/virtualgateway/members_finalizer.go
@@ -22,7 +22,7 @@ type MembersFinalizer interface {
 	Finalize(ctx context.Context, vg *appmesh.VirtualGateway) error
 }
 
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func NewPendingMembersFinalizer(k8sClient client.Client, eventRecorder record.EventRecorder, log logr.Logger) MembersFinalizer {
 	return &pendingMembersFinalizer{


### PR DESCRIPTION
**Description of changes**
Make the RBAC permissions more fine grained and removed unnecessary permissions on events API. Added the leader election ID (aka configmap) to the RBAC policy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
