### PR TITLE
Improve build time by ALOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,15 @@ FROM --platform=${TARGETPLATFORM} golang:1.16 as builder
 
 WORKDIR /workspace
 
-COPY . ./
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
+COPY go.mod go.sum ./
+
+# uncomment if using vendor
+# COPY ./vendor ./vendor
+
+ENV GOPROXY=direct
 RUN go mod download
+
+COPY . ./
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This will cache the `go mod download` step separately so that changes to the source file do not invalidate the cache and require ~15 min wait times. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
