### PR TITLE
Update config.go

### DIFF
--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -164,7 +164,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 		"Number of seconds after Envoy has started before readiness probes are initiated")
 	fs.Int32Var(&cfg.ReadinessProbePeriod, flagReadinessProbePeriod, 10,
 		"How often (in seconds) to perform the readiness probe on Envoy container")
-	fs.StringVar(&cfg.InitImage, flagInitImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v6-prod",
+	fs.StringVar(&cfg.InitImage, flagInitImage, "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v7-prod",
 		"Init container image.")
 	fs.StringVar(&cfg.IgnoredIPs, flagIgnoredIPs, "169.254.169.254",
 		"Init container ignored IPs.")


### PR DESCRIPTION
***Issue #:***
Release aws-appmesh-proxy-route-manager v7 #436

***Description of changes:***
Update Default App Mesh Proxy Route Manager Image version to [v7-prod](https://github.com/aws/aws-app-mesh-roadmap/issues/436)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
