### PR TITLE
Adding envoy env variable for using dual-stack endpoints and enabling admin access for IPv6

### DIFF
--- a/config/helm/appmesh-controller/templates/deployment.yaml
+++ b/config/helm/appmesh-controller/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
         - --readiness-probe-period={{ .Values.sidecar.probes.readinessProbePeriod }}
         - --envoy-admin-access-port={{ .Values.sidecar.envoyAdminAccessPort }}
         - --envoy-admin-access-log-file={{ .Values.sidecar.envoyAdminAccessLogFile }}
+        - --envoy-admin-access-enable-ipv6={{ .Values.sidecar.envoyAdminAccessEnableIPv6 }}
+        - --dual-stack-endpoint={{ .Values.sidecar.useDualStackEndpoint }}
         - --preview={{ .Values.preview }}
         - --enable-sds={{ .Values.sds.enabled }}
         - --sds-uds-path={{ .Values.sds.udsPath }}

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -21,6 +21,8 @@ sidecar:
   logLevel: info
   envoyAdminAccessPort: 9901
   envoyAdminAccessLogFile: /tmp/envoy_admin_access.log
+  envoyAdminAccessEnableIPv6: false
+  useDualStackEndpoint: false
   resources:
     # sidecar.resources.requests: Envoy CPU and memory requests
     requests:

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -21,6 +21,8 @@ sidecar:
   logLevel: info
   envoyAdminAccessPort: 9901
   envoyAdminAccessLogFile: /tmp/envoy_admin_access.log
