### PR TITLE
Bump Envoy image version to v1.23.1.0-prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE ?= $(REPO):$(VERSION)
 PREVIEW=false
 ENABLE_BACKEND_GROUPS?=false
 WAIT_PROXY_READY=false
-SIDECAR_IMAGE_TAG=v1.22.2.1-prod
+SIDECAR_IMAGE_TAG=v1.23.1.0-prod
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1"

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -16,7 +16,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.22.2.1-prod
+    tag: v1.23.1.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -17,7 +17,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.22.2.1-prod
+    tag: v1.23.1.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -137,7 +137,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&cfg.EnableBackendGroups, flagEnableBackendGroups, false, "If enabled, experimental Backend Groups feature will be enabled.")
 	fs.StringVar(&cfg.SidecarImageRepository, flagSidecarImageRepository, "public.ecr.aws/appmesh/aws-appmesh-envoy",
 		"Envoy sidecar container image repository.")
-	fs.StringVar(&cfg.SidecarImageTag, flagSidecarImageTag, "v1.22.2.1-prod", "Envoy sidecar container image tag.")
+	fs.StringVar(&cfg.SidecarImageTag, flagSidecarImageTag, "v1.23.1.0-prod", "Envoy sidecar container image tag.")
 	fs.StringVar(&cfg.SidecarCpuRequests, flagSidecarCpuRequests, "10m",
 		"Sidecar CPU resources requests.")
 	fs.StringVar(&cfg.SidecarMemoryRequests, flagSidecarMemoryRequests, "32Mi",

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -2906,7 +2906,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 											"${BASH_REMATCH[2]} -ge 22 && ${BASH_REMATCH[3]} -gt 2) || (${BASH_REMATCH[1]} -ge 1 && ${BASH_REMATCH[2]} -ge 22 && " +
 											"${BASH_REMATCH[3]} -ge 2 && ${BASH_REMATCH[4]} -gt 0) ]]; then APPNET_AGENT_POLL_ENVOY_READINESS_TIMEOUT_S=60 " +
 											"APPNET_AGENT_POLL_ENVOY_READINESS_INTERVAL_S=5 /usr/bin/agent -envoyReadiness; else echo 'WaitUntilProxyReady " +
-											"is not supported in Envoy version < 1.22.2.1'; fi",
+											"is not supported in Envoy version < 1.23.1.0'; fi",
 									}},
 								},
 								PreStop: &corev1.Handler{

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -24,7 +24,7 @@ func getConfig(fp func(Config) Config) Config {
 		LogLevel:                    "debug",
 		Preview:                     false,
 		SidecarImageRepository:      "public.ecr.aws/appmesh/aws-appmesh-envoy",
-		SidecarImageTag:             "v1.22.2.1-prod",
+		SidecarImageTag:             "v1.23.1.0-prod",
 		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
 		SidecarMemoryRequests:       "32Mi",
 		SidecarCpuRequests:          "10m",

--- a/pkg/inject/sidecar_builder.go
+++ b/pkg/inject/sidecar_builder.go
@@ -199,13 +199,13 @@ func buildEnvoySidecar(vars EnvoyTemplateVariables, env map[string]string) (core
 	if vars.WaitUntilProxyReady {
 		envoy.Lifecycle.PostStart = &corev1.Handler{
 			Exec: &corev1.ExecAction{Command: []string{
-				// use bash regex and rematch to parse and check envoy version is >= 1.22.2.1
+				// use bash regex and rematch to parse and check envoy version is >= 1.23.1.0
 				"sh", "-c", fmt.Sprintf("if [[ $(/usr/bin/envoy --version) =~ ([0-9]+)\\.([0-9]+)\\.([0-9]+)-appmesh\\.([0-9]+) && "+
 					"${BASH_REMATCH[1]} -ge 2 || (${BASH_REMATCH[1]} -ge 1 && ${BASH_REMATCH[2]} -gt 22) || (${BASH_REMATCH[1]} -ge 1 && "+
 					"${BASH_REMATCH[2]} -ge 22 && ${BASH_REMATCH[3]} -gt 2) || (${BASH_REMATCH[1]} -ge 1 && ${BASH_REMATCH[2]} -ge 22 && "+
 					"${BASH_REMATCH[3]} -ge 2 && ${BASH_REMATCH[4]} -gt 0) ]]; then APPNET_AGENT_POLL_ENVOY_READINESS_TIMEOUT_S=%d "+
 					"APPNET_AGENT_POLL_ENVOY_READINESS_INTERVAL_S=%d /usr/bin/agent -envoyReadiness; else echo 'WaitUntilProxyReady "+
-					"is not supported in Envoy version < 1.22.2.1'; fi", vars.PostStartTimeout, vars.PostStartInterval),
+					"is not supported in Envoy version < 1.23.1.0'; fi", vars.PostStartTimeout, vars.PostStartInterval),
 			}},
 		}
 	}

--- a/scripts/test-with-kind.sh
+++ b/scripts/test-with-kind.sh
@@ -85,8 +85,8 @@ function run_integration_tests {
        check_deployment_rollout appmesh-controller appmesh-system
        kubectl get pod -n appmesh-system
         ;;
-      sidecar-v1.22.2.0)
-       APPMESH_PREVIEW=y AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make helm-deploy WAIT_PROXY_READY=true SIDECAR_IMAGE_TAG=v1.22.2.0-prod
+      sidecar-v1.23.1.0)
+       APPMESH_PREVIEW=y AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make helm-deploy WAIT_PROXY_READY=true SIDECAR_IMAGE_TAG=v1.23.1.0-prod
        check_deployment_rollout appmesh-controller appmesh-system
        kubectl get pod -n appmesh-system
         ;;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump AppMesh Envoy image version from v1.22.2.1-prod to v1.23.1.0-prod .
Ref: https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/621
 Envoy v1.23.0 release notes: https://www.envoyproxy.io/docs/envoy/v1.23.1/version_history/v1.23/v1.23.0
Envoy v1.23.1 release notes: https://www.envoyproxy.io/docs/envoy/v1.23.1/version_history/v1.23/v1.23.1

Note: please monitor this [feature request](https://github.com/aws/aws-app-mesh-roadmap/issues/431) and make sure the v1.23.1.0 Envoy image is available in public ECR before merging this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
