### PR TITLE
Debug Logs for Register/Deregister Instances with cloudMap

### DIFF
--- a/pkg/cloudmap/instances_reconcile_task.go
+++ b/pkg/cloudmap/instances_reconcile_task.go
@@ -97,6 +97,9 @@ func (t *instancesReconcileTask) reconcile(ctx context.Context, service serviceS
 	}
 
 	instancesToCreateOrUpdate, instancesToDelete := t.matchDesiredInstancesAgainstExistingInstances(desiredReadyInstanceInfoByID, desiredNotReadyInstanceInfoByID, existingInstanceAttrsByID)
+
+	t.log.V(1).Info("CloudMap: Register Instances", "InstanceToCreateOrUpdate", instancesToCreateOrUpdate)
+
 	for instanceID, info := range instancesToCreateOrUpdate {
 		if t.instancesWithOngoingOperation.Has(instanceID) {
 			continue
@@ -111,6 +114,8 @@ func (t *instancesReconcileTask) reconcile(ctx context.Context, service serviceS
 		}(instanceID, info)
 	}
 
+	t.log.V(1).Info("CloudMap: Deregister Instances", "instancesToDelete", instancesToDelete)
+
 	for _, instanceID := range instancesToDelete {
 		if t.instancesWithOngoingOperation.Has(instanceID) {
 			continue
@@ -124,6 +129,7 @@ func (t *instancesReconcileTask) reconcile(ctx context.Context, service serviceS
 			}
 		}(instanceID)
 	}
+
 	return nil
 }
 

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -2,6 +2,8 @@ package inject
 
 import (
 	"errors"
+	"testing"
+
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/google/go-cmp/cmp"
@@ -10,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func Test_envoyMutator_mutate(t *testing.T) {
@@ -461,6 +462,8 @@ func Test_envoyMutator_mutate(t *testing.T) {
 					sidecarCPURequests:         cpuRequests.String(),
 					sidecarMemoryRequests:      memoryRequests.String(),
 					enableJaegerTracing:        true,
+					jaegerPort:                 "8000",
+					jaegerAddress:              "localhost",
 				},
 			},
 			args: args{
@@ -529,18 +532,20 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "9901",
 								},
 								{
-									Name:  "ENVOY_TRACING_CFG_FILE",
-									Value: "/tmp/envoy/envoyconf.yaml",
+									Name:  "ENABLE_ENVOY_JAEGER_TRACING",
+									Value: "1",
+								},
+								{
+									Name:  "JAEGER_TRACER_PORT",
+									Value: "8000",
+								},
+								{
+									Name:  "JAEGER_TRACER_ADDRESS",
+									Value: "localhost",
 								},
 								{
 									Name:  "AWS_REGION",
 									Value: "us-west-2",
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "envoy-tracing-config",
-									MountPath: "/tmp/envoy",
 								},
 							},
 							Resources: corev1.ResourceRequirements{

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -129,6 +129,8 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				enableXrayTracing:          m.config.EnableXrayTracing,
 				xrayDaemonPort:             m.config.XrayDaemonPort,
 				enableJaegerTracing:        m.config.EnableJaegerTracing,
+				jaegerPort:                 m.config.JaegerPort,
+				jaegerAddress:              m.config.JaegerAddress,
 				enableDatadogTracing:       m.config.EnableDatadogTracing,
 				datadogTracerPort:          m.config.DatadogPort,
 				datadogTracerAddress:       m.config.DatadogAddress,
@@ -169,6 +171,16 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 			readinessProbePeriod:       m.config.ReadinessProbePeriod,
 			enableXrayTracing:          m.config.EnableXrayTracing,
 			xrayDaemonPort:             m.config.XrayDaemonPort,
+			enableJaegerTracing:        m.config.EnableJaegerTracing,
+			jaegerPort:                 m.config.JaegerPort,
+			jaegerAddress:              m.config.JaegerAddress,
+			enableDatadogTracing:       m.config.EnableDatadogTracing,
+			datadogTracerPort:          m.config.DatadogPort,
+			datadogTracerAddress:       m.config.DatadogAddress,
+			enableStatsTags:            m.config.EnableStatsTags,
+			enableStatsD:               m.config.EnableStatsD,
+			statsDPort:                 m.config.StatsDPort,
+			statsDAddress:              m.config.StatsDAddress,
 		}, ms, vg),
 			newXrayMutator(xrayMutatorConfig{
 				awsRegion:             m.awsRegion,
@@ -179,6 +191,10 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				xRayImage:             m.config.XRayImage,
 				xRayDaemonPort:        m.config.XrayDaemonPort,
 			}, m.config.EnableXrayTracing),
