### PR TITLE
Add helm v2 and v3 lint for controller charts

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,5 +26,7 @@ jobs:
         export PATH=$PATH:/usr/local/kubebuilder/bin
     - name: checkout code
       uses: actions/checkout@v2
-    - name: make test
+    - name: unit tests
       run: make test
+    - name: helm v2 and v3 lint
+      run: make helm-lint

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ deploy: check-env manifests
 	cd config/controller && kustomize edit set image controller=$(IMAGE)
 	kustomize build config/default | kubectl apply -f -
 
+helm-lint:
+	${MAKEFILE_PATH}/test/helm/helm-lint.sh
+
+
 helm-deploy: check-env manifests
 	helm upgrade -i appmesh-controller config/helm/appmesh-controller --namespace appmesh-system --set image.repository=$(REPO) --set image.tag=$(VERSION) --set preview=$(PREVIEW)
 

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -1,0 +1,146 @@
+# Test values for appmesh-controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+region: ""
+accountId: ""
+preview: false
+
+image:
+  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
+  tag: v1.2.1
+  pullPolicy: IfNotPresent
+
+sidecar:
+  image:
+    repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
+    tag: v1.16.1.0-prod
+    # sidecar.logLevel: Envoy log level can be info, warn, error or debug
+  logLevel: info
+  envoyAdminAccessPort: 9901
+  envoyAdminAccessLogFile: /tmp/envoy_admin_access.log
+  resources:
+    # sidecar.resources.requests: Envoy CPU and memory requests
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    # sidecar.resources/limits: Envoy CPU and memory limits
+    limits:
+      cpu: 100m
+      memory: 64Mi
+  lifecycleHooks:
+    # sidecar.lifecycleHooks: Envoy PreStop Hook Delay
+    preStopDelay: 20
+  probes:
+    # sidecar.probes: Envoy Readiness Probe
+    readinessProbeInitialDelay: 1
+    readinessProbePeriod: 10
+init:
+  image:
+    repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
+    tag: v3-prod
+
+xray:
+  image:
+    repository: amazon/aws-xray-daemon
+    tag: latest
+
+nameOverride: ""
+fullnameOverride: ""
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+
+nodeSelector: {
+    test: test
+}
+
+tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoExecute"
+
+affinity: {
+    test: test
+}
+
+podAnnotations: {
+    test: test
+}
+
+podLabels: {
+    test: test
+}
+
+cloudMapCustomHealthCheck:
+  # cloudMapCustomHealthCheck.enabled: `true` if CustomHealthCheck needs to be enabled in CloudMap
+  enabled: true
+
+cloudMapDNS:
+  # cloudMapDNS.ttl if set will use this global ttl value
+  ttl: 300
+
+sds:
+  # sds.enabled: `true` if SDS based mTLS support needs to be enabled in envoy
+  enabled: true
+  #sds.udsPath: UDS Path of the SDS Provider. Default value is tied to SPIRE.
+  udsPath: /run/spire/sockets/agent.sock
+
+serviceAccount:
+  # serviceAccount.create: Whether to create a service account or not
+  create: true
+  # serviceAccount.name: The name of the service account to create or use
+  name: test
+  # serviceAccount.annotations: optional annotations to be applied to service account
+  annotations: {
+      test: test
+  }
+
+rbac:
+  # rbac.create: `true` if rbac resources should be created
+  create: true
+  # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
+  pspEnabled: true
+
+log:
+  #log.level: info (default), debug
+  level: "info"
+
+tracing:
+  # tracing.enabled: `true` if Envoy should be configured tracing
+  enabled: true
+  # tracing.provider: can be x-ray, jaeger or datadog
+  provider: x-ray
+  # tracing.address: Jaeger or Datadog agent server address (ignored for X-Ray)
+  address: appmesh-jaeger.appmesh-system
+  # tracing.port: Jaeger or Datadog agent server port
+  port: 2000
+
+stats:
+  # stats.tagsEnabled: `true` if Envoy should include app-mesh tags
+  tagsEnabled: false
+  # stats.statsdEnabled: `true` if Envoy should publish stats to statsd endpoint @ 127.0.0.1:8125
+  statsdEnabled: false
+  #stats.statsdAddress: DogStatsD daemon address
+  statsdAddress: 127.0.0.1
+  #stats.statsdPort: DogStatsD daemon port
+  statsdPort: 8125
+
+# Enable cert-manager
+enableCertManager: false
+
+# Environment variables to set in appmesh-controller pod
+env: {}
+
+#Example
+#env:
+#    http_proxy: http://proxyserver:3128
+#    https_proxy: http://proxyserver:3128
+#    no_proxy: "localhost,127.0.0.1,.cluster.local"

--- a/test/helm/helm-lint.sh
+++ b/test/helm/helm-lint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+set +x
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+AM_HELM_CHART=$SCRIPTPATH/../../config/helm/appmesh-controller/
+TMP_DIR="$SCRIPTPATH/../../build"
+PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
+HELM3_VERSION="3.3.1"
+HELM2_VERSION="2.16.10"
+HELM_DIR="${SCRIPTPATH}/../../config/helm"
+
+mkdir -p $TMP_DIR
+
+if [ ! -x "$TMP_DIR/helm" ]; then
+    echo "🥑 Downloading the \"helm3\" binary"
+    curl -L https://get.helm.sh/helm-v$HELM3_VERSION-$PLATFORM-amd64.tar.gz | tar zxf - -C $TMP_DIR
+    mv $TMP_DIR/$PLATFORM-amd64/helm $TMP_DIR/.
+    chmod +x $TMP_DIR/helm
+    echo "👍 Downloaded the \"helm\" binary"
+fi
+
+if [ ! -x "$TMP_DIR/helm2" ]; then
+    echo "🥑 Downloading the \"helm2\" binary"
+    curl -L https://get.helm.sh/helm-v$HELM2_VERSION-$PLATFORM-amd64.tar.gz | tar zxf - -C $TMP_DIR
+    mv $TMP_DIR/$PLATFORM-amd64/helm $TMP_DIR/helm2
+    chmod +x $TMP_DIR/helm2
+    echo "👍 Downloaded the \"helm2\" binary"
+fi
+export PATH=$TMP_DIR:$PATH
+
+echo "=============================================================================="
+echo "                     Linting Helm Chart w/ Helm v3"
+echo "=============================================================================="
+helm lint $AM_HELM_CHART
+
+echo "=============================================================================="
+echo "                     Linting Helm Chart w/ Helm v2"
+echo "=============================================================================="
+helm2 lint $AM_HELM_CHART
+
+echo "✅ Helm Linting for v2 and v3 have successfully completed!"
+
+echo "=============================================================================="
+echo "                   Generate Template w/ Helm v3"
+echo "=============================================================================="
+
+helm template appmesh-controller "${HELM_DIR}/appmesh-controller" --debug --namespace=appmesh-system -f "${HELM_DIR}/appmesh-controller/test.yaml" > /dev/null
+
+echo "=============================================================================="
+echo "                   Generate Template w/ Helm v2"
+echo "=============================================================================="
+
+helm2 template --name appmesh-controller "${HELM_DIR}/appmesh-controller" --debug --namespace=appmesh-system -f "${HELM_DIR}/appmesh-controller/test.yaml" > /dev/null
+
+echo "✅ Helm template generation for v2 and v3 have successfully completed!"


### PR DESCRIPTION
**Issue**
#412 

**Description of changes**
Added helm v2 and v3 lint and template generate (using a test config) for controller charts and enabled it in GitHub Action workflow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
