### PR TITLE
Add kinD support to run integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: clean work dir from previous runs
       run: |
-      rm -rf *
+        rm -rf *
     - name: setup go 1.14
       uses: actions/setup-go@v2
       with:
@@ -22,5 +22,7 @@ jobs:
         source ~/.bashrc
     - name: checkout code
       uses: actions/checkout@v2
-    - name: make test
-      run: make test
+    - name: setup kind and run integration tests
+      run: make integration-test
+    - name: cleanup all the kind clusters
+      run: make delete-all-kind-clusters

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 bin
+build
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,16 @@ docker-build: check-env test
 docker-push: check-env
 	docker push $(IMAGE)
 
+integration-test: ## Run the integration using kind clusters
+	@./scripts/test-with-kind.sh
+
+delete-all-kind-clusters:	## Delete all local kind clusters
+	@kind get clusters | \
+	while read name ; do \
+	kind delete cluster --name $$name; \
+	done
+	@rm -rf build/tmp-test*
+
 setup-appmesh-sdk-override:
 	@if [ "$(APPMESH_SDK_OVERRIDE)" = "y" ] ; then \
 	    ./appmesh_models_override/setup.sh ; \

--- a/scripts/delete-kind-cluster.sh
+++ b/scripts/delete-kind-cluster.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+USAGE=$(cat << 'EOM'
+  Usage: delete-cluster  [-c <CLUSTER_CONTEXT>] [-o]
+  Deletes a kind cluster and context dir
+  Example: delete-cluster -c build/tmp-cluster-1234
+          Required:
+            -c          Cluster context directory
+          Optional:
+            -o          Override path w/ your own kubectl and kind binaries
+EOM
+)
+
+# Process our input arguments
+while getopts "c:o" opt; do
+  case ${opt} in
+    c ) # Cluster context directory
+        TMP_DIR=$OPTARG
+        CLUSTER_NAME=$(cat $TMP_DIR/clustername)
+      ;;
+    o ) # Override path with your own kubectl and kind binaries
+	      OVERRIDE_PATH=1
+        export PATH=$PATH:$TMP_DIR
+      ;;
+    \? )
+        echoerr "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+echo "🥑 Deleting k8s cluster using \"kind\""
+kind delete cluster --name "$CLUSTER_NAME"
+rm -r $TMP_DIR

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-cert-manager.sh
+#
+# Installs a stable version of cert-manager
+
+set -Eo pipefail
+
+CERT_MANAGER_VERSION="v0.14.3"
+
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml

--- a/scripts/install-controller-gen.sh
+++ b/scripts/install-controller-gen.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-controller-gen.sh
+#
+# Checks that the `controller-gen` binary is available on the host system and
+# if it is, that it matches the exact version that we require in order to
+# standardize the YAML manifests for CRDs and Kubernetes Roles.
+#
+# If the locally-installed controller-gen does not match the required version,
+# prints an error message asking the user to uninstall it.
+#
+# NOTE: We use this technique of building using `go build` within a temp
+# directory because controller-tools does not have a binary release artifact
+# for controller-gen.
+#
+# See: https://github.com/kubernetes-sigs/controller-tools/issues/500
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+CONTROLLER_TOOLS_VERSION="v0.4.0"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+if ! is_installed controller-gen; then
+    # GOBIN not always set... so default to installing into $GOPATH/bin if
+    # not...
+    __install_dir=${GOBIN:-$GOPATH/bin}
+    __install_path="$__install_dir/controller-gen"
+    __work_dir=$(mktemp -d /tmp/controller-gen-XXX)
+
+    echo -n "installing controller-gen ${CONTROLLER_TOOLS_VERSION} ... "
+    cd "$__work_dir"
+
+    go mod init tmp 1>/dev/null 2>&1
+    go get -d "sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_TOOLS_VERSION}" 1>/dev/null 2>&1
+    go build -o "$__work_dir/controller-gen" sigs.k8s.io/controller-tools/cmd/controller-gen 1>/dev/null 2>&1
+    mv "$__work_dir/controller-gen" "$__install_path"
+
+    rm -rf "$WORK_DIR"
+    echo "ok."
+fi

