### PR TITLE
Updated defaultfeApp, defaultbackendApp, defaultApp images

### DIFF
--- a/test/Readme.md
+++ b/test/Readme.md
@@ -1,0 +1,65 @@
+## AWS-APPMESH-CONTROLLER-TESTS
+---
+The test folder consists of integration and e2e tests which can be run using the Ginkgo framework
+
+### Types of Tests  
+#### e2e tests  
+These tests deploy a sample test app within appmesh and tests for end to end connectivity using following modes.  
+1. DNS Service Discovery type 
+2. CloudMap Service Discovery type 
+
+You can trigger e2e tests with following ginkgo command (default: mTLS is disabled)
+```
+ginkgo -v -r test/e2e/ -- --cluster-kubeconfig=<absolute_path_kube_config_file> --cluster-name=<cluster_name> --aws-region=<region> --aws-vpc-id=<vpc_id>
+
+Sample
+ginkgo -v -r test/e2e/ -- --cluster-kubeconfig=/Users/xxxx/.kube/config --cluster-name=test-cluster --aws-region=us-west-2 --aws-vpc-id=vpc-0afa5f08378f21e50 
+```
+
+Run above command again by enabling mTLS sds based. Enable mTLS-sds based as below  
+1. Enable SDS on the controller
+```
+ helm upgrade -i appmesh-controller eks/appmesh-controller --namespace appmesh-system --set sds.enabled=true
+```
+2. Set IsTLSEnabled to false and IsmTLSEnabled to true over [here](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/67d8cf133696c3d035b700659ad27050f4b80f52/test/e2e/fishapp/dynamic_stack_test.go#L39)  
+```
+stackPrototype = fishapp.DynamicStack{
+				IsTLSEnabled: false,
+				//Please set "enable-sds" to true in controller, prior to enabling this.
+				//*TODO* Rename it to include SDS in it's name once we convert file based TLS test -> file based mTLS test.
+				IsmTLSEnabled: true,
+```
+
+Rerun the above ginkgo command for e2e test with these settings. This will test connectivity with mTLS enabled  
+
+**NOTE**  
+For running e2e test on ARM64 based instances, change following [line](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/67d8cf133696c3d035b700659ad27050f4b80f52/test/e2e/fishapp/dynamic_stack.go#L46) to use an arm compatible image as shown below  
+```
+defaultHTTPProxyImage = "ghcr.io/abhinavsingh/proxy.py:v2.4.0b3.dev31.ga062f80-linux.arm64.v8"
+```
+As of today we do not have mTLS support on arm since the spire agent and spire server images are not compatible with arm. We will update the images once we have arm support from spire.   
+So only e2e tests without mTLS can be run on arm with the above suggested changes.  
+
+#### integration tests  
+These tests check creation/deletion of different appmesh components such as virtualgateway, virtualnode etc.
+You can run the entire suite with following ginkgo command
+```
+ginkgo -v -r test/integration/ -- --cluster-kubeconfig=<absolute_path_kube_config_file> --cluster-name=<cluster_name> --aws-region=<region> --aws-vpc-id=<vpc_id>
+
+Sample
+ginkgo -v -r test/integration/ -- --cluster-kubeconfig=/Users/xxxx/.kube/config --cluster-name=test-cluster --aws-region=us-west-2 --aws-vpc-id=vpc-0afa5f08378f21e50 
+```
+
+You can also run tests for individual component as below  
+```
+ginkgo -v -r test/integration/<component_name>/ -- --cluster-kubeconfig=<absolute_path_kube_config_file> --cluster-name=<cluster_name> --aws-region=<region> --aws-vpc-id=<vpc_id>
+
+Sample
+ginkgo -v -r test/integration/virtualnode/ -- --cluster-kubeconfig=/Users/xxxx/.kube/config --cluster-name=test-cluster --aws-region=us-west-2 --aws-vpc-id=vpc-0afa5f08378f21e50
+```
+
+In case of failures, refer to [Troubleshooting](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/docs/guide/troubleshooting.md) guide.   
+
+
+
+

--- a/test/Readme.md
+++ b/test/Readme.md
@@ -37,8 +37,7 @@ For running e2e test on ARM64 based instances, change following [line](https://g
 ```
 defaultHTTPProxyImage = "ghcr.io/abhinavsingh/proxy.py:v2.4.0b3.dev31.ga062f80-linux.arm64.v8"
 ```
-As of today we do not have mTLS support on arm since the spire agent and spire server images are not compatible with arm. We will update the images once we have arm support from spire.   
-So only e2e tests without mTLS can be run on arm with the above suggested changes.  
+As of today we do not have SDS based mTLS support on ARM since the spire agent and spire server images are not compatible with arm. We will update the images once we have arm support from spire.File based mTLS should work without any issues on ARM instances as well.  
 
 #### integration tests  
 These tests check creation/deletion of different appmesh components such as virtualgateway, virtualnode etc.

--- a/test/e2e/fishapp/dynamic_stack.go
+++ b/test/e2e/fishapp/dynamic_stack.go
@@ -42,7 +42,7 @@ const (
 	connectivityCheckUniformDistributionSL = 0.001 // Significance level that traffic to targets are uniform distributed.
 	AppContainerPort                       = 9080
 	HttpProxyContainerPort                 = 8899
-	defaultAppImage                        = "970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest"
+	defaultAppImage                        = "public.ecr.aws/e6v3k1j4/colorteller:v1"
 	defaultHTTPProxyImage                  = "abhinavsingh/proxy.py:latest"
 	caCertScript                           = "certs/ca_certs.sh"
 	nodeCertScript                         = "certs/node_certs.sh"

--- a/test/integration/test_app/backend/Dockerfile
+++ b/test/integration/test_app/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.11.0a3-alpine
 
 WORKDIR /usr/src/app
 

--- a/test/integration/test_app/frontend/Dockerfile
+++ b/test/integration/test_app/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.11.0a3-alpine
 
 WORKDIR /usr/src/app
 

--- a/test/integration/timeout/timeout_stack.go
+++ b/test/integration/timeout/timeout_stack.go
@@ -28,8 +28,8 @@ import (
 const (
 	//If you're not able to access below images, try to build them based on the app code under "timeout_app"
 	//directory and push it to any accessible ECR repo and update the below values
-	defaultFrontEndImage = "928111597794.dkr.ecr.us-west-2.amazonaws.com/amazon/test_app:feapp-img"
-	defaultBackEndImage  = "928111597794.dkr.ecr.us-west-2.amazonaws.com/amazon/test_app:beapp-img"
+	defaultFrontEndImage = "public.ecr.aws/e6v3k1j4/appmesh-test-feapp:v1"
+	defaultBackEndImage  = "public.ecr.aws/e6v3k1j4/appmesh-test-beapp:v1"
 
 	timeoutTest      = "timeout-e2e"
 	AppContainerPort = 8080

--- a/test/integration/tls/tls_stack.go
+++ b/test/integration/tls/tls_stack.go
@@ -31,8 +31,8 @@ import (
 const (
 	//If you're not able to access below images, try to build them based on the app code under "timeout_app"
 	//directory and push it to any accessible ECR repo and update the below values
-	defaultFrontEndImage = "928111597794.dkr.ecr.us-west-2.amazonaws.com/amazon/test_app:feapp-img"
-	defaultBackEndImage  = "928111597794.dkr.ecr.us-west-2.amazonaws.com/amazon/test_app:beapp-img"
+	defaultFrontEndImage = "public.ecr.aws/e6v3k1j4/appmesh-test-feapp:v1"
+	defaultBackEndImage  = "public.ecr.aws/e6v3k1j4/appmesh-test-beapp:v1"
 
 	tlsTest          = "tls-e2e"
 	AppContainerPort = 8080

--- a/test/integration/virtualnode/virtualnode_test.go
+++ b/test/integration/virtualnode/virtualnode_test.go
@@ -3,11 +3,12 @@ package virtualnode_test
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	appsv1 "k8s.io/api/apps/v1"
-	"sync"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,7 +31,7 @@ import (
 )
 
 const (
-	defaultAppImage  = "970805265562.dkr.ecr.us-west-2.amazonaws.com/colorteller:latest"
+	defaultAppImage  = "public.ecr.aws/e6v3k1j4/colorteller:v1"
 	AppContainerPort = 8080
 )
 


### PR DESCRIPTION
*Description of changes:*
Currently the feapp,beapp and defaultApp Images are hosted in private ECR repos so need to move them to public
The images had to be regenerated to be arm compatible, this will enable running integration test on ARM 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