+			newJaegerMutator(jaegerMutatorConfig{
+				jaegerAddress: m.config.JaegerAddress,
+				jaegerPort:    m.config.JaegerPort,
+			}, m.config.EnableJaegerTracing),
 		}
 	}
 

--- a/pkg/inject/sidecar_builder.go
+++ b/pkg/inject/sidecar_builder.go
@@ -2,43 +2,48 @@ package inject
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/aws/aws-sdk-go/aws"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"strconv"
 )
 
-func buildEnvoySidecar(vars EnvoyTemplateVariables, env map[string]string) corev1.Container {
+const envoyTracingConfigVolumeName = "envoy-tracing-config"
 
-	envoy := corev1.Container{
-		Name:  "envoy",
-		Image: vars.SidecarImage,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: aws.Int64(1337),
-		},
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "stats",
-				ContainerPort: vars.AdminAccessPort,
-				Protocol:      "TCP",
-			},
-		},
-		Lifecycle: &corev1.Lifecycle{
-			PostStart: nil,
-			PreStop: &corev1.Handler{
-				Exec: &corev1.ExecAction{Command: []string{
-					"sh", "-c", fmt.Sprintf("sleep %s", vars.PreStopDelay),
-				}},
-			},
-		},
-	}
+// Envoy template variables used by envoys in pod and the envoy in VirtualGateway
+//as we use the same envoy image
+type EnvoyTemplateVariables struct {
+	AWSRegion                string
+	MeshName                 string
+	VirtualGatewayOrNodeName string
+	Preview                  string
+	EnableSDS                bool
+	SdsUdsPath               string
+	LogLevel                 string
+	AdminAccessPort          int32
+	AdminAccessLogFile       string
+	PreStopDelay             string
+	SidecarImage             string
+	EnableXrayTracing        bool
+	XrayDaemonPort           int32
+	EnableJaegerTracing      bool
+	JaegerPort               string
+	JaegerAddress            string
+	EnableDatadogTracing     bool
+	DatadogTracerPort        int32
+	DatadogTracerAddress     string
+	EnableStatsTags          bool
+	EnableStatsD             bool
+	StatsDPort               int32
+	StatsDAddress            string
+}
 
-	vn := fmt.Sprintf("mesh/%s/virtualNode/%s", vars.MeshName, vars.VirtualNodeName)
-
+func updateEnvMapForEnvoy(vars EnvoyTemplateVariables, env map[string]string, vname string) {
 	// add all the controller managed env to the map so
 	// 1) we remove duplicates
 	// 2) we don't allow overriding controller managed env with pod annotations
-	env["APPMESH_VIRTUAL_NODE_NAME"] = vn
+	env["APPMESH_VIRTUAL_NODE_NAME"] = vname
 	env["AWS_REGION"] = vars.AWSRegion
 
 	// Set the value to 1 to connect to the App Mesh Preview Channel endpoint.
@@ -109,19 +114,39 @@ func buildEnvoySidecar(vars EnvoyTemplateVariables, env map[string]string) corev
 	}
 
 	if vars.EnableJaegerTracing {
-		// Specify a file path in the Envoy container file system.
-		// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/http_tracer.proto
-		env["ENVOY_TRACING_CFG_FILE"] = "/tmp/envoy/envoyconf.yaml"
+		env["ENABLE_ENVOY_JAEGER_TRACING"] = "1"
+		env["JAEGER_TRACER_PORT"] = vars.JaegerPort
+		env["JAEGER_TRACER_ADDRESS"] = vars.JaegerAddress
+	}
+}
 
-		vol_mount := []corev1.VolumeMount{
+func buildEnvoySidecar(vars EnvoyTemplateVariables, env map[string]string) corev1.Container {
+
+	envoy := corev1.Container{
+		Name:  "envoy",
+		Image: vars.SidecarImage,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser: aws.Int64(1337),
+		},
+		Ports: []corev1.ContainerPort{
 			{
-				Name:      vars.EnvoyTracingConfigVolumeName,
-				MountPath: "/tmp/envoy",
+				Name:          "stats",
+				ContainerPort: vars.AdminAccessPort,
+				Protocol:      "TCP",
 			},
-		}
-		envoy.VolumeMounts = vol_mount
+		},
+		Lifecycle: &corev1.Lifecycle{
+			PostStart: nil,
+			PreStop: &corev1.Handler{
+				Exec: &corev1.ExecAction{Command: []string{
+					"sh", "-c", fmt.Sprintf("sleep %s", vars.PreStopDelay),
+				}},
+			},
+		},
 	}
 
