### PR TITLE
Replace busybox image in jaeger init container

### DIFF
--- a/pkg/inject/jaeger.go
+++ b/pkg/inject/jaeger.go
@@ -39,7 +39,7 @@ const jaegerInitContainerTemplate = `
     "-c",
     "cat <<EOF >> /tmp/envoy/envoyconf.yaml{{ .EnvoyConfig }}EOF\n\ncat /tmp/envoy/envoyconf.yaml\n"
   ],
-  "image": "busybox",
+  "image": "public.ecr.aws/docker/library/busybox",
   "imagePullPolicy": "IfNotPresent",
   "name": "inject-jaeger-config",
   "volumeMounts": [

--- a/pkg/inject/jaeger_test.go
+++ b/pkg/inject/jaeger_test.go
@@ -100,7 +100,7 @@ func Test_jaegerMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:            "inject-jaeger-config",
-							Image:           "busybox",
+							Image:           "public.ecr.aws/docker/library/busybox",
 							ImagePullPolicy: "IfNotPresent",
 							Command: []string{
 								"sh",


### PR DESCRIPTION
*Issue #, if available:*

The init container uses a busybox image from docker hub. The private clusters with no outbound internet access are not able to pull this image. 

*Description of changes:*

Replaced the `busybox` image from dockerhub and used the same image from public ECR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
