### PR TITLE
Update proxy route manager to v4-prod

### DIFF
--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.4.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -39,7 +39,7 @@ sidecar:
 init:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
-    tag: v3-prod
+    tag: v4-prod
 
 xray:
   image:

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -39,7 +39,7 @@ sidecar:
 init:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
-    tag: v3-prod
+    tag: v4-prod
 
 xray:
   image:

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -135,7 +135,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		"Number of seconds after Envoy has started before readiness probes are initiated")
 	fs.Int32Var(&cfg.ReadinessProbePeriod, flagReadinessProbePeriod, 10,
 		"How often (in seconds) to perform the readiness probe on Envoy container")
-	fs.StringVar(&cfg.InitImage, flagInitImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+	fs.StringVar(&cfg.InitImage, flagInitImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 		"Init container image.")
 	fs.StringVar(&cfg.IgnoredIPs, flagIgnoredIPs, "169.254.169.254",
 		"Init container ignored IPs.")

--- a/pkg/inject/init_proxy_test.go
+++ b/pkg/inject/init_proxy_test.go
@@ -32,7 +32,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 			name: "normal case",
 			fields: fields{
 				mutatorConfig: initProxyMutatorConfig{
-					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 					cpuRequests:    cpuRequests.String(),
 					memoryRequests: memoryRequests.String(),
 					cpuLimits:      cpuLimits.String(),
@@ -59,7 +59,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
@@ -116,7 +116,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 			name: "normal case without resource limits",
 			fields: fields{
 				mutatorConfig: initProxyMutatorConfig{
-					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 					cpuRequests:    cpuRequests.String(),
 					memoryRequests: memoryRequests.String(),
 				},
@@ -141,7 +141,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
@@ -194,7 +194,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 			name: "normal case + exists other init container",
 			fields: fields{
 				mutatorConfig: initProxyMutatorConfig{
-					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 					cpuRequests:    cpuRequests.String(),
 					memoryRequests: memoryRequests.String(),
 				},
@@ -228,7 +228,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 						},
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
@@ -281,7 +281,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 			name: "no-op when already contains proxyInit container",
 			fields: fields{
 				mutatorConfig: initProxyMutatorConfig{
-					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 					cpuRequests:    cpuRequests.String(),
 					memoryRequests: memoryRequests.String(),
 				},

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -24,7 +24,7 @@ func getConfig(fp func(Config) Config) Config {
 		LogLevel:                    "debug",
 		Preview:                     false,
 		SidecarImage:                "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.19.1.1-prod",
-		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 		SidecarMemoryRequests:       "32Mi",
 		SidecarCpuRequests:          "10m",
 		EnableIAMForServiceAccounts: true,

--- a/pkg/inject/proxy_test.go
+++ b/pkg/inject/proxy_test.go
@@ -36,7 +36,7 @@ func Test_proxyMutator_mutate(t *testing.T) {
 	}
 	mutatorConfig := proxyMutatorConfig{
 		initProxyMutatorConfig: initProxyMutatorConfig{
-			containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+			containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 			cpuRequests:    cpuRequests.String(),
 			memoryRequests: memoryRequests.String(),
 		},
@@ -70,7 +70,7 @@ func Test_proxyMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
@@ -133,7 +133,7 @@ func Test_proxyMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v3-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{


### PR DESCRIPTION
**Description of changes:**
Update Default App Mesh Proxy Route Manager Image version to v4-prod

**Testing**
Ran eks walkthrough howto-k8s-http2 to confirm the working of this image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.