### PR TITLE
Add integration tests to gh actions kind infra

### DIFF
--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -6,7 +6,11 @@
 
 set -Eo pipefail
 
+SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 DEFAULT_CERT_MANAGER_VERSION="v0.14.3"
+
+source "$SCRIPTS_DIR/lib/k8s.sh"
+source "$SCRIPTS_DIR/lib/common.sh"
 
 check_is_installed kubectl "You can install kubectl with the helper scripts/install-kubectl.sh"
 
@@ -15,8 +19,24 @@ if [ "z$__cert_manager_version" == "z" ]; then
     __cert_manager_version=${CERT_MANAGER_VERSION:-$DEFAULT_CERT_MANAGER_VERSION}
 fi
 
-echo -n "installing cert-manager ... "
-__cert_manager_url="https://github.com/jetstack/cert-manager/releases/download/${__cert_manager_version}/cert-manager.yaml"
-echo -n "installing cert-manager from $__cert_manager_url ... "
-kubectl apply --validate=false -f $__cert_manager_url
-echo "ok."
+install() {
+    echo -n "installing cert-manager ... "
+    __cert_manager_url="https://github.com/jetstack/cert-manager/releases/download/${__cert_manager_version}/cert-manager.yaml"
+    echo -n "installing cert-manager from $__cert_manager_url ... "
+    kubectl apply --validate=false -f $__cert_manager_url
+    echo "ok."
+}
+
+check() {
+    echo -n "checking cert-manager deployments have rolled out ... "
+    local __ns="cert-manager"
+    local __timeout="4m"
+    check_deployment_rollout cert-manager-webhook $__ns $__timeout
+    check_deployment_rollout cert-manager $__ns
+    check_deployment_rollout cert-manager-cainjector $__ns
+    echo "ok."
+}
+
+
+install
+check

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -23,10 +23,10 @@ ecr_login() {
     local __err_msg="Failed ECR login. Please make sure you have IAM permissions to access ECR."
     if [ $AWS_CLI_VERSION -gt 1 ]; then
         ( aws ecr get-login-password --region $__aws_region | \
-		docker login --username AWS --password-stdin $__ecr_url ) ||
-		( echo "\n$__err_msg" && exit 1 )
+                docker login --username AWS --password-stdin $__ecr_url ) ||
+                ( echo "\n$__err_msg" && exit 1 )
     else
-	    $( aws ecr get-login --no-include-email ) || ( echo "\n$__err_msg" && exit 1 ) 
+        $( aws ecr get-login --no-include-email ) || ( echo "\n$__err_msg" && exit 1 )
     fi
     echo "ok."
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -39,8 +39,8 @@ is_installed() {
 # vpc id is needed for setting up AWS CloudMap namespaces
 vpc_id() {
     local __md_url="http://169.254.169.254/latest/meta-data/network/interfaces"
-    local __macid=$( curl $__md_url/macs/ || exit 1 )
-    local __vpcid=$( curl $__md_url/macs/${macid}/vpc-id || exit 1 )
+    local __macid=$( curl ${__md_url}/macs/ || exit 1 )
+    local __vpcid=$( curl ${__md_url}/macs/${__macid}vpc-id || exit 1 )
     echo "$__vpcid"
 
 }

--- a/scripts/lib/k8s.sh
+++ b/scripts/lib/k8s.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$THIS_DIR/../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+
+# resource_exists returns 0 when the supplied resource can be found, 1
+# otherwise. An optional second parameter overrides the Kubernetes namespace
+# argument
+k8s_resource_exists() {
+    local __res_name=${1:-}
+    local __namespace=${2:-}
+    local __args=""
+    if [ -n "$__namespace" ]; then
+        __args="$__args-n $__namespace"
+    fi
+    kubectl get $__args "$__res_name" >/dev/null 2>&1
+}
+
+
+# check_deployment_rollout watches the status of the latest rollout
+# until it's done or until the timeout. Namespace and timeout are optional
+# parameters
+check_deployment_rollout() {
+    local __dep_name=${1:-}
+    local __namespace=${2:-}
+    local __timeout=${3:-"2m"}
+    local __args=""
+    if [ -n "$__namespace" ]; then
+        __args="$__args-n $__namespace"
+    fi
+    kubectl rollout status deployment/"$__dep_name" $__args --timeout=$__timeout
+}

--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -3,10 +3,10 @@ package utils
 import "time"
 
 const (
-	PollIntervalShort  = 2 * time.Second
-	PollIntervalMedium = 10 * time.Second
-	PollRetries        = 5
+	PollIntervalShort  = 5 * time.Second
+	PollIntervalMedium = 15 * time.Second
+	PollRetries        = 10
 
-	AWSPollIntervalShort  = 1 * time.Second
-	AWSPollIntervalMedium = 5 * time.Second
+	AWSPollIntervalShort  = 5 * time.Second
+	AWSPollIntervalMedium = 15 * time.Second
 )


### PR DESCRIPTION
**Issue** #348 

**Description of changes**
Added support to run integration tests in GitHub Actions end to end testing setup. This change enables a subset of test suites (`mesh`, `virtualservice`, `virtualrouter ` and `gatewayroute`). We'll use these to get multiple runs in the CI and make sure the test infra is stable and there are no sporadic failures. Rest of the test suites will be enabled in a follow up.

- Added installation and rollout readiness checks helpers
- Install the controller to test KinD cluster for integration tests
- Change the test framework default poll timeout and retries
- Enabled `mesh`, `virtualservice`, `virtualrouter ` and `gatewayroute` integration tests in gh actions

**Testing**
See the integration-test GitHub Actions[ workflow results for this PR](https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/381/checks?check_run_id=1355539829)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