+  envoyAdminAccessEnableIPv6: false
+  useDualStackEndpoint: false
   resources:
     # sidecar.resources.requests: Envoy CPU and memory requests
     requests:

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -24,6 +24,8 @@ const (
 	flagReadinessProbePeriod       = "readiness-probe-period"
 	flagEnvoyAdminAccessPort       = "envoy-admin-access-port"
 	flagEnvoyAdminAccessLogFile    = "envoy-admin-access-log-file"
+	flagEnvoyAdminAccessEnableIpv6 = "envoy-admin-access-enable-ipv6"
+	flagDualStackEndpoint          = "dual-stack-endpoint"
 
 	flagInitImage  = "init-image"
 	flagIgnoredIPs = "ignored-ips"
@@ -73,6 +75,8 @@ type Config struct {
 	ReadinessProbePeriod       int32
 	EnvoyAdminAcessPort        int32
 	EnvoyAdminAccessLogFile    string
+	DualStackEndpoint          bool
+	EnvoyAdminAccessEnableIPv6 bool
 
 	// Init container settings
 	InitImage  string
@@ -181,6 +185,8 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		"DogStatsD Agent tracing port")
 	fs.StringVar(&cfg.StatsDSocketPath, flagStatsDSocketPath, "",
 		"DogStatsD Agent unix domain socket")
+	fs.BoolVar(&cfg.DualStackEndpoint, flagDualStackEndpoint, false, "Use DualStack Endpoint")
+	fs.BoolVar(&cfg.DualStackEndpoint, flagEnvoyAdminAccessEnableIpv6, false, "Enable Admin access when using IPv6")
 	fs.StringVar(&cfg.ClusterName, flagClusterName, "", "ClusterName in context")
 }
 

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -286,6 +286,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -406,6 +414,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -539,6 +555,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -701,6 +725,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -833,6 +865,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -954,6 +994,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -1094,6 +1142,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -1213,6 +1269,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -1381,6 +1445,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -1521,6 +1593,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -1653,6 +1733,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -1790,6 +1878,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -1934,6 +2030,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -2118,6 +2222,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -2254,6 +2366,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -2409,6 +2529,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -2534,6 +2662,14 @@ func Test_envoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -2991,6 +3127,60 @@ func Test_envoyMutator_getAugmentedMeshName(t *testing.T) {
 				mutatorConfig: tt.fields.mutatorConfig,
 			}
 			got := m.getAugmentedMeshName()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_envoyMutator_getUseDualStackEndpoints(t *testing.T) {
+	type fields struct {
+		ms            *appmesh.Mesh
+		mutatorConfig envoyMutatorConfig
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "enable using dualstack endpoint",
+			fields: fields{
+				ms: &appmesh.Mesh{
+					Spec: appmesh.MeshSpec{
+						AWSName: aws.String("my-mesh"),
+					},
+				},
+				mutatorConfig: envoyMutatorConfig{
+					accountID:            "000000000000",
+					useDualStackEndpoint: false,
+				},
+			},
+			want: "0",
+		},
+		{
+			name: "disable using dualstack endpoint",
+			fields: fields{
+				ms: &appmesh.Mesh{
+					Spec: appmesh.MeshSpec{
+						AWSName:   aws.String("my-mesh"),
+						MeshOwner: aws.String("000000000000"),
+					},
+				},
+				mutatorConfig: envoyMutatorConfig{
+					accountID:            "000000000000",
+					useDualStackEndpoint: true,
+				},
+			},
+			want: "1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &envoyMutator{
+				ms:            tt.fields.ms,
+				mutatorConfig: tt.fields.mutatorConfig,
+			}
+			got := m.getUseDualStackEndpoint(m.mutatorConfig.useDualStackEndpoint)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -146,6 +146,8 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				statsDSocketPath:           m.config.StatsDSocketPath,
 				controllerVersion:          m.controllerVersion,
 				k8sVersion:                 m.k8sVersion,
+				useDualStackEndpoint:       m.config.DualStackEndpoint,
+				enableAdminAccessIPv6:      m.config.EnvoyAdminAccessEnableIPv6,
 			}, ms, vn),
 			newXrayMutator(xrayMutatorConfig{
 				awsRegion:             m.awsRegion,
@@ -195,6 +197,8 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 			statsDSocketPath:           m.config.StatsDSocketPath,
 			controllerVersion:          m.controllerVersion,
 			k8sVersion:                 m.k8sVersion,
+			useDualStackEndpoint:       m.config.DualStackEndpoint,
+			enableAdminAccessIPv6:      m.config.EnvoyAdminAccessEnableIPv6,
 		}, ms, vg),
 			newXrayMutator(xrayMutatorConfig{
 				awsRegion:             m.awsRegion,

--- a/pkg/inject/sidecar_builder.go
+++ b/pkg/inject/sidecar_builder.go
@@ -44,6 +44,8 @@ type EnvoyTemplateVariables struct {
 	StatsDSocketPath         string
 	K8sVersion               string
 	ControllerVersion        string
+	EnableAdminAccessForIpv6 bool
+	UseDualStackEndpoint     string
 }
 
 func updateEnvMapForEnvoy(vars EnvoyTemplateVariables, env map[string]string, vname string) error {
@@ -52,6 +54,10 @@ func updateEnvMapForEnvoy(vars EnvoyTemplateVariables, env map[string]string, vn
 	// 2) we don't allow overriding controller managed env with pod annotations
 	env["APPMESH_VIRTUAL_NODE_NAME"] = vname
 	env["AWS_REGION"] = vars.AWSRegion
+
+	env["ENVOY_ADMIN_ACCESS_ENABLE_IPV6"] = strconv.FormatBool(vars.EnableAdminAccessForIpv6)
+
+	env["APPMESH_DUALSTACK_ENDPOINT"] = vars.UseDualStackEndpoint
 
 	// Set the value to 1 to connect to the App Mesh Preview Channel endpoint.
 	// See https://docs.aws.amazon.com/app-mesh/latest/userguide/preview.html

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -38,6 +38,8 @@ type virtualGatwayEnvoyConfig struct {
 	statsDSocketPath           string
 	controllerVersion          string
 	k8sVersion                 string
+	useDualStackEndpoint       bool
+	enableAdminAccessIPv6      bool
 }
 
 // newVirtualGatewayEnvoyConfig constructs new newVirtualGatewayEnvoyConfig
@@ -109,6 +111,7 @@ func (m *virtualGatewayEnvoyConfig) buildTemplateVariables(pod *corev1.Pod) Envo
 	meshName := m.getAugmentedMeshName()
 	virtualGatewayName := aws.StringValue(m.vg.Spec.AWSName)
 	preview := m.getPreview(pod)
+	useDualStackEndpoint := m.getUseDualStackEndpoint(m.mutatorConfig.useDualStackEndpoint)
 	sdsEnabled := m.mutatorConfig.enableSDS
 	if m.mutatorConfig.enableSDS && isSDSDisabled(pod) {
 		sdsEnabled = false
@@ -140,6 +143,8 @@ func (m *virtualGatewayEnvoyConfig) buildTemplateVariables(pod *corev1.Pod) Envo
 		StatsDSocketPath:         m.mutatorConfig.statsDSocketPath,
 		ControllerVersion:        m.mutatorConfig.controllerVersion,
 		K8sVersion:               m.mutatorConfig.k8sVersion,
+		UseDualStackEndpoint:     useDualStackEndpoint,
+		EnableAdminAccessForIpv6: m.mutatorConfig.enableAdminAccessIPv6,
 	}
 }
 
@@ -183,5 +188,13 @@ func (m *virtualGatewayEnvoyConfig) virtualGatewayImageOverride(pod *corev1.Pod)
 		return true
 	default:
 		return true
+	}
+}
+
+func (m *virtualGatewayEnvoyConfig) getUseDualStackEndpoint(useDualStackEndpoint bool) string {
+	if useDualStackEndpoint {
+		return "1"
+	} else {
+		return "0"
 	}
 }

--- a/pkg/inject/virtualgateway_envoy_test.go
+++ b/pkg/inject/virtualgateway_envoy_test.go
@@ -341,6 +341,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -432,8 +440,16 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "v1.4.1",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -536,6 +552,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -630,6 +654,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -728,6 +760,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -822,6 +862,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -929,6 +977,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -1068,6 +1124,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -1186,6 +1250,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -1299,6 +1371,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -1389,6 +1469,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -1487,6 +1575,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
@@ -1602,6 +1698,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "v1.20.1-eks-fdsedv",
 								},
 								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
+								},
+								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",
 									Value: "",
 									ValueFrom: &corev1.EnvVarSource{
@@ -1698,6 +1802,14 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								{
 									Name:  "APPMESH_PLATFORM_K8S_VERSION",
 									Value: "v1.20.1-eks-fdsedv",
+								},
+								{
+									Name:  "APPMESH_DUALSTACK_ENDPOINT",
+									Value: "0",
+								},
+								{
+									Name:  "ENVOY_ADMIN_ACCESS_ENABLE_IPV6",
+									Value: "false",
 								},
 								{
 									Name:  "APPMESH_PLATFORM_K8S_POD_UID",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding envoy env variable:
* APPMESH_DUALSTACK_ENDPOINT
* ENVOY_ADMIN_ACCESS_ENABLE_IPV6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
