### PR TITLE
Add LogLevel to xray sidecar

### DIFF
--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -389,6 +389,7 @@ Parameter | Description | Default
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`
 `tracing.port` |  Jaeger or Datadog agent port (ignored for X-Ray) | `9411`
 `tracing.samplingRate` | X-Ray tracer sampling rate. Value can be a decimal number between 0 and 1.00 (100%)  | `0.05`
+`tracing.logLevel` | X-Ray Agent log level, from most verbose to least: dev, debug, info, warn, error, prod. | `prod`
 `enableCertManager` |  Enable Cert-Manager | `false`
 `xray.image.repository` | X-Ray image repository | `public.ecr.aws/xray/aws-xray-daemon`
 `xray.image.tag` | X-Ray image tag | `latest`

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -124,6 +124,8 @@ tracing:
   port: 2000
   # tracing.samplingRate: X-Ray tracer sampling rate
   samplingRate: 0.05
+  # tracing.logLevel: X-Ray Agent log level
+  logLevel: prod
 
 stats:
   # stats.tagsEnabled: `true` if Envoy should include app-mesh tags

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -110,6 +110,9 @@ tracing:
   port: 2000
   # tracing.samplingRate: X-Ray tracer sampling rate
   samplingRate: 0.05
+  # tracing.logLevel: X-Ray Agent log level
+  logLevel: prod
+
 
 stats:
   # stats.tagsEnabled: `true` if Envoy should include app-mesh tags

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -37,6 +37,7 @@ const (
 	flagEnableXrayTracing    = "enable-xray-tracing"
 	flagXrayDaemonPort       = "xray-daemon-port"
 	flagXraySamplingRate     = "xray-sampling-rate"
+	flagXrayLogLevel         = "xray-log-level"
 	flagEnableStatsTags      = "enable-stats-tags"
 	flagEnableStatsD         = "enable-statsd"
 	flagStatsDAddress        = "statsd-address"
@@ -84,6 +85,7 @@ type Config struct {
 	EnableXrayTracing    bool
 	XrayDaemonPort       int32
 	XraySamplingRate     string
+	XrayLogLevel         string
 	EnableStatsTags      bool
 	EnableStatsD         bool
 	StatsDAddress        string
@@ -159,6 +161,8 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		"X-Ray tracer sampling rate")
 	fs.StringVar(&cfg.XRayImage, flagXRayImage, "public.ecr.aws/xray/aws-xray-daemon",
 		"X-Ray daemon container image")
+	fs.StringVar(&cfg.XrayLogLevel, flagXrayLogLevel, "prod",
+		"X-Ray Agent log level")
 	fs.BoolVar(&cfg.EnableStatsTags, flagEnableStatsTags, false,
 		"Enable Envoy to tag stats")
 	fs.BoolVar(&cfg.EnableStatsD, flagEnableStatsD, false,

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -155,6 +155,7 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				sidecarMemoryLimits:   m.config.SidecarMemoryLimits,
 				xRayImage:             m.config.XRayImage,
 				xRayDaemonPort:        m.config.XrayDaemonPort,
+				xRayLogLevel:          m.config.XrayLogLevel,
 			}, m.config.EnableXrayTracing),
 			newJaegerMutator(jaegerMutatorConfig{
 				jaegerAddress: m.config.JaegerAddress,
@@ -202,6 +203,7 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				sidecarMemoryLimits:   m.config.SidecarMemoryLimits,
 				xRayImage:             m.config.XRayImage,
 				xRayDaemonPort:        m.config.XrayDaemonPort,
+				xRayLogLevel:          m.config.XrayLogLevel,
 			}, m.config.EnableXrayTracing),
 			newJaegerMutator(jaegerMutatorConfig{
 				jaegerAddress: m.config.JaegerAddress,

--- a/pkg/inject/xray.go
+++ b/pkg/inject/xray.go
@@ -12,6 +12,7 @@ const xrayDaemonContainerTemplate = `
 {
   "name": "xray-daemon",
   "image": "{{ .XRayImage }}",
+  "command": "-l {{ .XrayLogLevel }}",
   "securityContext": {
     "runAsUser": 1337
   },
@@ -35,6 +36,7 @@ type XrayTemplateVariables struct {
 	AWSRegion      string
 	XRayImage      string
 	XrayDaemonPort int32
+	XrayLogLevel   string
 }
 
 type xrayMutatorConfig struct {
@@ -45,6 +47,7 @@ type xrayMutatorConfig struct {
 	sidecarMemoryLimits   string
 	xRayImage             string
 	xRayDaemonPort        int32
+	xRayLogLevel          string
 }
 
 func newXrayMutator(mutatorConfig xrayMutatorConfig, enabled bool) *xrayMutator {
@@ -102,6 +105,7 @@ func (m *xrayMutator) buildTemplateVariables(pod *corev1.Pod) XrayTemplateVariab
 		AWSRegion:      m.mutatorConfig.awsRegion,
 		XRayImage:      m.mutatorConfig.xRayImage,
 		XrayDaemonPort: m.mutatorConfig.xRayDaemonPort,
+		XrayLogLevel:   m.mutatorConfig.xRayLogLevel,
 	}
 }
 
@@ -117,6 +121,10 @@ func (m *xrayMutator) checkConfig() error {
 
 	if m.mutatorConfig.xRayDaemonPort == 0 {
 		missingConfig = append(missingConfig, "xRayDaemonPort")
+	}
+
+	if m.mutatorConfig.xRayLogLevel == "" {
+		missingConfig = append(missingConfig, "xRayLogLevel")
 	}
 
 	if len(missingConfig) > 0 {


### PR DESCRIPTION
*Issue #, if available:*
Resolves #545 

*Description of changes:*
Adds a flag to set the X-Ray Log Level on the xray-daemon sidecar image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
