### PR TITLE
Backfill helm chart PRs from eks-charts

### DIFF
--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.6
+version: 1.4.7
 appVersion: 1.4.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.5
+version: 1.4.6
 appVersion: 1.4.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/appmesh-controller/templates/webhook.yaml
+++ b/config/helm/appmesh-controller/templates/webhook.yaml
@@ -121,7 +121,11 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Certificate
 metadata:
   name: {{ template "appmesh-controller.fullname" . }}-serving-cert
@@ -137,7 +141,11 @@ spec:
     name: {{ template "appmesh-controller.fullname" . }}-selfsigned-issuer
   secretName: {{ template "appmesh-controller.fullname" . }}-webhook-server-cert
 ---
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Issuer
 metadata:
   name: {{ template "appmesh-controller.fullname" . }}-selfsigned-issuer

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -87,7 +87,7 @@ serviceAccount:
   # serviceAccount.name: The name of the service account to create or use
   name: ""
   # serviceAccount.annotations: optional annotations to be applied to service account
-  annotations: ""
+  annotations: {}
 
 rbac:
   # rbac.create: `true` if rbac resources should be created


### PR DESCRIPTION
The Helm charts for the App Mesh Controller are actually mastered in this repo and synced over to EKS-Charts. To address this, I am backfilling these two PRs with some minor modification.

Thanks to the following for your contributions! I included your name/emails within the git commits themselves, so I hope your contributions are still tied to your accounts.
- @gitfool https://github.com/aws/eks-charts/pull/725
- @mlazzaro-better https://github.com/aws/eks-charts/pull/712