### PR TITLE
Build and publish the controller image in the CI

### DIFF
--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -6,6 +6,17 @@
 
 set -Eo pipefail
 
-CERT_MANAGER_VERSION="v0.14.3"
+DEFAULT_CERT_MANAGER_VERSION="v0.14.3"
 
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+check_is_installed kubectl "You can install kubectl with the helper scripts/install-kubectl.sh"
+
+__cert_manager_version="$1"
+if [ "z$__cert_manager_version" == "z" ]; then
+    __cert_manager_version=${CERT_MANAGER_VERSION:-$DEFAULT_CERT_MANAGER_VERSION}
+fi
+
+echo -n "installing cert-manager ... "
+__cert_manager_url="https://github.com/jetstack/cert-manager/releases/download/${__cert_manager_version}/cert-manager.yaml"
+echo -n "installing cert-manager from $__cert_manager_url ... "
+kubectl apply --validate=false -f $__cert_manager_url
+echo "ok."

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+AWS_CLI_VERSION=$(aws --version 2>&1 | cut -d/ -f2 | cut -d. -f1)
+
+# aws_check_credentials() calls the STS::GetCallerIdentity API call and
+# verifies that there is a local identity for running AWS commands
+aws_check_credentials() {
+    echo -n "checking AWS credentials ... "
+    aws sts get-caller-identity --query "Account" >/dev/null ||
+        ( echo "\nFATAL: No AWS credentials found. Please run \`aws configure\` to set up the CLI for your credentials." && exit 1 )
+    echo "ok."
+}
+
+aws_account_id() {
+    JSON=$( aws sts get-caller-identity --output json || exit 1 )
+    echo "${JSON}" | jq --raw-output ".Account"
+}
+
+ecr_login() {
+    echo -n "ecr login ... "
+    local __aws_region=$1
+    local __ecr_url=$2
+    local __err_msg="Failed ECR login. Please make sure you have IAM permissions to access ECR."
+    if [ $AWS_CLI_VERSION -gt 1 ]; then
+        ( aws ecr get-login-password --region $__aws_region | \
+		docker login --username AWS --password-stdin $__ecr_url ) ||
+		( echo "\n$__err_msg" && exit 1 )
+    else
+	    $( aws ecr get-login --no-include-email ) || ( echo "\n$__err_msg" && exit 1 ) 
+    fi
+    echo "ok."
+}

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -35,6 +35,16 @@ is_installed() {
     fi
 }
 
+# vpc_id fetches the vpc id of the GitHub Actions runner/EC2 instance.
+# vpc id is needed for setting up AWS CloudMap namespaces
+vpc_id() {
+    local __md_url="http://169.254.169.254/latest/meta-data/network/interfaces"
+    local __macid=$( curl $__md_url/macs/ || exit 1 )
+    local __vpcid=$( curl $__md_url/macs/${macid}/vpc-id || exit 1 )
+    echo "$__vpcid"
+
+}
+
 DEFAULT_DEBUG_PREFIX="DEBUG: "
 
 # debug_msg prints out a supplied message if the DEBUG environs variable is


### PR DESCRIPTION
**Issue** #348 

**Description of changes**
As part of GitHub Actions setup to run integration tests, we will build the controller image from source, install the image and run integration tests against it. This PR adds the support to build and publish controller images as part of the integration tests workflow

**Testing**
See the `integration-test` GitHub Actions [workflow results for this PR](https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/380/checks?check_run_id=1354747804)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
