### PR TITLE
Support to control/toggle SDS  per VirtualNode

### DIFF
--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -39,6 +39,9 @@ const (
 	//AppMeshGatewaySkipImageOverride specifies if Virtual Gateway sidecar image override needs to be skipped for customers
 	//to use their own sidecare image for Virtual Gateway
 	AppMeshGatewaySkipImageOverride = "appmesh.k8s.aws/virtualGatewaySkipImageOverride"
+	//AppMeshSDSAnnotation is used if SDS is enabled at the controller level but needs to be disabled
+	//for a particular VirtualNode.
+	AppMeshSDSAnnotation = "appmesh.k8s.aws/sds"
 
 	//Pod Labels
 

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -1111,7 +1111,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "sds-socket-volume",
+									Name:      "appmesh-sds-socket-volume",
 									MountPath: "/run/spire/sockets/agent.sock",
 								},
 							},
@@ -1119,7 +1119,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "sds-socket-volume",
+							Name: "appmesh-sds-socket-volume",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: "/run/spire/sockets/agent.sock",

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -57,6 +57,8 @@ func Test_envoyMutator_mutate(t *testing.T) {
 	annotationCpuLimit, _ := resource.ParseQuantity("256Mi")
 	annotationMemoryLimit, _ := resource.ParseQuantity("80m")
 
+	SDSVolumeType := corev1.HostPathSocket
+
 	podWithResourceAnnotations := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "my-ns",
@@ -988,6 +990,259 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: "svc1-svc2-ca-bundle",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enable SDS controller flag + no pod annotation",
+			fields: fields{
+				vn: vn,
+				ms: ms,
+				mutatorConfig: envoyMutatorConfig{
+					awsRegion:                  "us-west-2",
+					preview:                    true,
+					enableSDS:                  true,
+					sdsUdsPath:                 "/run/spire/sockets/agent.sock",
+					logLevel:                   "debug",
+					adminAccessPort:            9901,
+					preStopDelay:               "20",
+					readinessProbeInitialDelay: 10,
+					readinessProbePeriod:       2,
+					sidecarImage:               "envoy:v2",
+					sidecarCPURequests:         cpuRequests.String(),
+					sidecarMemoryRequests:      memoryRequests.String(),
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "app",
+								Image: "app/v1",
+							},
+						},
+					},
+				}},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: aws.Int64(1337),
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "stats",
+									ContainerPort: 9901,
+									Protocol:      "TCP",
+								},
+							},
+							Lifecycle: &corev1.Lifecycle{
+								PostStart: nil,
+								PreStop: &corev1.Handler{
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "sleep 20",
+									}},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "curl -s http://localhost:9901/server_info | grep state | grep -q LIVE",
+									}},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       2,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "1",
+								},
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "APPMESH_SDS_SOCKET_PATH",
+									Value: "/run/spire/sockets/agent.sock",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_PORT",
+									Value: "9901",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    cpuRequests,
+									"memory": memoryRequests,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "sds-socket-volume",
+									MountPath: "/run/spire/sockets/agent.sock",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "sds-socket-volume",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/run/spire/sockets/agent.sock",
+									Type: &SDSVolumeType,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enable SDS controller flag + pod annotation to disable sds",
+			fields: fields{
+				vn: vn,
+				ms: ms,
+				mutatorConfig: envoyMutatorConfig{
+					awsRegion:                  "us-west-2",
+					preview:                    true,
+					enableSDS:                  true,
+					sdsUdsPath:                 "/run/spire/sockets/agent.sock",
+					logLevel:                   "debug",
+					adminAccessPort:            9901,
+					preStopDelay:               "20",
+					readinessProbeInitialDelay: 10,
+					readinessProbePeriod:       2,
+					sidecarImage:               "envoy:v2",
+					sidecarCPURequests:         cpuRequests.String(),
+					sidecarMemoryRequests:      memoryRequests.String(),
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-pod",
+						Annotations: map[string]string{
+							"appmesh.k8s.aws/sds": "disabled",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "app",
+								Image: "app/v1",
+							},
+						},
+					},
+				}},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+					Annotations: map[string]string{
+						"appmesh.k8s.aws/sds": "disabled",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "app/v1",
+						},
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: aws.Int64(1337),
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "stats",
+									ContainerPort: 9901,
+									Protocol:      "TCP",
+								},
+							},
+							Lifecycle: &corev1.Lifecycle{
+								PostStart: nil,
+								PreStop: &corev1.Handler{
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "sleep 20",
+									}},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "curl -s http://localhost:9901/server_info | grep state | grep -q LIVE",
+									}},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       2,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "1",
+								},
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_PORT",
+									Value: "9901",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    cpuRequests,
+									"memory": memoryRequests,
 								},
 							},
 						},

