### PR TITLE
Add gh actions workflow to use self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,22 @@
-name: Build
-
+name: build
 on:
-  pull_request_target:
-    branches: [ master ]
+  pull_request:
+    branches:
+      - master
 
 jobs:
-
-  build_x86_64:
-    name: Build
+  build:
+    name: build
     runs-on: ubuntu-latest
     steps:
-
     - name: Set up Go 1.14
       uses: actions/setup-go@v2
       with:
         go-version: ^1.14
       id: go
-
-    - name: Check out code into the Go module directory
+    - name: checkout code
       uses: actions/checkout@v2
-
-    - name: Build
+    - name: make controller
       run: make controller
-
-    - name: Run
+    - name: check controller binary
       run: ./bin/controller -h || true

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,26 @@
+name: integration-test
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: integration-test
+    runs-on: [self-hosted, aws-app-mesh-controller-for-k8s]
+    steps:
+    - name: clean work dir from previous runs
+      run: |
+      rm -rf *
+    - name: setup go 1.14
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.14
+      id: go
+    - name: setup environment
+      run: |
+        source ~/.bashrc
+    - name: checkout code
+      uses: actions/checkout@v2
+    - name: make test
+      run: make test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,32 +1,27 @@
-name: Unit Test
-
+name: unit-test
 on:
-  pull_request_target:
-    branches: [ master ]
+  pull_request:
+    branches:
+      - master
 
 jobs:
-
-  build_x86_64:
-    name: Unit Test
+  build:
+    name: unit-test
     runs-on: ubuntu-latest
     steps:
-
-    - name: Set up Go 1.14
+    - name: setup go 1.14
       uses: actions/setup-go@v2
       with:
         go-version: ^1.14
       id: go
-
-    - name: Setup kubebuilder
+    - name: setup kubebuilder
       run: |
         arch=$(go env GOARCH)
         os=$(go env GOOS)
         curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
         sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
         export PATH=$PATH:/usr/local/kubebuilder/bin
-
-    - name: Checkout code into the Go module directory
+    - name: checkout code
       uses: actions/checkout@v2
-
-    - name: Run unit tests
+    - name: make test
       run: make test


### PR DESCRIPTION
**Issue** #348 

**Description of changes**
We have added three GitHub Actions self-hosted runners to run integration tests. As a first step towards enabling self-hosted runners, this PR adds a unit test workflow to use self-hosted runners. Once the unit test workflow has successful runs on the self-hosted runners, we will add support to spin up kinD clusters and run integrations tests.

Also, re-formatted the build and unit-test workflows


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
