### PR TITLE
Helm release 1.4.8

### DIFF
--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.7
+version: 1.4.8
 appVersion: 1.4.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.4.5
+version: 1.4.7
 appVersion: 1.4.3
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -400,7 +400,7 @@ Parameter | Description | Default
 `stats.statsdPort` |  DogStatsD daemon port. This will be overridden if `stats.statsdSocketPath` is specified | `8125`
 `stats.statsdSocketPath` | DogStatsD Unix domain socket path. If statsd is enabled but this value is not specified then we will use combination of <statsAddress:statsPort> as the default | None
 `cloudMapCustomHealthCheck.enabled` |  If `true`, CustomHealthCheck will be enabled for CloudMap Services | `false`
-`cloudMapDNS.ttl` |  Sets CloudMap DNS TTL | `300`
+`cloudMapDNS.ttl` |  Sets CloudMap DNS TTL. Will set value for new CloudMap services, but will not update existing CloudMap services. Existing CloudMap services can be updated using the [AWS CloudMap API](https://docs.aws.amazon.com/cloud-map/latest/api/API_UpdateService.html) | `300`
 `tracing.enabled` |  If `true`, Envoy will be configured with tracing | `false`
 `tracing.provider` |  The tracing provider can be x-ray, jaeger or datadog | `x-ray`
 `tracing.address` |  Jaeger or Datadog agent server address (ignored for X-Ray) | `appmesh-jaeger.appmesh-system`

--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -1,5 +1,7 @@
 # App Mesh Controller
 
+> :warning: **This controller is published in multiple repos**: Contributions to this Helm chart must be written to [aws/aws-app-mesh-controller-for-k8s Github repo.](https://github.com/aws/aws-app-mesh-controller-for-k8s/tree/master/config/helm/appmesh-controller) PRs to other repos like **aws/eks-charts** may be closed or overwritten upon next controller release.
+
 App Mesh controller Helm chart for Kubernetes
 
 **Note**: If you wish to use [App Mesh preview](https://docs.aws.amazon.com/app-mesh/latest/userguide/preview.html) features, please refer to our [preview version](https://github.com/aws/eks-charts/blob/preview/stable/appmesh-controller/README.md) instructions.
@@ -127,13 +129,28 @@ https://github.com/aws/aws-app-mesh-examples/blob/5a2d04227593d292d52e5e2ca638d8
 ``` 
 
 #### Without IRSA   
-If not setting up IAM role for service account, apply the IAM policies manually to your worker nodes:
+Find the Node Instance IAM Role from your worker nodes and attach below policies to it.
+**Note** If you created service account for the controller as indicated above then you can skip attaching the Controller IAM policy to worker nodes. Instead attach only the Envoy IAM policy.
 
 Controller IAM policy
 - https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/controller-iam-policy.json
+Use below command to download the policy if not already
+```sh
+curl -o controller-iam-policy.json https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/controller-iam-policy.json
+```
 
 Envoy IAM policy
+Attach the below envoy policy to your Worker Nodes (Node Instance IAM Role)
 - https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/envoy-iam-policy.json  
+Use below command to download the policy if not already
+```sh
+curl -o envoy-iam-policy.json https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/envoy-iam-policy.json
+```
+
+Apply the IAM policy directly to the worker nodes by replacing the `<NODE_INSTANCE_IAM_ROLE_NAME>`, `<policy-name>`, and `<policy-filename>` in below command:
+```sh
+aws iam put-role-policy --role-name <NODE_INSTANCE_IAM_ROLE_NAME> --policy-name <policy-name> --policy-document file://<policy-filename>
+```
 
 Deploy appmesh-controller
 ```sh
@@ -362,7 +379,7 @@ Parameter | Description | Default
 `tolerations` | list of node taints to tolerate | `[]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
-`serviceAccount.annotations` | optional annotations to add to service account | None
+`serviceAccount.annotations` | optional annotations to add to service account | `{}`
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used | None
 `sidecar.image.repository` | Envoy image repository. If you override with non-Amazon built Envoy image, you will need to test/ensure it works with the App Mesh | `840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy`

--- a/config/helm/appmesh-controller/templates/deployment.yaml
+++ b/config/helm/appmesh-controller/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
         {{- if .Values.cloudMapCustomHealthCheck.enabled }}
         - --enable-custom-health-check=true
         {{- end }}
-        {{- if kindIs "float64" .Values.cloudMapDNS.ttl }}
+        {{- if kindIs "int64" .Values.cloudMapDNS.ttl }}
         - --cloudmap-dns-ttl={{ .Values.cloudMapDNS.ttl }}
         {{- end }}
         {{- if .Values.stats.statsdEnabled }}

--- a/config/helm/appmesh-controller/templates/webhook.yaml
+++ b/config/helm/appmesh-controller/templates/webhook.yaml
@@ -121,7 +121,11 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Certificate
 metadata:
   name: {{ template "appmesh-controller.fullname" . }}-serving-cert
@@ -137,7 +141,11 @@ spec:
     name: {{ template "appmesh-controller.fullname" . }}-selfsigned-issuer
   secretName: {{ template "appmesh-controller.fullname" . }}-webhook-server-cert
 ---
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Issuer
 metadata:
   name: {{ template "appmesh-controller.fullname" . }}-selfsigned-issuer

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -87,7 +87,7 @@ serviceAccount:
   # serviceAccount.name: The name of the service account to create or use
   name: ""
   # serviceAccount.annotations: optional annotations to be applied to service account
-  annotations: ""
+  annotations: {}
 
 rbac:
   # rbac.create: `true` if rbac resources should be created


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cherry-picking the following onto the release-1.4 branch. Once merged, this will be tagged and sync'd to EKS charts, restoring the previous working chart version (1.4.6) while applying only the cloudmap and cert-manager changes.

https://github.com/aws/aws-app-mesh-controller-for-k8s/commit/0a38ff9cbc64ac4018d646c74c3c4ecdf3835968
https://github.com/aws/aws-app-mesh-controller-for-k8s/commit/f4a551399c4a4428d31692d0e6d944c2b78f2753
https://github.com/aws/aws-app-mesh-controller-for-k8s/commit/86188b195698e0a1af75eb94cbb96f54b242c3f2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
