### PR TITLE
Setup the controller using Helm for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,17 @@ IMAGE_NAME=amazon/appmesh-controller
 REPO=$(AWS_ACCOUNT).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE_NAME)
 VERSION ?= $(shell git describe --dirty --tags --always)
 IMAGE ?= $(REPO):$(VERSION)
+PREVIEW=false
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1beta1"
 
 # app mesh aws-sdk-go override in case we need to build against a custom version
 APPMESH_SDK_OVERRIDE ?= "y"
+
+ifeq ($(APPMESH_SDK_OVERRIDE), "y")
+PREVIEW=true
+endif
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -45,7 +50,7 @@ deploy: check-env manifests
 	kustomize build config/default | kubectl apply -f -
 
 helm-deploy: check-env manifests
-	helm upgrade -i appmesh-controller config/helm/appmesh-controller --namespace appmesh-system --set image.repository=$(REPO) --set image.tag=$(VERSION)
+	helm upgrade -i appmesh-controller config/helm/appmesh-controller --namespace appmesh-system --set image.repository=$(REPO) --set image.tag=$(VERSION) --set preview=$(PREVIEW)
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ deploy: check-env manifests
 	cd config/controller && kustomize edit set image controller=$(IMAGE)
 	kustomize build config/default | kubectl apply -f -
 
+helm-deploy: check-env manifests
+	helm upgrade -i appmesh-controller config/helm/appmesh-controller --namespace appmesh-system --set image.repository=$(REPO) --set image.tag=$(VERSION)
+
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=controller-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases

--- a/config/helm/appmesh-controller/templates/deployment.yaml
+++ b/config/helm/appmesh-controller/templates/deployment.yaml
@@ -68,6 +68,7 @@ spec:
         - --readiness-probe-period={{ .Values.sidecar.probes.readinessProbePeriod }}
         - --envoy-admin-access-port={{ .Values.sidecar.envoyAdminAccessPort }}
         - --envoy-admin-access-log-file={{ .Values.sidecar.envoyAdminAccessLogFile }}
+        - --preview={{ .Values.preview }}
         {{- if .Values.cloudMapCustomHealthCheck.enabled }}
         - --enable-custom-health-check=true
         {{- end }}

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -14,7 +14,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.15.1.0-prod
+    tag: v1.16.1.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 region: ""
 accountId: ""
+preview: false
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller

--- a/scripts/test-with-kind.sh
+++ b/scripts/test-with-kind.sh
@@ -63,7 +63,7 @@ function install_controller {
        local __controller_name="appmesh-controller"
        local __ns="appmesh-system"
        kubectl create ns $__ns
-       AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make helm-deploy
+       APPMESH_PREVIEW=y AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make helm-deploy
        check_deployment_rollout $__controller_name $__ns
        echo -n "check the pods in appmesh-system namespace ... "
        kubectl get pod -n $__ns

--- a/scripts/test-with-kind.sh
+++ b/scripts/test-with-kind.sh
@@ -62,7 +62,8 @@ function install_controller {
        echo -n "installing appmesh controller ... "
        local __controller_name="appmesh-controller"
        local __ns="appmesh-system"
-       AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make deploy
+       kubectl create ns $__ns
+       AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make helm-deploy
        check_deployment_rollout $__controller_name $__ns
        echo -n "check the pods in appmesh-system namespace ... "
        kubectl get pod -n $__ns
@@ -105,9 +106,6 @@ export KUBECONFIG="${TMP_DIR}/kubeconfig"
 
 # Generate and install CRDs
 install_crds
-
-# Install cert-manager
-$SCRIPTS_DIR/install-cert-manager.sh
 
 # Install the controller
 install_controller


### PR DESCRIPTION
**Issue**
#412 

**Description of changes**
This is part 2/3 of the PR #430.
- Use repo local helm charts to install the controller for the integration tests to make sure Helm chart installation and defaults get tested. We override the controller image/tag with the image/tag generated as part of the CI build
- Move the Helm default Envoy version to `v1.16.1.0-prod`

**Testing**
See the integration test run for this PR

```
kustomize build config/crd > config/helm/appmesh-controller/crds/crds.yaml
helm upgrade -i appmesh-controller config/helm/appmesh-controller --namespace appmesh-system --set image.repository=115811320858.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller --set image.tag=72ef82c-dirty --set preview=true
Release "appmesh-controller" does not exist. Installing it now.
NAME: appmesh-controller
LAST DEPLOYED: Fri Jan 29 05:00:00 2021
NAMESPACE: appmesh-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
AWS App Mesh controller installed!
make[1]: Leaving directory `/home/ssm-user/actions-runner/_work/aws-app-mesh-controller-for-k8s/aws-app-mesh-controller-for-k8s'
Waiting for deployment "appmesh-controller" rollout to finish: 0 of 1 updated replicas are available...
deployment "appmesh-controller" successfully rolled out
check the pods in appmesh-system namespace ... NAME                                  READY   STATUS    RESTARTS   AGE
appmesh-controller-6fb68c4f56-6mb7t   1/1     Running   0          52s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
