### PR TITLE
Bump envoy image version to v1.21.1.2-prod

### DIFF
--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -15,7 +15,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.21.1.1-prod
+    tag: v1.21.1.2-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -15,7 +15,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.21.1.1-prod
+    tag: v1.21.1.2-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -115,7 +115,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 	//Set to the SPIRE Agent's default UDS path for now as App Mesh only supports SPIRE as SDS provider for preview.
 	fs.StringVar(&cfg.SdsUdsPath, flagSdsUdsPath, "/run/spire/sockets/agent.sock",
 		"Unix Domain Socket path for SDS provider")
-	fs.StringVar(&cfg.SidecarImage, flagSidecarImage, "public.ecr.aws/appmesh/aws-appmesh-envoy:v1.21.1.1-prod",
+	fs.StringVar(&cfg.SidecarImage, flagSidecarImage, "public.ecr.aws/appmesh/aws-appmesh-envoy:v1.21.1.2-prod",
 		"Envoy sidecar container image.")
 	fs.StringVar(&cfg.SidecarCpuRequests, flagSidecarCpuRequests, "10m",
 		"Sidecar CPU resources requests.")

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -23,7 +23,7 @@ func getConfig(fp func(Config) Config) Config {
 		IgnoredIPs:                  "169.254.169.254",
 		LogLevel:                    "debug",
 		Preview:                     false,
-		SidecarImage:                "public.ecr.aws/appmesh/aws-appmesh-envoy:v1.21.1.1-prod",
+		SidecarImage:                "public.ecr.aws/appmesh/aws-appmesh-envoy:v1.21.1.2-prod",
 		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v4-prod",
 		SidecarMemoryRequests:       "32Mi",
 		SidecarCpuRequests:          "10m",


### PR DESCRIPTION
*Description of changes:*

Bump AppMesh Envoy image version from v1.21.1.1-prod to v1.21.1.2-prod
Ref: https://github.com/aws/aws-app-mesh-roadmap/issues/402
Envoy 1.21.1 release notes: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.21.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
