### PR TITLE
Fix for Integration Test Panic

### DIFF
--- a/test/e2e/fishapp/dynamic_stack_test.go
+++ b/test/e2e/fishapp/dynamic_stack_test.go
@@ -3,22 +3,20 @@ package fishapp_test
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-app-mesh-controller-for-k8s/test/e2e/fishapp"
-	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework/manifest"
 	. "github.com/onsi/ginkgo"
-	"time"
 )
 
 var _ = Describe("test dynamically generated symmetrical mesh", func() {
 	var (
 		ctx context.Context
-		f   *framework.Framework
 	)
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		f = framework.New(framework.GlobalOptions)
 
 		if f.Options.ControllerImage != "" {
 			By("Reset cluster with default controller", func() {

--- a/test/e2e/fishapp/fishapp_suite_test.go
+++ b/test/e2e/fishapp/fishapp_suite_test.go
@@ -3,11 +3,20 @@ package fishapp_test
 import (
 	"testing"
 
+	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var f *framework.Framework
 
 func TestFishApp(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "FishApp Suite")
 }
+
+var _ = BeforeSuite(func() {
+	var err error
+	f = framework.New(framework.GlobalOptions)
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
*Description of changes:*
Fixed Integration Test error caused by Panic in SetupSignalHandler (close on closed channel)
Moved Call to framework.New() to BeforeSuite from BeforeEach in fishapp_suite_test.go


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
