### PR TITLE
Run gh actions workflows on push as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,5 +1,8 @@
 name: integration-test
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,5 +1,8 @@
 name: unit-test
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,9 @@
-![Build](https://github.com/aws/aws-app-mesh-controller-for-k8s/workflows/Build/badge.svg?branch=master)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/aws/aws-app-mesh-controller-for-k8s/issues)
+![GitHub issues](https://img.shields.io/github/issues-raw/aws/aws-app-mesh-controller-for-k8s?style=flat)
+![GitHub](https://img.shields.io/github/license/aws/aws-app-mesh-controller-for-k8s?style=flat)
+
+
+![Build](https://github.com/aws/aws-app-mesh-controller-for-k8s/workflows/build/badge.svg?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/aws/aws-app-mesh-controller-for-k8s)](https://goreportcard.com/report/github.com/aws/aws-app-mesh-controller-for-k8s)
 
 <p>


### PR DESCRIPTION
**Description of changes**
GitHub Actions status badge shows "no status" as the workflows are only run pull_request currently. Enable the GitHub Actions to run on push as well so the status badge reflects the last state (pass, fail etc) of the workflows


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
