### PR TITLE
use ubuntu-18.04 instead of latest in github actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Set up Go 1.14
       uses: actions/setup-go@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: unit-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: setup go 1.14
       uses: actions/setup-go@v2


### PR DESCRIPTION
**Description**
ubuntu-latest workflows will use ubuntu-20.04 moving forward [1]
The change will be rolled out over a period of several weeks
beginning 11/30/2020. Until ubuntu-20.04 rollout is complete, use
ubuntu-18.04 for consistent builds.

[1] https://github.com/actions/virtual-environments/issues/1816

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
