### PR TITLE
Use xray daemon from ecr public repo instead of dockerhub

### DIFF
--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -390,7 +390,7 @@ Parameter | Description | Default
 `tracing.port` |  Jaeger or Datadog agent port (ignored for X-Ray) | `9411`
 `tracing.samplingRate` | X-Ray tracer sampling rate. Value can be a decimal number between 0 and 1.00 (100%)  | `0.05`
 `enableCertManager` |  Enable Cert-Manager | `false`
-`xray.image.repository` | X-Ray image repository | `amazon/aws-xray-daemon`
+`xray.image.repository` | X-Ray image repository | `public.ecr.aws/xray/aws-xray-daemon`
 `xray.image.tag` | X-Ray image tag | `latest`
 `accountId` | AWS Account ID for the Kubernetes cluster | None
 `env` |  environment variables to be injected into the appmesh-controller pod | `{}`

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -43,7 +43,7 @@ init:
 
 xray:
   image:
-    repository: amazon/aws-xray-daemon
+    repository: public.ecr.aws/xray/aws-xray-daemon
     tag: latest
 
 nameOverride: ""

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -43,7 +43,7 @@ init:
 
 xray:
   image:
-    repository: amazon/aws-xray-daemon
+    repository: public.ecr.aws/xray/aws-xray-daemon
     tag: latest
 
 nameOverride: ""

--- a/docs/guide/tracing.md
+++ b/docs/guide/tracing.md
@@ -13,8 +13,8 @@ AppMesh controller supports integration with multiple tracing solutions for data
 
     You can optionally use a specific X-Ray image by setting the following flags in addition to the above:
     ```sh
-        --set xray.image.repository=amazon/aws-xray-daemon \
-        --set xray.image.tag=3.2.0
+        --set xray.image.repository=public.ecr.aws/xray/aws-xray-daemon \
+        --set xray.image.tag=3.3.3
     ```
 
 **Note**: You should restart all pods running inside the mesh after enabling tracing.

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -157,7 +157,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		"X-Ray Agent tracing port")
 	fs.StringVar(&cfg.XraySamplingRate, flagXraySamplingRate, "",
 		"X-Ray tracer sampling rate")
-	fs.StringVar(&cfg.XRayImage, flagXRayImage, "amazon/aws-xray-daemon",
+	fs.StringVar(&cfg.XRayImage, flagXRayImage, "public.ecr.aws/xray/aws-xray-daemon",
 		"X-Ray daemon container image")
 	fs.BoolVar(&cfg.EnableStatsTags, flagEnableStatsTags, false,
 		"Enable Envoy to tag stats")

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -158,7 +158,7 @@ func Test_InjectEnvoyContainerVN(t *testing.T) {
 			conf: getConfig(func(cnf Config) Config {
 				cnf.EnableXrayTracing = true
 				cnf.XrayDaemonPort = 2000
-				cnf.XRayImage = "amazon/aws-xray-daemon"
+				cnf.XRayImage = "public.ecr.aws/xray/aws-xray-daemon"
 				return cnf
 			}),
 			args: args{
@@ -302,7 +302,7 @@ func Test_InjectEnvoyContainerVG(t *testing.T) {
 			conf: getConfig(func(cnf Config) Config {
 				cnf.EnableXrayTracing = true
 				cnf.XrayDaemonPort = 2000
-				cnf.XRayImage = "amazon/aws-xray-daemon"
+				cnf.XRayImage = "public.ecr.aws/xray/aws-xray-daemon"
 				return cnf
 			}),
 			args: args{
@@ -320,7 +320,7 @@ func Test_InjectEnvoyContainerVG(t *testing.T) {
 			name: "Inject Envoy container with xray - missing xray daemon port",
 			conf: getConfig(func(cnf Config) Config {
 				cnf.EnableXrayTracing = true
-				cnf.XRayImage = "amazon/aws-xray-daemon"
+				cnf.XRayImage = "public.ecr.aws/xray/aws-xray-daemon"
 				return cnf
 			}),
 			args: args{

--- a/pkg/inject/xray_test.go
+++ b/pkg/inject/xray_test.go
@@ -66,7 +66,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 		sidecarMemoryRequests: memoryRequests.String(),
 		sidecarCPULimits:      cpuLimits.String(),
 		sidecarMemoryLimits:   memoryLimits.String(),
-		xRayImage:             "amazon/aws-xray-daemon",
+		xRayImage:             "public.ecr.aws/xray/aws-xray-daemon",
 		xRayDaemonPort:        2000,
 	}
 	type fields struct {
@@ -172,7 +172,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 						},
 						{
 							Name:  "xray-daemon",
-							Image: "amazon/aws-xray-daemon",
+							Image: "public.ecr.aws/xray/aws-xray-daemon",
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: aws.Int64(1337),
 							},
@@ -212,7 +212,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 					awsRegion:             "us-west-2",
 					sidecarCPURequests:    cpuRequests.String(),
 					sidecarMemoryRequests: memoryRequests.String(),
-					xRayImage:             "amazon/aws-xray-daemon",
+					xRayImage:             "public.ecr.aws/xray/aws-xray-daemon",
 					xRayDaemonPort:        2000,
 				},
 			},
@@ -232,7 +232,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 						},
 						{
 							Name:  "xray-daemon",
-							Image: "amazon/aws-xray-daemon",
+							Image: "public.ecr.aws/xray/aws-xray-daemon",
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: aws.Int64(1337),
 							},
@@ -269,7 +269,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 					sidecarCPURequests:    cpuRequests.String(),
 					sidecarMemoryRequests: memoryRequests.String(),
 					sidecarMemoryLimits:   memoryLimits.String(),
-					xRayImage:             "amazon/aws-xray-daemon",
+					xRayImage:             "public.ecr.aws/xray/aws-xray-daemon",
 					xRayDaemonPort:        2000,
 				},
 			},
@@ -289,7 +289,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 						},
 						{
 							Name:  "xray-daemon",
-							Image: "amazon/aws-xray-daemon",
+							Image: "public.ecr.aws/xray/aws-xray-daemon",
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: aws.Int64(1337),
 							},
