### PR TITLE
Remove field length constraints from query parameter exact match

### DIFF
--- a/apis/appmesh/v1beta2/types.go
+++ b/apis/appmesh/v1beta2/types.go
@@ -174,8 +174,6 @@ type HTTPQueryParameters struct {
 }
 
 type QueryMatchMethod struct {
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=255
 	// +optional
 	Exact *string `json:"exact,omitempty"`
 }

--- a/config/crd/bases/appmesh.k8s.aws_gatewayroutes.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_gatewayroutes.yaml
@@ -420,8 +420,6 @@ spec:
                             description: The QueryMatchMethod object.
                             properties:
                               exact:
-                                maxLength: 255
-                                minLength: 1
                                 type: string
                             type: object
                           name:
@@ -650,8 +648,6 @@ spec:
                             description: The QueryMatchMethod object.
                             properties:
                               exact:
-                                maxLength: 255
-                                minLength: 1
                                 type: string
                             type: object
                           name:

--- a/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
@@ -513,8 +513,6 @@ spec:
                                   description: The QueryMatchMethod object.
                                   properties:
                                     exact:
-                                      maxLength: 255
-                                      minLength: 1
                                       type: string
                                   type: object
                                 name:
@@ -792,8 +790,6 @@ spec:
                                   description: The QueryMatchMethod object.
                                   properties:
                                     exact:
-                                      maxLength: 255
-                                      minLength: 1
                                       type: string
                                   type: object
                                 name:

--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/appmesh-controller/crds/crds.yaml
+++ b/config/helm/appmesh-controller/crds/crds.yaml
@@ -356,8 +356,6 @@ spec:
                             description: The QueryMatchMethod object.
                             properties:
                               exact:
-                                maxLength: 255
-                                minLength: 1
                                 type: string
                             type: object
                           name:
@@ -556,8 +554,6 @@ spec:
                             description: The QueryMatchMethod object.
                             properties:
                               exact:
-                                maxLength: 255
-                                minLength: 1
                                 type: string
                             type: object
                           name:
@@ -2718,8 +2714,6 @@ spec:
                                   description: The QueryMatchMethod object.
                                   properties:
                                     exact:
-                                      maxLength: 255
-                                      minLength: 1
                                       type: string
                                   type: object
                                 name:
@@ -2971,8 +2965,6 @@ spec:
                                   description: The QueryMatchMethod object.
                                   properties:
                                     exact:
-                                      maxLength: 255
-                                      minLength: 1
                                       type: string
                                   type: object
                                 name:


### PR DESCRIPTION

Updated Chart minor version


*Description of changes:*
Remove field length constraint for query parameter exact match 
reference: https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_QueryParameterMatch.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