--- a/scripts/install-kind.sh
+++ b/scripts/install-kind.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-kind.sh [<kind version>]
+#
+# Installs KinD if not installed. Optional parameter specifies the version of
+# KinD to install. Defaults to the value of the environment variable
+# "KIND_VERSION" and if that is not set, the value of the DEFAULT_KIND_VERSION
+# variable.
+#
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/kind
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+DEFAULT_KIND_VERSION="0.9.0"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+__kind_version="$1"
+if [ "x$__kind_version" == "x" ]; then
+    __kind_version=${KIND_VERSION:-$DEFAULT_KIND_VERSION}
+fi
+
+if ! is_installed kind; then
+    __kind_url="https://kind.sigs.k8s.io/dl/v${__kind_version}/kind-linux-amd64"
+    echo -n "installing kind from $__kind_url ... "
+    curl --silent -Lo ./kind "$__kind_url"
+    chmod +x ./kind
+    sudo mv ./kind /usr/local/bin/kind
+    echo "ok."
+fi

--- a/scripts/install-kubectl.sh
+++ b/scripts/install-kubectl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-kubectl.sh
+#
+# Installs the latest stable version kubectl if not installed.
+#
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/kubectl
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+if ! is_installed kubectl; then
+    __platform=$(uname | tr '[:upper:]' '[:lower:]')
+    __stable_k8s_version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+    __kubectl_url="https://storage.googleapis.com/kubernetes-release/release/$__stable_k8s_version/bin/$__platform/amd64/kubectl"
+    echo -n "installing kubectl from $__kubectl_url ... "
+    curl --silent -Lo ./kubectl "$__kubectl_url"
+    chmod +x ./kubectl
+    sudo mv ./kubectl /usr/local/bin/kubectl
+    echo "ok."
+fi

--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-kustomize.sh
+#
+# Installs the latest version kustomize if not installed.
+#
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/kustomize
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+if ! is_installed kustomize ; then
+    __kustomize_url="https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+    echo -n "installing kustomize from $__kustomize_url ... "
+    curl --silent "$__kustomize_url" | bash 1>/dev/null
+    chmod +x kustomize
+    sudo mv kustomize /usr/local/bin/kustomize
+    echo "ok."
+fi

--- a/scripts/kind-two-node-cluster.yaml
+++ b/scripts/kind-two-node-cluster.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        apiVersion: kubeadm.k8s.io/v1beta2
+        kind: ClusterConfiguration
+        metadata:
+          name: config
+  - role: worker

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# check_is_installed checks to see if the supplied executable is installed and
+# exits if not. An optional second argument is an extra message to display when
+# the supplied executable is not installed.
+#
+# Usage:
+#
+#   check_is_installed PROGRAM [ MSG ]
+#
+# Example:
+#
+#   check_is_installed kind "You can install kind with the helper scripts/install-kind.sh"
+check_is_installed() {
+    local __name="$1"
+    local __extra_msg="$2"
+    if ! is_installed "$__name"; then
+        echo "FATAL: Missing requirement '$__name'"
+        echo "Please install $__name before running this script."
+        if [[ -n $__extra_msg ]]; then
+            echo ""
+            echo "$__extra_msg"
+            echo ""
+        fi
+        exit 1
+    fi
+}
+
+is_installed() {
+    local __name="$1"
+    if $(which $__name >/dev/null 2>&1); then
+        return 0
+    else
+        return 1
+    fi
+}
+
+DEFAULT_DEBUG_PREFIX="DEBUG: "
+
+# debug_msg prints out a supplied message if the DEBUG environs variable is
+# set. An optional second argument indicates the "indentation level" for the
+# message. If the indentation level argument is missing, we look for the
+# existence of an environs variable called "indent_level" and use that
+debug_msg() {
+    local __msg=${1:-}
+    local __indent_level=${2:-}
+    local __debug="${DEBUG:-""}"
+    local __debug_prefix="${DEBUG_PREFIX:-$DEFAULT_DEBUG_PREFIX}"
+    if [ ! -n "$__debug" ]; then
+        return 0
+    fi
+    __indent=""
+    if [ -n "$__indent_level" ]; then
+        __indent="$( for each in $( seq 0 $__indent_level ); do printf " "; done )"
+    fi
+    echo "$__debug_prefix$__indent$__msg"
+}

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# A script that provisions a KinD Kubernetes cluster for local development and
+# testing
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+
+source "$SCRIPTS_DIR"/lib/common.sh
+
+check_is_installed uuidgen
+check_is_installed wget
+check_is_installed docker
+check_is_installed kind "You can install kind with the helper scripts/install-kind.sh"
+
+OVERRIDE_PATH=0
+KIND_CONFIG_FILE="$SCRIPTS_DIR/kind-two-node-cluster.yaml"
+
+K8_1_18="kindest/node:v1.18.4@sha256:9ddbe5ba7dad96e83aec914feae9105ac1cffeb6ebd0d5aa42e820defe840fd4"
+K8_1_17="kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
+K8_1_16="kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"
+K8_1_15="kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50"
+K8_1_14="kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6"
+
+K8_VERSION="$K8_1_16"
+
+USAGE="
+Usage:
+  $(basename "$0") CLUSTER_NAME [-v K8S_VERSION]
+
+Provisions a KinD cluster for local development and testing.
+
+Example: $(basename "$0") my-test -v 1.16
+
+      Optional:
+        -v          K8s version to use in this test
+"
+
+cluster_name="$1"
+if [[ -z "$cluster_name" ]]; then
+    echo "FATAL: required cluster name argument missing."
+    echo "${USAGE}" 1>&2
+    exit 1
+fi
+
+shift
+
+# Process our input arguments
+while getopts "b:i:v:k:" opt; do
+  case ${opt} in
+    v ) # K8s version to provision
+        OPTARG="K8_$(echo "${OPTARG}" | sed 's/\./\_/g')"
+        if [ ! -z ${OPTARG+x} ]; then
+            K8_VERSION=${!OPTARG}
+        else
+            echo "K8s version not supported" 1>&2
+            exit 2
+        fi
+      ;;
+    \? )
+        echo "${USAGE}" 1>&2
+        exit
+      ;;
+  esac
+done
+
+TMP_DIR=$ROOT_DIR/build/tmp-$cluster_name
+mkdir -p "${TMP_DIR}"
+
+debug_msg "kind: using Kubernetes $K8_VERSION"
+echo -n "creating kind cluster $cluster_name ... "
+for i in $(seq 0 5); do
+  if [[ -z $(kind get clusters 2>/dev/null | grep $cluster_name) ]]; then
+      kind create cluster -q --name "$cluster_name" --image $K8_VERSION --config "$KIND_CONFIG_FILE" --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
+  else
+      break
+  fi
+done
+echo "ok."
+
+echo "$cluster_name" > $TMP_DIR/clustername

