### PR TITLE
upgrades SPIRE version to support SDS V3

### DIFF
--- a/test/e2e/fishapp/certs/spire_setup.yaml
+++ b/test/e2e/fishapp/certs/spire_setup.yaml
@@ -151,7 +151,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.10.0
+          image: gcr.io/spiffe-io/spire-server:0.12.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -272,7 +272,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.10.0
+          image: gcr.io/spiffe-io/spire-agent:0.12.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config


### PR DESCRIPTION
*Description of changes:*
https://github.com/aws/aws-app-mesh-examples/pull/443  
this ensures SPIRE SDS functionality for any envoy image version. without this change SDS is broken for envoy version 1.17+.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
