### PR TITLE
Fix envoy version in change log and default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.2.0
 
 ### Summary
-This release includes support for outlier detection, circuit breakers using connection pools, support for additional Envoy config parameters, new Envoy version v1.15.0.0-prod, GitHub Actions integration for automated tests and bug fixes.
+This release includes support for outlier detection, circuit breakers using connection pools, support for additional Envoy config parameters, new Envoy version v1.15.1.0-prod, GitHub Actions integration for automated tests and bug fixes.
 
 ### Changes
 * Update API docs with outlier detection and connection pools ([#384](https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/384)  @fawadkhaliq)

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -96,7 +96,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		`If enabled, a fsGroup: 1337 will be injected in the absence of it within pod securityContext`)
 	fs.BoolVar(&cfg.EnableECRSecret, flagEnableECRSecret, false,
 		"If enabled, 'appmesh-ecr-secret' secret will be injected in the absence of it within pod imagePullSecrets")
-	fs.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
+	fs.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.15.1.0-prod",
 		"Envoy sidecar container image.")
 	fs.StringVar(&cfg.SidecarCpuRequests, flagSidecarCpuRequests, "10m",
 		"Sidecar CPU resources requests.")


### PR DESCRIPTION
**Description of changes**
Fixed typo in 1.2.0 change log to correct the default envoy version to `v1.15.1.0-prod`

The default in [appmesh-controller Helm chart](https://github.com/aws/eks-charts/blob/master/stable/appmesh-controller/values.yaml#L17) is set to `v1.15.1.0-prod`. Changing it here as well. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
