### PR TITLE
Handle duplicate CloudMap service scenarios

### DIFF
--- a/pkg/cloudmap/resource_manager.go
+++ b/pkg/cloudmap/resource_manager.go
@@ -228,6 +228,7 @@ func (m *defaultResourceManager) findCloudMapService(ctx context.Context, nsSumm
 	if sdkSVCSummary != nil {
 		svcSummary := &serviceSummary{
 			serviceID:               awssdk.StringValue(sdkSVCSummary.Id),
+			serviceARN:              sdkSVCSummary.Arn,
 			healthCheckCustomConfig: sdkSVCSummary.HealthCheckCustomConfig,
 		}
 		m.serviceSummaryCache.Add(cacheKey, svcSummary, defaultServiceCacheTTL)
@@ -448,6 +449,9 @@ func (m *defaultResourceManager) isCloudMapServiceCreated(ctx context.Context, v
 }
 
 func (m *defaultResourceManager) updateCRDVirtualNode(ctx context.Context, vn *appmesh.VirtualNode, svcSummary *serviceSummary) error {
+	if svcSummary.serviceARN == nil {
+		return nil
+	}
 	oldVN := vn.DeepCopy()
 	vnAnnotations := oldVN.Annotations
 

--- a/pkg/cloudmap/resource_manager_test.go
+++ b/pkg/cloudmap/resource_manager_test.go
@@ -52,6 +52,26 @@ func Test_defaultResourceManager_updateCRDVirtualNode(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "virtualNode patch flow with no ARN",
+			args: args{
+				vn: &appmesh.VirtualNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "vn-1",
+						Annotations: map[string]string{},
+					},
+					Status: appmesh.VirtualNodeStatus{},
+				},
+				svcSummary: &serviceSummary{
+					serviceID: "cloudMapService",
+				},
+			},
+			wantVN: &appmesh.VirtualNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vn-1",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
#397

*Description of changes:*
AppMesh controller currently doesn't handle scenarios where a user might create duplicate AppMesh resources across different meshes that share the same CloudMap namespace. Although this is unsupported config, it currently results in controller going in to a crash loop until the config is corrected. PR addresses the crash. However, this sort of config might result in unexpected service mesh behavior. We will introduce resource tagging(#349) in the near future and that will assist the controller in alerting the user about the config issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
