### PR TITLE
Volume injection support

### DIFF
--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -36,6 +36,8 @@ const (
 	AppMeshSidecarInjectAnnotation = "appmesh.k8s.aws/sidecarInjectorWebhook"
 	//AppMeshSecretMountsAnnotation specifies the list of Secret that need to be mounted to the proxy as a volume
 	AppMeshSecretMountsAnnotation = "appmesh.k8s.aws/secretMounts"
+	//AppMeshVolumeMountsAnnotation specifies the list of volumes that need to be mounted to the proxy
+	AppMeshVolumeMountsAnnotation = "appmesh.k8s.aws/volumeMounts"
 	//AppMeshGatewaySkipImageOverride specifies if Virtual Gateway sidecar image override needs to be skipped for customers
 	//to use their own sidecare image for Virtual Gateway
 	AppMeshGatewaySkipImageOverride = "appmesh.k8s.aws/virtualGatewaySkipImageOverride"

--- a/pkg/inject/envoy.go
+++ b/pkg/inject/envoy.go
@@ -226,11 +226,11 @@ func (m *envoyMutator) getVolumeMounts(pod *corev1.Pod) (map[string]string, erro
 		for _, segment := range strings.Split(v, ",") {
 			pair := strings.Split(segment, ":")
 			if len(pair) != 2 { // volumeName:mountPath
-				return nil, errors.Errorf("malformed annotation %s, expected format: %s", AppMeshSecretMountsAnnotation, "secretName:mountPath")
+				return nil, errors.Errorf("malformed annotation %s, expected format: %s", AppMeshVolumeMountsAnnotation, "volumeName:mountPath")
 			}
-			secretName := strings.TrimSpace(pair[0])
+			volumeName := strings.TrimSpace(pair[0])
 			mountPath := strings.TrimSpace(pair[1])
-			volumeMounts[secretName] = mountPath
+			volumeMounts[volumeName] = mountPath
 		}
 	}
 	return volumeMounts, nil


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This PR adds support for mounting a volume specified in your pod manifest into the Envoy sidecar. This obviates the need for a custom image build for file-based certificates.

Background: we have an agent that rotates certificates daily, so using the secrets mount solution is not practical. This agent runs on each worker node, but there is also a sidecar that can run with this agent to mint certificates with an identity specific to the app. Whichever the approach, the agent talks to a service that issues these certificates, signed by our CA. 

Because the rotation happens automatically (and at random times), it is not practical to have another process watching for filesystem changes, update the secrets mount, and reload Envoy (if necessary). The vast majority of our applications are using this sidecar approach, each with a different identity, so all of the certificates across the cluster are unique.

With the `certificateChain` and `privateKey` options, the paths are relative to `/` in the Envoy sidecar. If not using `secretsMount`, then a custom image must be made to pull the certificates on startup, unless they are baked in. This solution allows for certificates to be mounted from a volume to avoid these workarounds. A sidecar could do the certificate pull/rotation, and have them available to Envoy immediately. 

Example showing `/var/lib/sia` being mounted from the worker node to the Envoy sidecar via `volumeMounts`:

```
apiVersion: appmesh.k8s.aws/v1beta2
kind: VirtualNode
metadata:
  name: fleks-vn
  namespace: fleks
spec:
  podSelector:
    matchLabels:
      app: default-behavior

  backendDefaults:
    clientPolicy:
      tls:
        certificate:
          file:
            certificateChain: /var/lib/sia/certs/service.cert.pem
            privateKey: /var/lib/sia/keys/service.key.pem
        enforce: true
        ports: []
        validation:
          trust:
            file:
              certificateChain: /var/lib/sia/certs/ca.cert.pem

  listeners:
    - portMapping:
        port: 8080
        protocol: http

      tls:
        mode: STRICT
        certificate:
          file:
            certificateChain: /var/lib/sia/certs/service.cert.pem
            privateKey: /var/lib/sia/keys/service.key.pem
        validation:
          trust:
            file:
              certificateChain: /var/lib/sia/certs/ca.cert.pem

  logging: {}
  serviceDiscovery:
    dns:
      hostname: default-behavior.fleks.svc.cluster.local
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: default-behavior
  namespace: fleks
spec:
  selector:
    matchLabels:
      app: default-behavior
  template:
    metadata:
      labels:
        app: default-behavior
      annotations:
        appmesh.k8s.aws/volumeMounts: sia:/var/lib/sia
        appmesh.k8s.aws/sidecarInjectorWebhook: enabled
    spec:
      containers:
      - name: default-behavior
        image: k8s.gcr.io/echoserver:1.4
        volumeMounts:
        - mountPath: /var/lib/sia
          name: sia
      volumes:
      - name: sia
        hostPath:
          path: /var/lib/sia
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
