### PR TITLE
Add xray daemon port in virtualgateway pod mutator

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -173,6 +173,7 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				sidecarCPULimits:      m.config.SidecarCpuLimits,
 				sidecarMemoryLimits:   m.config.SidecarMemoryLimits,
 				xRayImage:             m.config.XRayImage,
+				xRayDaemonPort:        m.config.XrayDaemonPort,
 			}, m.config.EnableXrayTracing),
 		}
 	}

--- a/pkg/inject/xray_test.go
+++ b/pkg/inject/xray_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -374,6 +375,153 @@ func Test_xrayMutator_mutate(t *testing.T) {
 									"cpu": cpuLimits,
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "missing xray daemon port",
+			fields: fields{
+				enabled: true,
+				mutatorConfig: xrayMutatorConfig{
+					awsRegion:             "us-west-2",
+					sidecarCPURequests:    cpuRequests.String(),
+					sidecarMemoryRequests: memoryRequests.String(),
+					xRayImage:             "amazon/aws-xray-daemon",
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantErr: errors.New("Missing configuration parameters: xRayDaemonPort"),
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "missing aws region",
+			fields: fields{
+				enabled: true,
+				mutatorConfig: xrayMutatorConfig{
+					sidecarCPURequests:    cpuRequests.String(),
+					sidecarMemoryRequests: memoryRequests.String(),
+					xRayImage:             "amazon/aws-xray-daemon",
+					xRayDaemonPort:        2000,
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantErr: errors.New("Missing configuration parameters: AWSRegion"),
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "missing xray image",
+			fields: fields{
+				enabled: true,
+				mutatorConfig: xrayMutatorConfig{
+					awsRegion:             "us-west-2",
+					sidecarCPURequests:    cpuRequests.String(),
+					sidecarMemoryRequests: memoryRequests.String(),
+					xRayDaemonPort:        2000,
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantErr: errors.New("Missing configuration parameters: xRayImage"),
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "missing aws region and xray image",
+			fields: fields{
+				enabled: true,
+				mutatorConfig: xrayMutatorConfig{
+					sidecarCPURequests:    cpuRequests.String(),
+					sidecarMemoryRequests: memoryRequests.String(),
+					xRayDaemonPort:        2000,
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantErr: errors.New("Missing configuration parameters: AWSRegion,xRayImage"),
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "missing aws region, xray image and xray daemon port",
+			fields: fields{
+				enabled: true,
+				mutatorConfig: xrayMutatorConfig{
+					sidecarCPURequests:    cpuRequests.String(),
+					sidecarMemoryRequests: memoryRequests.String(),
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantErr: errors.New("Missing configuration parameters: AWSRegion,xRayImage,xRayDaemonPort"),
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
 						},
 					},
 				},


### PR DESCRIPTION
**Issue**
#395 

**Description of changes**
When xray sidecar injection (tracing) is enabled, virtual gateway pod mutator does not pass the xray daemon port to the mutator. This leads to xray daemon container coming up without a container port. The issue was introduced as part of adding new config parameters for Envoy (https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/365) where xray mutotar init for virtual gateway does not get the xray daemon port passed down to the mutator, which leads to incorrect spec. 

This change adds the `XrayDaemonPort` to the xray mutator init, adds checks for mandatory fields and corresponding tests to avoid regression

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