+	vname := fmt.Sprintf("mesh/%s/virtualNode/%s", vars.MeshName, vars.VirtualGatewayOrNodeName)
+	updateEnvMapForEnvoy(vars, env, vname)
 	envoy.Env = getEnvoyEnv(env)
 	return envoy
 
@@ -262,4 +287,14 @@ func envVar(envName, envVal string) corev1.EnvVar {
 		Name:  envName,
 		Value: envVal,
 	}
+}
+
+// containsEnvoyTracingConfigVolume checks whether pod already contains "envoy-tracing-config" volume
+func containsEnvoyTracingConfigVolume(pod *corev1.Pod) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == envoyTracingConfigVolumeName {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/inject/virtualgateway_envoy_test.go
+++ b/pkg/inject/virtualgateway_envoy_test.go
@@ -1,6 +1,8 @@
 package inject
 
 import (
+	"testing"
+
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/google/go-cmp/cmp"
@@ -8,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
@@ -798,6 +799,288 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "XRAY_DAEMON_PORT",
 									Value: "2000",
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "curl -s http://localhost:9901/server_info | grep state | grep -q LIVE",
+									}},
+								},
+								InitialDelaySeconds: 1,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enable jaeger tracing",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:                  "us-west-2",
+					preview:                    false,
+					logLevel:                   "debug",
+					adminAccessPort:            9901,
+					adminAccessLogFile:         "/tmp/envoy_admin_access.log",
+					sidecarImage:               "envoy:v2",
+					enableJaegerTracing:        true,
+					jaegerPort:                 "80",
+					jaegerAddress:              "jaeger-collector.system",
+					readinessProbeInitialDelay: 1,
+					readinessProbePeriod:       10,
+					enableDatadogTracing:       false,
+					datadogTracerPort:          8126,
+					datadogTracerAddress:       "127.0.0.1",
+					enableStatsD:               false,
+					statsDAddress:              "127.0.0.1",
+					statsDPort:                 8125,
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_PORT",
+									Value: "9901",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_LOG_FILE",
+									Value: "/tmp/envoy_admin_access.log",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+								{
+									Name:  "JAEGER_TRACER_PORT",
+									Value: "80",
+								},
+								{
+									Name:  "JAEGER_TRACER_ADDRESS",
+									Value: "jaeger-collector.system",
+								},
+								{
+									Name:  "ENABLE_ENVOY_JAEGER_TRACING",
+									Value: "1",
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "curl -s http://localhost:9901/server_info | grep state | grep -q LIVE",
+									}},
+								},
+								InitialDelaySeconds: 1,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enable statsD tracing",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:                  "us-west-2",
+					preview:                    false,
+					logLevel:                   "debug",
+					adminAccessPort:            9901,
+					adminAccessLogFile:         "/tmp/envoy_admin_access.log",
+					sidecarImage:               "envoy:v2",
+					enableJaegerTracing:        false,
+					jaegerPort:                 "80",
+					jaegerAddress:              "jaeger-collector.system",
+					readinessProbeInitialDelay: 1,
+					readinessProbePeriod:       10,
+					enableDatadogTracing:       false,
+					datadogTracerPort:          8126,
+					datadogTracerAddress:       "127.0.0.1",
+					enableStatsD:               true,
+					statsDAddress:              "127.0.0.1",
+					statsDPort:                 8125,
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_PORT",
+									Value: "9901",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_LOG_FILE",
+									Value: "/tmp/envoy_admin_access.log",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+								{
+									Name:  "ENABLE_ENVOY_DOG_STATSD",
+									Value: "1",
+								},
+								{
+									Name:  "STATSD_PORT",
+									Value: "8125",
+								},
+								{
+									Name:  "STATSD_ADDRESS",
+									Value: "127.0.0.1",
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+
+									Exec: &corev1.ExecAction{Command: []string{
+										"sh", "-c", "curl -s http://localhost:9901/server_info | grep state | grep -q LIVE",
+									}},
+								},
+								InitialDelaySeconds: 1,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enable datadog tracing",
+			fields: fields{
+				vg: vg,
+				ms: ms,
+				mutatorConfig: virtualGatwayEnvoyConfig{
+					awsRegion:                  "us-west-2",
+					preview:                    false,
+					logLevel:                   "debug",
+					adminAccessPort:            9901,
+					adminAccessLogFile:         "/tmp/envoy_admin_access.log",
+					sidecarImage:               "envoy:v2",
+					enableJaegerTracing:        false,
+					jaegerPort:                 "80",
+					jaegerAddress:              "jaeger-collector.system",
+					readinessProbeInitialDelay: 1,
+					readinessProbePeriod:       10,
+					enableDatadogTracing:       true,
+					datadogTracerPort:          8126,
+					datadogTracerAddress:       "127.0.0.1",
+					enableStatsD:               false,
+					statsDAddress:              "127.0.0.1",
+					statsDPort:                 8125,
+				},
+			},
+			args: args{
+				pod: pod,
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: "envoy:v2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENVOY_LOG_LEVEL",
+									Value: "debug",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_PORT",
+									Value: "9901",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_LOG_FILE",
+									Value: "/tmp/envoy_admin_access.log",
+								},
+								{
+									Name:  "AWS_REGION",
+									Value: "us-west-2",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_PREVIEW",
+									Value: "0",
+								},
+								{
+									Name:  "ENABLE_ENVOY_DATADOG_TRACING",
+									Value: "1",
+								},
+								{
+									Name:  "DATADOG_TRACER_PORT",
+									Value: "8126",
+								},
+								{
+									Name:  "DATADOG_TRACER_ADDRESS",
+									Value: "127.0.0.1",
 								},
 							},
 							ReadinessProbe: &corev1.Probe{


### PR DESCRIPTION
Added log statements for Register/Deregister instances in cloudmap

Co-authored-by: Chinmay Gadgil <cgadgil@amazon.com>

*Description of changes:*
The log statements would allows us to check which instance IP were registered/deregistered with cloudmap

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
controller-logs
```
{"level":"debug","ts":1622621088.178019,"msg":"CloudMap: Register Instances","InstanceToCreateOrUpdate":{"192.168.22.41":{}}}
{"level":"debug","ts":1622621088.1780407,"msg":"CloudMap: Deregister Instances","instancesToDelete":[]}
{"level":"debug","ts":1622621090.4484007,"msg":"CloudMap: Register Instances","InstanceToCreateOrUpdate":{}}
{"level":"debug","ts":1622621090.448432,"msg":"CloudMap: Deregister Instances","instancesToDelete":[]}
{"level":"debug","ts":1622621090.5487428,"logger":"controller-runtime.controller","msg":"Successfully Reconciled","controller":"cloudMap","request":"howto-k8s-cloudmap/colorapp-blue"}
{"level":"debug","ts":1622621091.3088171,"msg":"CloudMap: Register Instances","InstanceToCreateOrUpdate":{}}
{"level":"debug","ts":1622621091.3088436,"msg":"CloudMap: Deregister Instances","instancesToDelete":[]}
{"level":"debug","ts":1622621091.308908,"logger":"controller-runtime.controller","msg":"Successfully Reconciled","controller":"cloudMap","request":"howto-k8s-cloudmap/colorapp-red"}
{"level":"debug","ts":1622621095.3222013,"msg":"probed instance healthStatus","healthyStatusByInstanceID":{"192.168.76.230":true}}
{"level":"debug","ts":1622621095.334191,"msg":"probed instance healthStatus","healthyStatusByInstanceID":{"192.168.22.41":true}}
{"level":"debug","ts":1622621095.8040714,"msg":"resolved VirtualNode endpoints","readyPods":1,"notReadyPods":0}
{"level":"debug","ts":1622621095.8041499,"msg":"Listed Nodes","count":2}
{"level":"debug","ts":1622621095.8041964,"msg":"CloudMap: Register Instances","InstanceToCreateOrUpdate":{"192.168.90.200":{}}}
```

kubectl get pods -o wide -n howto-k8s-cloudmap
```
NAME                             READY   STATUS        RESTARTS   AGE     IP               NODE                                          NOMINATED NODE   READINESS GATES
colorapp-blue-86b9dc8c86-kf4hw   2/2     Terminating   0          5m11s   192.168.76.230   ip-192-168-87-16.us-west-2.compute.internal   <none>           1/1
colorapp-red-54bb4f8cf8-6vbp8    2/2     Running       0          5m11s   192.168.22.41    ip-192-168-3-93.us-west-2.compute.internal    <none>           1/1
front-6b5bd6ff7-xg28c            2/2     Running       0          5m12s   192.168.90.200   ip-192-168-87-16.us-west-2.compute.internal
```

On deleting blue deployment
```
{"level":"debug","ts":1622621367.3741887,"msg":"CloudMap: Deregister Instances","instancesToDelete":["192.168.76.230"]}
{"level":"debug","ts":1622621370.4645221,"msg":"CloudMap: Register Instances","InstanceToCreateOrUpdate":{}}
{"level":"debug","ts":1622621370.4645526,"msg":"CloudMap: Deregister Instances","instancesToDelete":[]}
{"level":"debug","ts":1622621370.464576,"logger":"controller-runtime.controller","msg":"Successfully Reconciled","controller":"cloudMap","request":"howto-k8s-cloudmap/colorapp-blue"}
```

