### PR TITLE
Leave app ports empty for virtual nodes without listeners

### DIFF
--- a/pkg/inject/proxy.go
+++ b/pkg/inject/proxy.go
@@ -81,7 +81,8 @@ func (m *proxyMutator) getAppPorts(pod *corev1.Pod) string {
 		ports = append(ports, fmt.Sprintf("%d", listener.PortMapping.Port))
 	}
 	if len(ports) == 0 {
-		ports = []string{"0"}
+		// return empty string when there are no listener ports
+		return ""
 	}
 	return strings.Join(ports, ",")
 }


### PR DESCRIPTION
**Issue** #263 

**Description of changes**
For non-service tasks that do not listen on any port, application port/listener port field is not necessary. Instead of overriding empty listener to port=0, we should leave it empty. [aws-appmesh CNI plugin for Fargate](https://github.com/aws/amazon-vpc-cni-plugins/pull/37) and init proxy route manager both can handle applications without listeners/app ports and treating it as optional



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