--- a/scripts/test-with-kind.sh
+++ b/scripts/test-with-kind.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# A script that builds the appmesh controller, provisions a KinD
+# Kubernetes cluster, installs appmesh CRDs and controller into that
+# Kubernetes cluster and runs a set of tests
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+INT_TEST_DIR="$ROOT_DIR/test/integration"
+
+CLUSTER_NAME_BASE="test"
+K8S_VERSION="1.17"
+TMP_DIR=""
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+check_is_installed curl
+check_is_installed docker
+check_is_installed jq
+check_is_installed uuidgen
+check_is_installed wget
+check_is_installed kind "You can install kind with the helper scripts/install-kind.sh"
+check_is_installed kubectl "You can install kubectl with the helper scripts/install-kubectl.sh"
+check_is_installed kustomize "You can install kustomize with the helper scripts/install-kustomize.sh"
+check_is_installed controller-gen "You can install controller-gen with the helper scripts/install-controller-gen.sh"
+
+
+function setup_kind_cluster {
+    TEST_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+    CLUSTER_NAME_BASE=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+    CLUSTER_NAME="appmesh-test-$CLUSTER_NAME_BASE"-"${TEST_ID}"
+    TMP_DIR=$ROOT_DIR/build/tmp-$CLUSTER_NAME
+    $SCRIPTS_DIR/provision-kind-cluster.sh "${CLUSTER_NAME}" -v "${K8S_VERSION}"
+}
+
+function install_crds {
+    make install 
+}
+
+function build_and_publish_controller {
+        echo "Not implemented"
+}
+
+function install_controller {
+        echo "Not implemented"
+}
+
+function run_integration_tests {
+	echo "Not implemented"
+}
+
+setup_kind_cluster
+export KUBECONFIG="${TMP_DIR}/kubeconfig"
+
+# Generate and install CRDs
+install_crds
+
+# Install cert-manager
+$SCRIPTS_DIR/install-cert-manager.sh
+
+
+# Show the installed CRDs
+kubectl get crds


### PR DESCRIPTION
**Issue** #348 

**Description of changes**
To run integration tests, we will be using [kinD](https://kind.sigs.k8s.io/). Added the scripts to setup kinD clusters for testing. This PR verifies kind clusters come up fine on GitHub Action runners and that we can install App Mesh CRDs on the cluster. In the next step, we will build, publish and install appmesh controller. Followed by enabling integration tests. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
