### PR TITLE
Add sideEffects:None to webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION ?= $(shell git describe --dirty --tags --always)
 IMAGE ?= $(REPO):$(VERSION)
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1beta1"
 
 # app mesh aws-sdk-go override in case we need to build against a custom version
 APPMESH_SDK_OVERRIDE ?= "n"
@@ -96,7 +96,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/config/crd/bases/appmesh.k8s.aws_gatewayroutes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_gatewayroutes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: gatewayroutes.appmesh.k8s.aws
 spec:

--- a/config/crd/bases/appmesh.k8s.aws_meshes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_meshes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: meshes.appmesh.k8s.aws
 spec:

--- a/config/crd/bases/appmesh.k8s.aws_virtualgateways.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualgateways.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: virtualgateways.appmesh.k8s.aws
 spec:

--- a/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualnodes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: virtualnodes.appmesh.k8s.aws
 spec:

--- a/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: virtualrouters.appmesh.k8s.aws
 spec:

--- a/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualservices.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: virtualservices.appmesh.k8s.aws
 spec:

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- manifests.yaml
+- manifests.v1beta1.yaml
 - service.yaml
 
 configurations:

--- a/config/webhook/manifests.v1beta1.yaml
+++ b/config/webhook/manifests.v1beta1.yaml
@@ -7,7 +7,6 @@ metadata:
   name: mutating-webhook-configuration
 webhooks:
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -24,8 +23,8 @@ webhooks:
     - UPDATE
     resources:
     - gatewayroutes
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -42,8 +41,8 @@ webhooks:
     - UPDATE
     resources:
     - meshes
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -60,8 +59,8 @@ webhooks:
     - UPDATE
     resources:
     - virtualgateways
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -78,8 +77,8 @@ webhooks:
     - UPDATE
     resources:
     - virtualnodes
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -96,8 +95,8 @@ webhooks:
     - UPDATE
     resources:
     - virtualrouters
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -114,8 +113,8 @@ webhooks:
     - UPDATE
     resources:
     - virtualservices
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -131,6 +130,7 @@ webhooks:
     - CREATE
     resources:
     - pods
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -140,7 +140,6 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -157,8 +156,8 @@ webhooks:
     - UPDATE
     resources:
     - gatewayroutes
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -175,8 +174,8 @@ webhooks:
     - UPDATE
     resources:
     - meshes
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -193,8 +192,8 @@ webhooks:
     - UPDATE
     resources:
     - virtualgateways
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -211,8 +210,8 @@ webhooks:
     - UPDATE
     resources:
     - virtualnodes
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -229,8 +228,8 @@ webhooks:
     - UPDATE
     resources:
     - virtualrouters
+  sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -247,3 +246,4 @@ webhooks:
     - UPDATE
     resources:
     - virtualservices
+  sideEffects: None

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -18,6 +18,7 @@ check_is_installed kind "You can install kind with the helper scripts/install-ki
 OVERRIDE_PATH=0
 KIND_CONFIG_FILE="$SCRIPTS_DIR/kind-two-node-cluster.yaml"
 
+K8_1_19="kindest/node:v1.19.4@sha256:796d09e217d93bed01ecf8502633e48fd806fe42f9d02fdd468b81cd4e3bd40b"
 K8_1_18="kindest/node:v1.18.4@sha256:9ddbe5ba7dad96e83aec914feae9105ac1cffeb6ebd0d5aa42e820defe840fd4"
 K8_1_17="kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
 K8_1_16="kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"

--- a/webhooks/appmesh/gatewayroute_mutator.go
+++ b/webhooks/appmesh/gatewayroute_mutator.go
@@ -98,7 +98,7 @@ func (m *gatewayRouteMutator) designateVirtualGatewayMembership(ctx context.Cont
 	return virtualGateway, nil
 }
 
-// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-gatewayroute,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=create;update,versions=v1beta2,name=mgatewayroute.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-gatewayroute,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=create;update,versions=v1beta2,name=mgatewayroute.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (m *gatewayRouteMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutateAppMeshGatewayRoute, webhook.MutatingWebhookForMutator(m))

