### PR TITLE
Fix jaeger tracing collector endpoint and tracer type

### DIFF
--- a/pkg/inject/jaeger.go
+++ b/pkg/inject/jaeger.go
@@ -8,11 +8,11 @@ import (
 const jaegerEnvoyConfigTemplate = `
 tracing:
  http:
-  name: envoy.zipkin
+  name: envoy.tracers.zipkin
   typed_config:
    "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
    collector_cluster: jaeger
-   collector_endpoint: "/api/v1/spans"
+   collector_endpoint: "/api/v2/spans"
    collector_endpoint_version: HTTP_JSON
    shared_span_context: false
 static_resources:

--- a/pkg/inject/jaeger_test.go
+++ b/pkg/inject/jaeger_test.go
@@ -108,11 +108,11 @@ func Test_jaegerMutator_mutate(t *testing.T) {
 								`cat <<EOF >> /tmp/envoy/envoyconf.yaml
 tracing:
  http:
-  name: envoy.zipkin
+  name: envoy.tracers.zipkin
   typed_config:
    "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
    collector_cluster: jaeger
-   collector_endpoint: "/api/v1/spans"
+   collector_endpoint: "/api/v2/spans"
    collector_endpoint_version: HTTP_JSON
    shared_span_context: false
 static_resources:


### PR DESCRIPTION
**Description of changes**
`envoy.zipkin` is not a valid trace driver name. It should be `envoy.tracers.zipkin` [1]. Also, we were sending v2 JSON over HTTP to `/api/v1/spans`. `/api/v1/spans` is used for submitting spans in Zipkin JSON v1 or Zipkin Thrift format. `/api/v2/spans` is used for submitting spans in Zipkin JSON v2 [2]. Made v2 default.

[1] https://github.com/envoyproxy/envoy/blob/v1.15.1/api/envoy/config/trace/v2/http_tracer.proto#L40
[2] https://www.jaegertracing.io/docs/1.19/apis/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
