### PR TITLE
Use root image of minimal EKD-D to read service account token

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,8 +21,9 @@ jobs:
       run: |
         arch=$(go env GOARCH)
         os=$(go env GOOS)
-        curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
-        sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+        version="2.3.1"
+        curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_${os}_${arch}.tar.gz | tar -xz -C /tmp/
+        sudo mv /tmp/kubebuilder_${version}_${os}_${arch} /usr/local/kubebuilder
         export PATH=$PATH:/usr/local/kubebuilder/bin
     - name: checkout code
       uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN GIT_VERSION=$(git describe --tags --dirty --always) && \
     -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -a -o controller main.go
 
 # Build the container image
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-08-19-1629409339
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:2021-08-22-1629654770
 
 WORKDIR /
 COPY --from=builder /workspace/controller .


### PR DESCRIPTION
*Issue #, if available:*
Controller is unable to read service account token and fetch account id creds as the base image did not have root access

*Description of changes:*
Change the EKS-D base to root 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
