### PR TITLE
Cleanup kind cluster even if integration test job fails

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -15,6 +15,9 @@ jobs:
     name: integration-test
     runs-on: [self-hosted, aws-app-mesh-controller-for-k8s, X64 ]
     steps:
+      - name: intentionally break
+        run: |
+          lkasdf
       - name: clean work dir from previous runs
         run: |
           rm -rf *

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -30,5 +30,10 @@ jobs:
         uses: actions/checkout@v2
       - name: setup kind and run integration tests
         run: make integration-test
-      - name: cleanup all the kind clusters
+  cleanup:
+    runs-on: [self-hosted, aws-app-mesh-controller-for-k8s, X64]
+    if: ${{ always() }}
+    needs: [build]
+    steps:
+      - name: delete kind clusters
         run: make delete-all-kind-clusters

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -15,9 +15,6 @@ jobs:
     name: integration-test
     runs-on: [self-hosted, aws-app-mesh-controller-for-k8s, X64 ]
     steps:
-      - name: intentionally break
-        run: |
-          lkasdf
       - name: clean work dir from previous runs
         run: |
           rm -rf *


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Make cleaning up kind cluster independent of integration test job

*Testing:*
- [x] Run commit that breaks integration test job and validate cleanup still happens

https://github.com/aws/aws-app-mesh-controller-for-k8s/runs/7101608920?check_suite_focus=true

- [x] Confirm kind clusters are clearing properly
<img width="660" alt="Screen Shot 2022-06-28 at 15 57 00" src="https://user-images.githubusercontent.com/6402776/176317866-3090b83f-d1e4-4fb4-b071-e7d50e1c97f1.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
