### PR TITLE
GitHub CI Improvements

### DIFF
--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -17,10 +17,10 @@ jobs:
       - name: clean work dir from previous runs
         run: |
           rm -rf *
-      - name: setup go 1.16
+      - name: setup go 1.17
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16.*'
+          go-version: '1.17.*'
         id: go
       - name: setup environment
         run: |
@@ -40,10 +40,10 @@ jobs:
       - name: clean work dir from previous runs
         run: |
           rm -rf *
-      - name: setup go 1.16
+      - name: setup go 1.17
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16.*'
+          go-version: '1.17.*'
         id: go
       - name: setup environment
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: clean work dir from previous runs
         run: |
           rm -rf *
-      - name: setup go 1.16
+      - name: setup go 1.17
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16.*'
+          go-version: '1.17.*'
         id: go
       - name: setup environment
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 permissions:
   contents: read

--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -34,6 +34,13 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           role-session-name: ControllerProdRelease
+      - name: Push docker images (ECR public)
+        run: |
+          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin public.ecr.aws/appmesh/appmesh-controller
+          docker tag ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }} public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}
+          docker tag ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64 public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
+          docker push public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}
+          docker push public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
       - name: Push docker images
         run: |
           aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${{ secrets.PROD_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com

--- a/config/helm/appmesh-controller/ci/values.yaml
+++ b/config/helm/appmesh-controller/ci/values.yaml
@@ -4,6 +4,6 @@
 accountId: 123456789
 region: us-west-2
 image:
-  repository: paulyeo21/appmesh-controller
+  repository: public.ecr.aws/appmesh-controller
   tag: v1.7.0
   pullPolicy: IfNotPresent

--- a/config/helm/appmesh-controller/ci/values.yaml
+++ b/config/helm/appmesh-controller/ci/values.yaml
@@ -4,6 +4,6 @@
 accountId: 123456789
 region: us-west-2
 image:
-  repository: public.ecr.aws/appmesh-controller
+  repository: public.ecr.aws/appmesh/appmesh-controller
   tag: v1.7.0
   pullPolicy: IfNotPresent


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Publish controller images to [ECR public](https://gallery.ecr.aws/appmesh/appmesh-controller), where eks-charts CI can pull them without authentication. This removes the need to manually publish controller new images to an engineer's dockerhub before tests can run on the eks-charts PR.

Additionally, this PR disables integration tests on the pull_request target as per security policy.

This PR also makes our CI use Go 1.17 instead of Go 1.16; the backend group tests seem to be flaky on 1.16 (backend list comparison isn't ignoring the sort order), but I have yet to see them fail on 1.17. Other flaky tests may also benefit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
