### PR TITLE
Add nil check for cloudmap instanceport attribute

### DIFF
--- a/test/framework/resource/virtualnode/manager.go
+++ b/test/framework/resource/virtualnode/manager.go
@@ -3,11 +3,12 @@ package virtualnode
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
-	"time"
 
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/services"
@@ -204,8 +205,9 @@ func (m *defaultManager) CheckVirtualNodeInCloudMap(ctx context.Context, ms *app
 				cloudMapInstanceAttributes[cloudmap.AttrK8sNamespace] = *instance.Attributes[cloudmap.AttrK8sNamespace]
 				cloudMapInstanceAttributes[cloudmap.AttrAppMeshMesh] = *instance.Attributes[cloudmap.AttrAppMeshMesh]
 				cloudMapInstanceAttributes[cloudmap.AttrAppMeshVirtualNode] = *instance.Attributes[cloudmap.AttrAppMeshVirtualNode]
-				cloudMapInstanceAttributes[cloudmap.AttrAWSInstancePort] = *instance.Attributes[cloudmap.AttrAWSInstancePort]
-
+				if port, exists := instance.Attributes[cloudmap.AttrAWSInstancePort]; exists {
+					cloudMapInstanceAttributes[cloudmap.AttrAWSInstancePort] = *port
+				}
 				cloudMapInstanceInfoMap[*instance.Id] = cloudMapInstanceAttributes
 			}
 			return true
@@ -226,12 +228,13 @@ func (m *defaultManager) CheckVirtualNodeInCloudMap(ctx context.Context, ms *app
 func compareInstances(cloudMapInstanceInfo map[string]map[string]string, localInstanceInfo map[string]map[string]string) error {
 	for cloudMapInstanceId, cloudMapInstanceAttr := range cloudMapInstanceInfo {
 		localInstanceAttributes := localInstanceInfo[cloudMapInstanceId]
+		val, exists := cloudMapInstanceAttr[cloudmap.AttrAWSInstancePort]
 		if cloudMapInstanceAttr[cloudmap.AttrAWSInstanceIPV4] != localInstanceAttributes[cloudmap.AttrAWSInstanceIPV4] ||
 			cloudMapInstanceAttr[cloudmap.AttrK8sPod] != localInstanceAttributes[cloudmap.AttrK8sPod] ||
 			cloudMapInstanceAttr[cloudmap.AttrK8sNamespace] != localInstanceAttributes[cloudmap.AttrK8sNamespace] ||
 			cloudMapInstanceAttr[cloudmap.AttrAppMeshMesh] != localInstanceAttributes[cloudmap.AttrAppMeshMesh] ||
 			cloudMapInstanceAttr[cloudmap.AttrAppMeshVirtualNode] != localInstanceAttributes[cloudmap.AttrAppMeshVirtualNode] ||
-			cloudMapInstanceAttr[cloudmap.AttrAWSInstancePort] != localInstanceAttributes[cloudmap.AttrAWSInstancePort] {
+			(exists && val != localInstanceAttributes[cloudmap.AttrAWSInstancePort]) {
 			return fmt.Errorf("instance info mismatch")
 		}
 	}

--- a/test/integration/virtualnode/virtualnode_test.go
+++ b/test/integration/virtualnode/virtualnode_test.go
@@ -3,11 +3,12 @@ package virtualnode_test
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	appsv1 "k8s.io/api/apps/v1"
-	"sync"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
*Issue #, if available:*
Integration test for virtualnode with cloudmap were failing as value of nstancePort was nil 

*Description of changes:*
Added nil check to hand such case

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
