### PR TITLE
Added podDistruptionBudget for appmesh-controller pods

### DIFF
--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.3.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -393,3 +393,4 @@ Parameter | Description | Default
 `accountId` | AWS Account ID for the Kubernetes cluster | None
 `env` |  environment variables to be injected into the appmesh-controller pod | `{}`
 `livenessProbe` | Liveness probe settings for the controller | (see `values.yaml`)
+`podDisruptionBudget` | PodDisruptionBudget | `{}`

--- a/config/helm/appmesh-controller/templates/pdb.yaml
+++ b/config/helm/appmesh-controller/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget }}
+{{- if gt (int .Values.replicaCount) 1 }}
+kind: PodDisruptionBudget
+apiVersion: policy/v1beta1
+metadata:
+  name: {{ template "appmesh-controller.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace }} 
+  labels:
+{{ include "appmesh-controller.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: {{ template "appmesh-controller.fullname" . }}
+      app.kubernetes.io/name: {{ include "appmesh-controller.fullname" . }}
+      app.kubernetes.io/part-of: appmesh
+{{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -136,6 +136,10 @@ stats:
 # Enable cert-manager
 enableCertManager: false
 
+# podDisruptionBudget for Appmesh controller
+podDisruptionBudget: {}
+  # minAvailable: 1
+
 # Environment variables to set in appmesh-controller pod
 env: {}
 

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -122,6 +122,10 @@ stats:
 # Enable cert-manager
 enableCertManager: false
 
+# podDisruptionBudget for Appmesh controller
+podDisruptionBudget: {}
+#  minAvailable: 1
+
 # Environment variables to set in appmesh-controller pod
 env: {}
 


### PR DESCRIPTION
*Description of changes:*
Added support to specify PodDisruptionBudget for appmesh-controller pods 

With replicaCount: 2 and podDisruptionBudget minAvailable set to 1
```
helm upgrade -i appmesh-controller config/helm/appmesh-controller/ \
    --namespace appmesh-system \
    --set region=us-west-2 \
    --set image.repository=public.ecr.aws/e6v3k1j4/appmesh-controller \
    --set image.tag=v1.4.0-prod-final \
    --set serviceAccount.create=false \
    --set serviceAccount.name=appmesh-controller --set podDisruptionBudget.minAvailable=1 --set replicaCount=2

kubectl get pdb -n appmesh-system                                   
NAME                     MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
appmesh-controller-pdb   1               N/A               1                     9m1s

kubectl get pods -n appmesh-system -o wide
NAME                                  READY   STATUS    RESTARTS   AGE     IP               NODE                                          NOMINATED NODE   READINESS GATES
appmesh-controller-57f858b8ff-mrjx9   1/1     Running   0          4m51s   192.168.76.203   ip-192-168-87-16.us-west-2.compute.internal   <none>           <none>
appmesh-controller-57f858b8ff-wmw2t   1/1     Running   0          20m     192.168.25.138   ip-192-168-3-93.us-west-2.compute.internal    <none>           <none>
appmesh-jaeger-7b8b7474b5-zvm4b       1/1     Running   0          16h     192.168.80.184   ip-192-168-87-16.us-west-2.compute.internal   <none>
```

Should be able to drain 1 of the nodes as we have minAvailable=1 for appmesh-controller pod
```
kubectl drain node/ip-192-168-87-16.us-west-2.compute.internal --delete-emptydir-data --ignore-daemonsets
node/ip-192-168-87-16.us-west-2.compute.internal already cordoned
WARNING: ignoring DaemonSet-managed Pods: kube-system/aws-node-926df, kube-system/kube-proxy-scl4t
evicting pod kube-system/coredns-559b5db75d-75m8x
evicting pod default/grpc-cli-88d5488fb-2kdcg
evicting pod appmesh-system/appmesh-jaeger-7b8b7474b5-zvm4b
evicting pod appmesh-system/appmesh-controller-57f858b8ff-mrjx9
pod/appmesh-jaeger-7b8b7474b5-zvm4b evicted
pod/appmesh-controller-57f858b8ff-mrjx9 evicted
pod/coredns-559b5db75d-75m8x evicted
pod/grpc-cli-88d5488fb-2kdcg evicted
node/ip-192-168-87-16.us-west-2.compute.internal evicted
```

Now set minAvailable to 2 which is 0 disruption, node drain should be prevented
```
helm upgrade -i appmesh-controller config/helm/appmesh-controller/ \              
    --namespace appmesh-system \
    --set region=us-west-2 \
    --set image.repository=public.ecr.aws/e6v3k1j4/appmesh-controller \
    --set image.tag=v1.4.0-prod-final \
    --set serviceAccount.create=false \
    --set serviceAccount.name=appmesh-controller --set podDisruptionBudget.minAvailable=100% --set replicaCount=2 

kubectl get pods -n appmesh-system  -o wide                     
NAME                                  READY   STATUS    RESTARTS   AGE     IP               NODE                                         NOMINATED NODE   READINESS GATES
appmesh-controller-57f858b8ff-wmw2t   1/1     Running   0          28m     192.168.25.138   ip-192-168-3-93.us-west-2.compute.internal   <none>           <none>
appmesh-controller-57f858b8ff-zgvhk   1/1     Running   0          5m26s   192.168.11.200   ip-192-168-3-93.us-west-2.compute.internal   <none>           <none>
appmesh-jaeger-7b8b7474b5-cn2r4       1/1     Running   0          5m26s   192.168.22.41    ip-192-168-3-93.us-west-2.compute.internal   <none>           <none>

kubectl drain node/ip-192-168-3-93.us-west-2.compute.internal --delete-emptydir-data --ignore-daemonsets
node/ip-192-168-3-93.us-west-2.compute.internal already cordoned
WARNING: ignoring DaemonSet-managed Pods: kube-system/aws-node-z4hbk, kube-system/kube-proxy-gd4ck
evicting pod kube-system/coredns-559b5db75d-b7h6r
evicting pod appmesh-system/appmesh-controller-57f858b8ff-wmw2t
evicting pod default/greeter-67bf66fdbc-kzsmj
evicting pod appmesh-system/appmesh-controller-57f858b8ff-zgvhk
evicting pod kube-system/coredns-559b5db75d-2p6tn
evicting pod appmesh-system/appmesh-jaeger-7b8b7474b5-cn2r4
error when evicting pods/"appmesh-controller-57f858b8ff-zgvhk" -n "appmesh-system" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
error when evicting pods/"appmesh-controller-57f858b8ff-wmw2t" -n "appmesh-system" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```

The replica count of controller should be greater than 1
```
helm upgrade -i appmesh-controller config/helm/appmesh-controller \
    --namespace appmesh-system \
    --set region=us-west-2 \
    --set image.repository=public.ecr.aws/e6v3k1j4/appmesh-controller \
    --set image.tag=v1.4.0-prod-gamma-v2 \
    --set serviceAccount.create=false \
    --set serviceAccount.name=appmesh-controller --set podDisruptionBudget.minAvailable=1
```
Wont apply pdb as replicaCount is 1
```
kubectl get pdb -n appmesh-system
No resources found in appmesh-system namespace.
```

After increasing replicas
```
helm upgrade -i appmesh-controller config/helm/appmesh-controller \
    --namespace appmesh-system \
    --set region=us-west-2 \
    --set image.repository=public.ecr.aws/e6v3k1j4/appmesh-controller \
    --set image.tag=v1.4.0-prod-gamma-v2 \
    --set serviceAccount.create=false \
    --set serviceAccount.name=appmesh-controller --set podDisruptionBudget.minAvailable=1 --set replicaCount=2

kubectl get all -n appmesh-system
NAME                                     READY   STATUS    RESTARTS   AGE
pod/appmesh-controller-d44f647d7-jblnf   1/1     Running   0          11s
pod/appmesh-controller-d44f647d7-v8xf6   1/1     Running   0          75s

kubectl get pdb -n appmesh-system
NAME                     MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
appmesh-controller-pdb   1               N/A               1                     25s
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
