### PR TITLE
revert the manual workflow change until we have it working

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,12 +1,12 @@
 name: Manual test runner workflow
 
 on:
-  workflow_dispatch:
-    inputs:
-      pull_request_number:
-        description: 'PR number for which integration tests need to be run'
-        default: ''
-        required: true
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
*Description of changes:*
Manual workflow status of Integration test is not getting reported even when we successfully trigger and complete it, so reverting this change until we have the working fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