--- a/webhooks/appmesh/gatewayroute_validator.go
+++ b/webhooks/appmesh/gatewayroute_validator.go
@@ -63,7 +63,7 @@ func (v *gatewayRouteValidator) enforceFieldsImmutability(newGR *appmesh.Gateway
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-gatewayroute,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=create;update,versions=v1beta2,name=vgatewayroute.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-gatewayroute,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=gatewayroutes,verbs=create;update,versions=v1beta2,name=vgatewayroute.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (v *gatewayRouteValidator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathValidateAppMeshGatewayRoute, webhook.ValidatingWebhookForValidator(v))

--- a/webhooks/appmesh/mesh_mutator.go
+++ b/webhooks/appmesh/mesh_mutator.go
@@ -45,7 +45,7 @@ func (m *meshMutator) defaultingAWSName(mesh *appmesh.Mesh) error {
 	return nil
 }
 
-// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-mesh,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=meshes,verbs=create;update,versions=v1beta2,name=mmesh.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-mesh,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=meshes,verbs=create;update,versions=v1beta2,name=mmesh.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (m *meshMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutateAppMeshMesh, webhook.MutatingWebhookForMutator(m))

--- a/webhooks/appmesh/mesh_validator.go
+++ b/webhooks/appmesh/mesh_validator.go
@@ -57,7 +57,7 @@ func (v *meshValidator) enforceFieldsImmutability(mesh *appmesh.Mesh, oldMesh *a
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-mesh,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=meshes,verbs=create;update,versions=v1beta2,name=vmesh.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-mesh,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=meshes,verbs=create;update,versions=v1beta2,name=vmesh.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (v *meshValidator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathValidateAppMeshMesh, webhook.ValidatingWebhookForValidator(v))

--- a/webhooks/appmesh/virtualgateway_mutator.go
+++ b/webhooks/appmesh/virtualgateway_mutator.go
@@ -70,7 +70,7 @@ func (m *virtualGatewayMutator) designateMeshMembership(ctx context.Context, vg 
 	return nil
 }
 
-// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=mvirtualgateway.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=mvirtualgateway.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (m *virtualGatewayMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutateAppMeshVirtualGateway, webhook.MutatingWebhookForMutator(m))

--- a/webhooks/appmesh/virtualgateway_validator.go
+++ b/webhooks/appmesh/virtualgateway_validator.go
@@ -112,7 +112,7 @@ func (v *virtualGatewayValidator) checkListenerMultipleConnectionPools(ln appmes
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=vvirtualgateway.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualgateway,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualgateways,verbs=create;update,versions=v1beta2,name=vvirtualgateway.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (v *virtualGatewayValidator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathValidateAppMeshVirtualGateway, webhook.ValidatingWebhookForValidator(v))

--- a/webhooks/appmesh/virtualnode_mutator.go
+++ b/webhooks/appmesh/virtualnode_mutator.go
@@ -70,7 +70,7 @@ func (m *virtualNodeMutator) designateMeshMembership(ctx context.Context, vn *ap
 	return nil
 }
 
-// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualnode,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualnodes,verbs=create;update,versions=v1beta2,name=mvirtualnode.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualnode,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualnodes,verbs=create;update,versions=v1beta2,name=mvirtualnode.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (m *virtualNodeMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutateAppMeshVirtualNode, webhook.MutatingWebhookForMutator(m))

--- a/webhooks/appmesh/virtualnode_validator.go
+++ b/webhooks/appmesh/virtualnode_validator.go
@@ -162,7 +162,7 @@ func (v *virtualNodeValidator) checkListenerMultipleConnectionPools(ln appmesh.L
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualnode,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualnodes,verbs=create;update,versions=v1beta2,name=vvirtualnode.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualnode,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualnodes,verbs=create;update,versions=v1beta2,name=vvirtualnode.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (v *virtualNodeValidator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathValidateAppMeshVirtualNode, webhook.ValidatingWebhookForValidator(v))

--- a/webhooks/appmesh/virtualrouter_mutator.go
+++ b/webhooks/appmesh/virtualrouter_mutator.go
@@ -70,7 +70,7 @@ func (m *virtualRouterMutator) designateMeshMembership(ctx context.Context, vr *
 	return nil
 }
 
-// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualrouter,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualrouters,verbs=create;update,versions=v1beta2,name=mvirtualrouter.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualrouter,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualrouters,verbs=create;update,versions=v1beta2,name=mvirtualrouter.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (m *virtualRouterMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutateAppMeshVirtualRouter, webhook.MutatingWebhookForMutator(m))

--- a/webhooks/appmesh/virtualrouter_validator.go
+++ b/webhooks/appmesh/virtualrouter_validator.go
@@ -80,7 +80,7 @@ func (v *virtualRouterValidator) checkForDuplicateRouteEntries(vr *appmesh.Virtu
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualrouter,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualrouters,verbs=create;update,versions=v1beta2,name=vvirtualrouter.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualrouter,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualrouters,verbs=create;update,versions=v1beta2,name=vvirtualrouter.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (v *virtualRouterValidator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathValidateAppMeshVirtualRouter, webhook.ValidatingWebhookForValidator(v))

--- a/webhooks/appmesh/virtualservice_mutator.go
+++ b/webhooks/appmesh/virtualservice_mutator.go
@@ -70,7 +70,7 @@ func (m *virtualServiceMutator) designateMeshMembership(ctx context.Context, vs 
 	return nil
 }
 
-// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualservice,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualservices,verbs=create;update,versions=v1beta2,name=mvirtualservice.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-appmesh-k8s-aws-v1beta2-virtualservice,mutating=true,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualservices,verbs=create;update,versions=v1beta2,name=mvirtualservice.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (m *virtualServiceMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutateAppMeshVirtualService, webhook.MutatingWebhookForMutator(m))

--- a/webhooks/appmesh/virtualservice_validator.go
+++ b/webhooks/appmesh/virtualservice_validator.go
@@ -60,7 +60,7 @@ func (v *virtualServiceValidator) enforceFieldsImmutability(vs *appmesh.VirtualS
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualservice,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualservices,verbs=create;update,versions=v1beta2,name=vvirtualservice.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/validate-appmesh-k8s-aws-v1beta2-virtualservice,mutating=false,failurePolicy=fail,groups=appmesh.k8s.aws,resources=virtualservices,verbs=create;update,versions=v1beta2,name=vvirtualservice.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (v *virtualServiceValidator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathValidateAppMeshVirtualService, webhook.ValidatingWebhookForValidator(v))

--- a/webhooks/core/pod_mutator.go
+++ b/webhooks/core/pod_mutator.go
@@ -41,7 +41,7 @@ func (m *podMutator) MutateUpdate(ctx context.Context, obj runtime.Object, oldOb
 	return obj, nil
 }
 
-// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mpod.appmesh.k8s.aws
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mpod.appmesh.k8s.aws,sideEffects=None,webhookVersions=v1beta1
 
 func (m *podMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutatePod, webhook.MutatingWebhookForMutator(m))


### PR DESCRIPTION
*Issue #, if available:*
The v1beta1 version for mutating and validating webhook is deprecated and support will be removed in K8s 1.22. The sideEffects field in v1 version must be set to `None` or `NoneOnDryRun`.

*Description of changes:*
Add `sideEffects` field set to `None` to the mutating and validating webhook configuration. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