--- a/pkg/inject/utils.go
+++ b/pkg/inject/utils.go
@@ -5,12 +5,15 @@ import (
 	"bytes"
 	"encoding/json"
 	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"text/template"
 )
 
 const (
 	AppMeshSDSSocketVolume = "appmesh-sds-socket-volume"
 )
+
+var envoyUtilsLogger = ctrl.Log.WithName("envoy-utils")
 
 func renderTemplate(name string, t string, meta interface{}) (string, error) {
 	tmpl, err := template.New(name).Parse(t)
@@ -90,6 +93,7 @@ func isSDSDisabled(pod *corev1.Pod) bool {
 		if v == "disabled" {
 			return true
 		}
+		envoyUtilsLogger.Info("Unsupported Value. Annotation only accepts `disabled` in the value field. ", "Value Provided: ", v)
 	}
 	return false
 }

--- a/pkg/inject/utils.go
+++ b/pkg/inject/utils.go
@@ -80,3 +80,33 @@ func containsEnvoyContainer(pod *corev1.Pod) (bool, int) {
 	}
 	return false, -1
 }
+
+func isSDSDisabled(pod *corev1.Pod) bool {
+	if v, ok := pod.ObjectMeta.Annotations[AppMeshSDSAnnotation]; ok {
+		if v == "disabled" {
+			return true
+		}
+	}
+	return false
+}
+
+func mutateSDSMounts(pod *corev1.Pod, envoyContainer *corev1.Container, SdsUdsPath string) {
+	SDSVolumeType := corev1.HostPathSocket
+	volume := corev1.Volume{
+		Name: "sds-socket-volume",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: SdsUdsPath,
+				Type: &SDSVolumeType,
+			},
+		},
+	}
+
+	volumeMount := corev1.VolumeMount{
+		Name:      "sds-socket-volume",
+		MountPath: SdsUdsPath,
+	}
+
+	envoyContainer.VolumeMounts = append(envoyContainer.VolumeMounts, volumeMount)
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+}

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -188,24 +188,3 @@ func (m *virtualGatewayEnvoyConfig) virtualGatewayImageOverride(pod *corev1.Pod)
 		return true
 	}
 }
-
-func (m *virtualGatewayEnvoyConfig) mutateSDSMounts(pod *corev1.Pod, envoyContainer *corev1.Container) {
-	SDSVolumeType := corev1.HostPathSocket
-	volume := corev1.Volume{
-		Name: "sds-socket-volume",
-		VolumeSource: corev1.VolumeSource{
-			HostPath: &corev1.HostPathVolumeSource{
-				Path: m.mutatorConfig.sdsUdsPath,
-				Type: &SDSVolumeType,
-			},
-		},
-	}
-
-	volumeMount := corev1.VolumeMount{
-		Name:      "sds-socket-volume",
-		MountPath: m.mutatorConfig.sdsUdsPath,
-	}
-
-	envoyContainer.VolumeMounts = append(envoyContainer.VolumeMounts, volumeMount)
-	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
-}

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -117,7 +117,6 @@ func (m *virtualGatewayEnvoyConfig) mutate(pod *corev1.Pod) error {
 			m.mutatorConfig.readinessProbePeriod, strconv.Itoa(int(m.mutatorConfig.adminAccessPort)))
 	}
 
-	//TODO: Check for existing SDS mounts for VirtualGateway before proceeding.
 	if m.mutatorConfig.enableSDS && !isSDSDisabled(pod) {
 		mutateSDSMounts(pod, &pod.Spec.Containers[envoyIdx], m.mutatorConfig.sdsUdsPath)
 	}

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -118,8 +118,8 @@ func (m *virtualGatewayEnvoyConfig) mutate(pod *corev1.Pod) error {
 	}
 
 	//TODO: Check for existing SDS mounts for VirtualGateway before proceeding.
-	if m.mutatorConfig.enableSDS {
-		m.mutateSDSMounts(pod, &pod.Spec.Containers[envoyIdx])
+	if m.mutatorConfig.enableSDS && !isSDSDisabled(pod) {
+		mutateSDSMounts(pod, &pod.Spec.Containers[envoyIdx], m.mutatorConfig.sdsUdsPath)
 	}
 	return nil
 }
