### PR TITLE
Support for mTLS parameters in controller helm chart

### DIFF
--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -76,6 +76,9 @@ eksctl create iamserviceaccount --cluster $CLUSTER_NAME \
 ```
 
 Deploy appmesh-controller
+
+**Note:** To enable mTLS via SDS(SPIRE), please set "sds.enabled=true".
+
 ```sh
 helm upgrade -i appmesh-controller eks/appmesh-controller \
     --namespace appmesh-system \
@@ -157,6 +160,9 @@ eksctl create iamserviceaccount --cluster $CLUSTER_NAME \
 ```
 
 Deploy appmesh-controller
+
+**Note:** mTLS via SDS(SPIRE) is not supported on Fargate.
+
 ```sh
 helm upgrade -i appmesh-controller eks/appmesh-controller \
     --namespace appmesh-system \
@@ -310,6 +316,8 @@ Parameter | Description | Default
 `image.tag` | image tag | `<VERSION>`
 `image.pullPolicy` | image pull policy | `IfNotPresent`
 `log.level` | controller log level, possible values are `info` and `debug`  | `info`
+`sds.enabled` | If `true`, SDS will be enabled in Envoy | `false`
+`sds.udsPath` | Unix Domain Socket Path of the SDS Provider(SPIRE in the current release) | `/run/spire/sockets/agent.sock`
 `resources.requests/cpu` | pod CPU request | `100m`
 `resources.requests/memory` | pod memory request | `64Mi`
 `resources.limits/cpu` | pod CPU limit | `2000m`

--- a/config/helm/appmesh-controller/templates/deployment.yaml
+++ b/config/helm/appmesh-controller/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
         - --envoy-admin-access-port={{ .Values.sidecar.envoyAdminAccessPort }}
         - --envoy-admin-access-log-file={{ .Values.sidecar.envoyAdminAccessLogFile }}
         - --preview={{ .Values.preview }}
+        - --enable-sds={{ .Values.sds.enabled }}
+        - --sds-uds-path={{ .Values.sds.udsPath }}
         {{- if .Values.cloudMapCustomHealthCheck.enabled }}
         - --enable-custom-health-check=true
         {{- end }}

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -75,6 +75,12 @@ cloudMapDNS:
   # cloudMapDNS.ttl if set will use this global ttl value
   ttl: 300
 
+sds:
+  # sds.enabled: `true` if SDS based mTLS support needs to be enabled in envoy
+  enabled: false
+  #sds.udsPath: UDS Path of the SDS Provider. Default value is tied to SPIRE.
+  udsPath: /run/spire/sockets/agent.sock
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

AppMesh mTLS support introduces two new configurable parameters for SDS support. PR introduces support for both these parameters (i.e.,) "enable-sds" and "sds-uds-path" in the controller helm chart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
