### PR TITLE
Bump Envoy image version to v1.17.2.0-prod

### DIFF
--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -15,7 +15,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.16.1.1-prod
+    tag: v1.17.2.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -15,7 +15,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.16.1.1-prod
+    tag: v1.17.2.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -107,7 +107,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 	//Set to the SPIRE Agent's default UDS path for now as App Mesh only supports SPIRE as SDS provider for preview.
 	fs.StringVar(&cfg.SdsUdsPath, flagSdsUdsPath, "/run/spire/sockets/agent.sock",
 		"Unix Domain Socket path for SDS provider")
-	fs.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.16.1.1-prod",
+	fs.StringVar(&cfg.SidecarImage, flagSidecarImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.17.2.0-prod",
 		"Envoy sidecar container image.")
 	fs.StringVar(&cfg.SidecarCpuRequests, flagSidecarCpuRequests, "10m",
 		"Sidecar CPU resources requests.")

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -22,7 +22,7 @@ func getConfig(fp func(Config) Config) Config {
 		IgnoredIPs:                  "169.254.169.254",
 		LogLevel:                    "debug",
 		Preview:                     false,
-		SidecarImage:                "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.16.1.1-prod",
+		SidecarImage:                "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.17.2.0-prod",
 		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
 		SidecarMemoryRequests:       "32Mi",
 		SidecarCpuRequests:          "10m",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump AppMesh Envoy image version from v1.16.1.1-prod to v1.17.2.0-prod

Envoy v1.17.2 release notes for reference: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.2

The new Envoy image also contains fix for the following issues and bugs:
1. Bug: high default sampling rate for AWS X-Ray tracer in envoy proxy https://github.com/aws/aws-app-mesh-roadmap/issues/338

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
