### PR TITLE
add instructions for Helm deploy to ARM64

### DIFF
--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -346,6 +346,18 @@ Run the `appmesh-controller/upgrade/pre_upgrade_check.sh` script and make sure i
 
 For handling the existing custom resources and the CRDs please refer to either of the previous upgrade sections as relevant.
 
+## Running on ARM Based Instances
+The controller can run on ARM based instances. To do this you need to specify the ARM64 controller image when deploying the Helm chart.
+You can specify the ARM64 image by setting the image.tag Helm parameter to `<VERSION>-linux_arm64`
+
+For example, to run controller version 1.9.0 on ARM instances you could run the following:
+```console
+helm upgrade -i appmesh-controller eks/appmesh-controller \
+    --namespace appmesh-system \
+    --set region=$AWS_REGION \
+    --set image.tag=v1.9.0-linux_arm64
+```
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `appmesh-controller` deployment:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds instructions for deploying the App Mesh controller to ARM64 nodes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