@@ -128,6 +128,9 @@ func (m *virtualGatewayEnvoyConfig) buildTemplateVariables(pod *corev1.Pod) Virt
 	meshName := m.getAugmentedMeshName()
 	virtualGatewayName := aws.StringValue(m.vg.Spec.AWSName)
 	preview := m.getPreview(pod)
+	if m.mutatorConfig.enableSDS && isSDSDisabled(pod) {
+		m.mutatorConfig.enableSDS = false
+	}
 
 	return VirtualGatewayEnvoyVariables{
 		AWSRegion:          m.mutatorConfig.awsRegion,

--- a/pkg/inject/virtualgateway_envoy_test.go
+++ b/pkg/inject/virtualgateway_envoy_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
+	SDSVolumeType := corev1.HostPathSocket
 	ms := &appmesh.Mesh{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mesh",
@@ -158,6 +159,37 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "my-ns",
 			Name:      "my-pod",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "envoy",
+					Image: "envoy:v2",
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+
+							Exec: &corev1.ExecAction{Command: []string{
+								"sh", "-c", "curl -s http://localhost:8810/server_info | grep state | grep -q LIVE",
+							}},
+						},
+						InitialDelaySeconds: 20,
+						TimeoutSeconds:      1,
+						PeriodSeconds:       30,
+						SuccessThreshold:    2,
+						FailureThreshold:    3,
+					},
+				},
+			},
+		},
+	}
+
+	podSDSDisabled := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-pod",
+			Annotations: map[string]string{
+				"appmesh.k8s.aws/sds": "disabled",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -764,6 +796,179 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "my-ns",
 					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_PORT",
+									Value: "9901",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_LOG_FILE",
+									Value: "/tmp/envoy_admin_access.log",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "curl -s http://localhost:8810/server_info | grep state | grep -q LIVE",
+									}},
+								},
+								InitialDelaySeconds: 20,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       30,
+								SuccessThreshold:    2,
+								FailureThreshold:    3,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enable sds controller flag set + no annotation",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:                  "us-west-2",
+					preview:                    false,
+					logLevel:                   "debug",
+					enableSDS:                  true,
+					sdsUdsPath:                 "/run/spire/sockets/agent.sock",
+					adminAccessPort:            9901,
+					adminAccessLogFile:         "/tmp/envoy_admin_access.log",
+					sidecarImage:               "envoy:v2",
+					readinessProbeInitialDelay: 1,
+					readinessProbePeriod:       10,
+				},
+			},
+			args: args{
+				pod: podExistingProbe,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_PORT",
+									Value: "9901",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_LOG_FILE",
+									Value: "/tmp/envoy_admin_access.log",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+								{
+									Name:  "APPMESH_SDS_SOCKET_PATH",
+									Value: "/run/spire/sockets/agent.sock",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "curl -s http://localhost:8810/server_info | grep state | grep -q LIVE",
+									}},
+								},
+								InitialDelaySeconds: 20,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       30,
+								SuccessThreshold:    2,
+								FailureThreshold:    3,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "sds-socket-volume",
+									MountPath: "/run/spire/sockets/agent.sock",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "sds-socket-volume",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/run/spire/sockets/agent.sock",
+									Type: &SDSVolumeType,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enable sds controller flag set + pod annotation to disable sds",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:                  "us-west-2",
+					preview:                    false,
+					logLevel:                   "debug",
+					enableSDS:                  true,
+					sdsUdsPath:                 "/run/spire/sockets/agent.sock",
+					adminAccessPort:            9901,
+					adminAccessLogFile:         "/tmp/envoy_admin_access.log",
+					sidecarImage:               "envoy:v2",
+					readinessProbeInitialDelay: 1,
+					readinessProbePeriod:       10,
+				},
+			},
+			args: args{
+				pod: podSDSDisabled,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+					Annotations: map[string]string{
+						"appmesh.k8s.aws/sds": "disabled",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*

Ability to enable SDS based mTLS is currently a controller level flag. This PR, adds support to disable SDS @ VirtualNode level via an annotation on the corresponding deployment spec. AppMesh, currently bootstraps a static SDS cluster purely based on the presence of an environment variable (and not dynamically based on the presence of mTLS SDS config) and this change will help avoid it at the controller level.

If SDS is enabled via the controller flag(and SDS UDS path specified), controller will populate the "APPMESH_SDS_SOCKET_PATH" env variable and mount the UDS in to Envoy. To disable this @ VirtualNode level, one can use annotation "appmesh.k8s.aws/sds" set to disabled on the corresponding deployment spec.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
