### PR TITLE
Update jaegar tracing Envoy config to v3 API

### DIFF
--- a/pkg/inject/jaeger.go
+++ b/pkg/inject/jaeger.go
@@ -10,7 +10,7 @@ tracing:
  http:
   name: envoy.tracers.zipkin
   typed_config:
-   "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+   "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
    collector_cluster: jaeger
    collector_endpoint: "/api/v2/spans"
    collector_endpoint_version: HTTP_JSON

--- a/pkg/inject/jaeger_test.go
+++ b/pkg/inject/jaeger_test.go
@@ -110,7 +110,7 @@ tracing:
  http:
   name: envoy.tracers.zipkin
   typed_config:
-   "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+   "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
    collector_cluster: jaeger
    collector_endpoint: "/api/v2/spans"
    collector_endpoint_version: HTTP_JSON

--- a/pkg/inject/sidecar_builder.go
+++ b/pkg/inject/sidecar_builder.go
@@ -110,7 +110,7 @@ func buildEnvoySidecar(vars EnvoyTemplateVariables, env map[string]string) corev
 
 	if vars.EnableJaegerTracing {
 		// Specify a file path in the Envoy container file system.
-		// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/trace/v2/http_tracer.proto
+		// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/http_tracer.proto
 		env["ENVOY_TRACING_CFG_FILE"] = "/tmp/envoy/envoyconf.yaml"
 
 		vol_mount := []corev1.VolumeMount{


### PR DESCRIPTION
*Description of changes:*

The xDS v2 API is no longer supported in Envoy 1.18 and has been deprecated for some time. App Mesh will be defaulting Envoy to the xDS v3 API in our 1.17 image so I'd like to update the version for the Jaegar tracer config to v3 at least so we may support Envoy 1.18.

The ideal solution is to use the `ENABLE_ENVOY_JAEGER_TRACING` and [related environment variables](https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy-config.html) and let the Envoy image generate the config like is being done for Virtual Gateways in #462.

But I want to make sure we put this minimal change in place to ensure we stay compatible for the time being.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
