### PR TITLE
Pre_upgrade_check Add Validations

### DIFF
--- a/config/helm/appmesh-controller/upgrade/pre_upgrade_check.sh
+++ b/config/helm/appmesh-controller/upgrade/pre_upgrade_check.sh
@@ -1,5 +1,32 @@
 #!/bin/bash
 
+check_kube_connection() {
+
+	kube_err=$(kubectl cluster-info 2>&1 >/dev/null)
+    if [[ -z $kube_err ]]; then
+        echo "kubectl context check: PASSED!"
+        return 0
+    else
+        echo "kubectl context check: FAILED -- context or permissions issue for kubectl"
+        echo $kube_err
+        return 1
+    fi
+
+}
+
+check_installations() {
+
+    kube_err=$(kubectl version --client 2>&1 >/dev/null)
+    jq_err=$(jq --version 2>&1 >/dev/null)
+    if [[ -z $kube_err && -z $jq_err ]]; then
+        echo "kubectl and jq installation check: PASSED!"
+        return 0
+    else
+        echo "kubectl and jq installation check: FAILED -- kubectl or jq not installed"
+        return 1
+    fi
+}
+
 check_old_crds() {
 
     vs=$(kubectl get crd virtualservices.appmesh.k8s.aws --ignore-not-found -o json | jq -r '.spec.versions[]? | select(.? | .name == "v1beta1")')
@@ -50,17 +77,20 @@ check_injector() {
 main() {
 
     exitcode=0
-
-    check_old_crds || exitcode=1
-    check_controller_version || exitcode=1
-    check_injector || exitcode=1
-
+    check_kube_connection || exitcode=1
+    check_installations || exitcode=1
+    if [ ${exitcode} = 0 ]; then
+        check_old_crds || exitcode=1
+        check_controller_version || exitcode=1
+        check_injector || exitcode=1
+    fi
 
     if [ ${exitcode} = 0 ]; then
         echo -e "\nYour cluster is ready for upgrade. Please proceed to the installation instructions"
     else
-        echo -e "\nYour cluster is NOT ready for upgrade to v1.0.0. Please uninstall all the identified items before proceeding"
+        echo -e "\nYour cluster is NOT ready for upgrade to v1.0.0. Please install/uninstall all the identified items before proceeding"
     fi
+
 }
 
 main

--- a/config/helm/appmesh-controller/upgrade/pre_upgrade_check.sh
+++ b/config/helm/appmesh-controller/upgrade/pre_upgrade_check.sh
@@ -14,17 +14,30 @@ check_kube_connection() {
 
 }
 
-check_installations() {
+check_kube_installation() {
 
     kube_err=$(kubectl version --client 2>&1 >/dev/null)
-    jq_err=$(jq --version 2>&1 >/dev/null)
-    if [[ -z $kube_err && -z $jq_err ]]; then
-        echo "kubectl and jq installation check: PASSED!"
+    if [[ -z $kube_err ]]; then
+        echo "kubectl installation check: PASSED!"
         return 0
     else
-        echo "kubectl and jq installation check: FAILED -- kubectl or jq not installed"
+        echo "kubectl installation check: FAILED -- kubectl not installed"
         return 1
     fi
+
+}
+
+check_jq_installation() {
+
+    jq_err=$(jq --version 2>&1 >/dev/null)
+    if [[ -z $jq_err ]]; then
+        echo "jq installation check: PASSED!"
+        return 0
+    else
+        echo "jq installation check: FAILED -- jq not installed"
+        return 1
+    fi
+
 }
 
 check_old_crds() {
@@ -77,8 +90,9 @@ check_injector() {
 main() {
 
     exitcode=0
+    check_kube_installation || exitcode=1
+    check_jq_installation || exitcode=1
     check_kube_connection || exitcode=1
-    check_installations || exitcode=1
     if [ ${exitcode} = 0 ]; then
         check_old_crds || exitcode=1
         check_controller_version || exitcode=1


### PR DESCRIPTION
*Issue #, if available:*
[523](https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/523)

*Description of changes:*
There are now two additional checks which require jq and kubectl to be installed and configured correctly in order to execute the other checks to verify if a cluster is ready to be upgraded. This will prevent false positive "PASSED!" messages.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
