### PR TITLE
Increase timeout of flaky test

### DIFF
--- a/test/integration/sidecar-v1.22/sidecar_stack_test.go
+++ b/test/integration/sidecar-v1.22/sidecar_stack_test.go
@@ -37,7 +37,7 @@ var _ = Describe("sidecar features", func() {
 			stack.createMeshAndNamespace(ctx, f)
 			stack.createFrontendResources(ctx, f)
 
-			err := wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
+			err := wait.Poll(5*time.Second, 300*time.Second, func() (done bool, err error) {
 				pods, err := stack.k8client.CoreV1().Pods(stack.testName).List(ctx, metav1.ListOptions{})
 				if err != nil {
 					return false, err


### PR DESCRIPTION
*Issue #, if available:*

Fix flaky tests (it was previously 30 second timeout) 

Examples:

https://github.com/aws/aws-app-mesh-controller-for-k8s/runs/8119300554?check_suite_focus=true
https://github.com/aws/aws-app-mesh-controller-for-k8s/runs/8101335436?check_suite_focus=true

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
