### PR TITLE
Pass custom env variables to sidecar from annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.10.0
+	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gomodules.xyz/jsonpatch/v2 v2.0.1
 	gonum.org/v1/gonum v0.7.0
@@ -26,7 +27,6 @@ require (
 	k8s.io/client-go v0.18.2
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.6.0
-	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect
 )
 
 replace golang.org/x/sys => golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0

--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -43,6 +43,15 @@ const (
 	//for a particular VirtualNode.
 	AppMeshSDSAnnotation = "appmesh.k8s.aws/sds"
 
+	// AppMeshEnvAnnotation specifies the list of enviornment variables that need to be programmed on Envoy sidecars
+	// This allow passing tags like DataDog environment `DD_ENV` to Envoy to help correlate observability data
+	// Here's how a sample annotations will be like
+	//
+	//        e.g. appmesh.k8s.aws/sidecarEnv: "DD_ENV=qa1, ENV2=test"
+	//        e.g. appmesh.k8s.aws/sidecarEnv: "DD_ENV=prod"
+	//
+	AppMeshEnvAnnotation = "appmesh.k8s.aws/sidecarEnv"
+
 	//Pod Labels
 
 	//FargateProfileLabel is added by fargate-scheduler when pod is running on AWS Fargate


### PR DESCRIPTION
**Issue**
 #428 

**Description of changes**
Set arbitrary tags on the Envoy containers to allow use-cases like DataDog tracing (`DD_ENV`) etc

The admission controller will inject environment variables on the sidecar containers during injection. The environment variables need to be defined as an annotation `appmesh.k8s.aws/sidecarEnv`.
e.g.

`appmesh.k8s.aws/sidecarEnv: "DD_ENV=qa1, ENV1=test"` : both DD_ENV=qa1 and ENV1=test will be injected as environment variables on the Envoy sidecar
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dp
  namespace: ns
spec:
  template:
    metadata:
      annotations:
        appmesh.k8s.aws/sidecarEnv: "DD_ENV=qa1, ENV1=test"
    spec:
      containers:
      - name: ct
        image: tutum/curl
```
e.g.
`appmesh.k8s.aws/sidecarEnv: "DD_ENV=qa1"` : DD_ENV=qa1 will be injected as an environment variable on the Envoy sidecar
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dp
  namespace: ns
spec:
  template:
    metadata:
      annotations:
        appmesh.k8s.aws/sidecarEnv: "DD_ENV=prod"
    spec:
      containers:
      - name: ct
        image: tutum/curl
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