@@ -329,7 +329,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 					sidecarCPURequests:    cpuRequests.String(),
 					sidecarMemoryRequests: memoryRequests.String(),
 					sidecarCPULimits:      cpuLimits.String(),
-					xRayImage:             "amazon/aws-xray-daemon",
+					xRayImage:             "public.ecr.aws/xray/aws-xray-daemon",
 					xRayDaemonPort:        2000,
 				},
 			},
@@ -349,7 +349,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 						},
 						{
 							Name:  "xray-daemon",
-							Image: "amazon/aws-xray-daemon",
+							Image: "public.ecr.aws/xray/aws-xray-daemon",
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: aws.Int64(1337),
 							},
@@ -388,7 +388,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 					awsRegion:             "us-west-2",
 					sidecarCPURequests:    cpuRequests.String(),
 					sidecarMemoryRequests: memoryRequests.String(),
-					xRayImage:             "amazon/aws-xray-daemon",
+					xRayImage:             "public.ecr.aws/xray/aws-xray-daemon",
 				},
 			},
 			args: args{
@@ -417,7 +417,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 				mutatorConfig: xrayMutatorConfig{
 					sidecarCPURequests:    cpuRequests.String(),
 					sidecarMemoryRequests: memoryRequests.String(),
-					xRayImage:             "amazon/aws-xray-daemon",
+					xRayImage:             "public.ecr.aws/xray/aws-xray-daemon",
 					xRayDaemonPort:        2000,
 				},
 			},
@@ -555,7 +555,7 @@ func Test_xrayMutator_mutate(t *testing.T) {
 						},
 						{
 							Name:  "xray-daemon",
-							Image: "amazon/aws-xray-daemon",
+							Image: "public.ecr.aws/xray/aws-xray-daemon",
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: aws.Int64(1337),
 							},


### PR DESCRIPTION
**Description of changes:**

Changed controller helm configuration to pull X-Ray daemon image from ECR public repo instead of Dockerhub.

Benefits:
1. Reduced deployment size
amazon/aws-xray-daemon latest image on Dockerhub is 62MB [link](https://hub.docker.com/r/amazon/aws-xray-daemon/tags?page=1&ordering=last_updated). But xray/aws-xray-daemon on ECR public repo which is built from scratch is just 3.51MB [link](https://gallery.ecr.aws/xray/aws-xray-daemon).
1. Won't get throttled for pulling images from Dockerhub

No functional change here.

&nbsp;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

