### PR TITLE
Update proxy route manager to v6-prod

### DIFF
--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -42,7 +42,7 @@ sidecar:
 init:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
-    tag: v5-prod
+    tag: v6-prod
 
 xray:
   image:

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -42,7 +42,7 @@ sidecar:
 init:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager
-    tag: v5-prod
+    tag: v6-prod
 
 xray:
   image:

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -147,7 +147,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		"Number of seconds after Envoy has started before readiness probes are initiated")
 	fs.Int32Var(&cfg.ReadinessProbePeriod, flagReadinessProbePeriod, 10,
 		"How often (in seconds) to perform the readiness probe on Envoy container")
-	fs.StringVar(&cfg.InitImage, flagInitImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+	fs.StringVar(&cfg.InitImage, flagInitImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 		"Init container image.")
 	fs.StringVar(&cfg.IgnoredIPs, flagIgnoredIPs, "169.254.169.254",
 		"Init container ignored IPs.")

--- a/pkg/inject/init_proxy_test.go
+++ b/pkg/inject/init_proxy_test.go
@@ -32,7 +32,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 			name: "normal case",
 			fields: fields{
 				mutatorConfig: initProxyMutatorConfig{
-					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 					cpuRequests:    cpuRequests.String(),
 					memoryRequests: memoryRequests.String(),
 					cpuLimits:      cpuLimits.String(),
@@ -59,7 +59,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
@@ -120,7 +120,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 			name: "normal case without resource limits",
 			fields: fields{
 				mutatorConfig: initProxyMutatorConfig{
-					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 					cpuRequests:    cpuRequests.String(),
 					memoryRequests: memoryRequests.String(),
 				},
@@ -145,7 +145,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
@@ -202,7 +202,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 			name: "normal case + exists other init container",
 			fields: fields{
 				mutatorConfig: initProxyMutatorConfig{
-					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 					cpuRequests:    cpuRequests.String(),
 					memoryRequests: memoryRequests.String(),
 				},
@@ -236,7 +236,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 						},
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
@@ -293,7 +293,7 @@ func Test_initProxyMutator_mutate(t *testing.T) {
 			name: "no-op when already contains proxyInit container",
 			fields: fields{
 				mutatorConfig: initProxyMutatorConfig{
-					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+					containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 					cpuRequests:    cpuRequests.String(),
 					memoryRequests: memoryRequests.String(),
 				},

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -24,7 +24,7 @@ func getConfig(fp func(Config) Config) Config {
 		LogLevel:                    "debug",
 		Preview:                     false,
 		SidecarImage:                "public.ecr.aws/appmesh/aws-appmesh-envoy:v1.22.2.0-prod",
-		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 		SidecarMemoryRequests:       "32Mi",
 		SidecarCpuRequests:          "10m",
 		EnableIAMForServiceAccounts: true,

--- a/pkg/inject/proxy_test.go
+++ b/pkg/inject/proxy_test.go
@@ -36,7 +36,7 @@ func Test_proxyMutator_mutate(t *testing.T) {
 	}
 	mutatorConfig := proxyMutatorConfig{
 		initProxyMutatorConfig: initProxyMutatorConfig{
-			containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+			containerImage: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 			cpuRequests:    cpuRequests.String(),
 			memoryRequests: memoryRequests.String(),
 		},
@@ -70,7 +70,7 @@ func Test_proxyMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
@@ -137,7 +137,7 @@ func Test_proxyMutator_mutate(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "proxyinit",
-							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v5-prod",
+							Image: "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{


### PR DESCRIPTION
**Issue #:**
https://github.com/aws/aws-app-mesh-roadmap/issues/421

**Description of changes:**
Update Default App Mesh Proxy Route Manager Image version to [v6-prod](https://github.com/aws/aws-app-mesh-roadmap/issues/423)

**Manual testing**
Ran eks walkthrough howto-k8s-http2 to confirm the working of this image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
