### PR TITLE
Fix ECR public workflow

### DIFF
--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -25,7 +25,7 @@ jobs:
           role-session-name: ControllerProdRelease
       - name: Pull docker images
         run: |
-          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com
           docker pull ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}
           docker pull ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
       - name: Configure AWS Credentials (prod)

--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -25,7 +25,7 @@ jobs:
           role-session-name: ControllerProdRelease
       - name: Pull docker images
         run: |
-          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com
+          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com
           docker pull ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}
           docker pull ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
       - name: Configure AWS Credentials (prod)
@@ -36,7 +36,7 @@ jobs:
           role-session-name: ControllerProdRelease
       - name: Push docker images (ECR public)
         run: |
-          aws ecr-public get-login-password --region us-west-2 | docker login --username AWS --password-stdin public.ecr.aws
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
           docker tag ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }} public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}
           docker tag ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64 public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
           docker push public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}

--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -36,7 +36,7 @@ jobs:
           role-session-name: ControllerProdRelease
       - name: Push docker images (ECR public)
         run: |
-          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin public.ecr.aws/appmesh/appmesh-controller
+          aws ecr-public get-login-password --region us-west-2 | docker login --username AWS --password-stdin public.ecr.aws
           docker tag ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }} public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}
           docker tag ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64 public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
           docker push public.ecr.aws/appmesh/appmesh-controller:${{ github.event.inputs.tag }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes the prod workflow because apparently you can only get the ecr public auth token from us-east-1
Tested by pushing v1.7.0 images to ecr-public

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
