### PR TITLE
Modifies integration tests to be runnable outside of AWS

### DIFF
--- a/.github/actions/integration-test/action.yaml
+++ b/.github/actions/integration-test/action.yaml
@@ -1,0 +1,78 @@
+name: "Run Integration Test"
+description: "Runs integration tests in a kinD cluster on a github action"
+
+inputs:
+  aws_role:
+    description: "role to acquire from aws"
+    required: true
+  vpc_id:
+    description: "aws vpc id to use for the test"
+    required: true
+  account_id:
+    description: "aws account id to use"
+    required: true
+  cluster_name:
+    description: "name of the test cluster"
+    required: false
+    default: "test-cluster"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Go 1.17
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.17.*'
+      id: go
+
+    - name: Setup Test Tools
+      shell: bash
+      run: |
+        export GOBIN=/usr/local/bin/
+
+        mkdir -vp ~/.docker/cli-plugins/
+        curl -sL -o ~/.docker/cli-plugins/docker-buildx "https://github.com/docker/buildx/releases/download/v0.3.0/buildx-v0.3.0.linux-amd64"
+        chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+        curl -L -o kubebuilder.tar.gz "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz"
+        tar xzf kubebuilder.tar.gz
+        sudo mv "kubebuilder_2.3.1_linux_amd64" /usr/local/kubebuilder
+        export PATH=$PATH:/usr/local/kubebuilder/bin
+
+        curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+        chmod 700 get_helm.sh
+        ./get_helm.sh
+
+        ./scripts/install-controller-gen.sh
+        ./scripts/install-kubectl.sh
+        go install sigs.k8s.io/kustomize/kustomize/v4@latest
+
+        go mod download
+        go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+
+    - name: Run Unit Tests
+      shell: bash
+      run: |
+        make test
+
+    - name: Configure AWS Credentials (build)
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        aws-region: us-west-2
+        role-to-assume: ${{ inputs.aws_role }}
+        role-session-name: IntegrationTest
+
+    - name: Setup Kind
+      uses: engineerd/setup-kind@v0.5.0
+      with:
+        version: "v0.17.0"
+        name: "${{ inputs.cluster_name }}"
+
+    - name: Run Integration Tests
+      shell: bash
+      env:
+        VPC_ID: "${{ inputs.vpc_id }}"
+        AWS_ACCOUNT_ID: "${{ inputs.account_id }}"
+        CLUSTER_NAME: "${{ inputs.cluster_name }}"
+      run: |
+        KUBECONFIG="${HOME}/.kube/config" ./scripts/test-with-kind.sh

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -7,85 +7,57 @@ on:
         required: true
 
 permissions:
+  id-token: write
   contents: read
 
+env:
+  IMAGE_HOST: "${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com"
+  IMAGE: "${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller"
+  IMAGE_TAG: "${{ github.event.inputs.tag }}"
+  IMAGE_TAG_AMD: "${{ github.event.inputs.tag }}-linux_amd64"
+  IMAGE_TAG_ARM: "${{ github.event.inputs.tag }}-linux_arm64"
+
 jobs:
-  build:
-    name: integration-test
-    runs-on: [ self-hosted, aws-app-mesh-controller-for-k8s, X64 ]
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-22.04
     steps:
-      - name: clean work dir from previous runs
-        run: |
-          rm -rf *
-      - name: setup go 1.17
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.17.*'
-        id: go
-      - name: setup environment
-        run: |
-          source ~/.bashrc
-      - name: checkout code
-        uses: actions/checkout@v2
+      - name: Checkout Code
+        uses: actions/checkout@v3
         with:
           ref: refs/tags/${{ github.event.inputs.tag }}
-      - name: setup kind and run integration tests
-        run: VERSION=${{ github.event.inputs.tag }} make integration-test
-      - name: cleanup all the kind clusters
-        run: VERSION=${{ github.event.inputs.tag }} make delete-all-kind-clusters
-  build-arm64:
-    name: build-arm64
-    runs-on: [ self-hosted, aws-app-mesh-controller-for-k8s, ARM64 ]
+      - name: Run integration test action
+        uses: ./.github/actions/integration-test
+        with:
+          aws_role: "${{ secrets.BETA_TEST_AWS_ROLE }}"
+          vpc_id: "${{ secrets.INTEG_TEST_VPC }}"
+          account_id: "${{ secrets.BETA_AWS_ACCOUNT }}"
+
+  push-images:
+    name: Build And Push Images
+    runs-on: ubuntu-22.04
+    needs: [ integration-test ]
     steps:
-      - name: clean work dir from previous runs
+      - name: Clean
         run: |
           rm -rf *
-      - name: setup go 1.17
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.17.*'
-        id: go
-      - name: setup environment
-        run: |
-          source ~/.bashrc
-      - name: checkout code
-        uses: actions/checkout@v2
+      - name: Checkout Code
+        uses: actions/checkout@v3
         with:
           ref: refs/tags/${{ github.event.inputs.tag }}
-      - name: build for arm64
-        run: |
-          docker buildx build --platform linux/arm64 -t ${{ secrets.CI_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64 . --load
-          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${{ secrets.CI_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com
-          docker push ${{ secrets.CI_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
-  beta-release:
-    name: beta-release
-    runs-on: ubuntu-18.04
-    needs: [ build, build-arm64 ]
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Configure AWS Credentials (build)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.CI_AWS_ROLE }}
-          role-session-name: ControllerBetaRelease
-      - name: Pull docker image
-        run: |
-          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${{ secrets.CI_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com
-          docker pull ${{ secrets.CI_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}
-          docker pull ${{ secrets.CI_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
-      - name: Configure AWS Credentials (beta)
-        uses: aws-actions/configure-aws-credentials@v1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.BETA_AWS_ROLE }}
-          role-session-name: ControllerBetaRelease
-      - name: Push docker image
+          role-session-name: ImagePusher
+
+      - name: Build Images
         run: |
-          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com
-          docker tag ${{ secrets.CI_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }} ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}
-          docker tag ${{ secrets.CI_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64 ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
-          docker push ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}
-          docker push ${{ secrets.BETA_AWS_ACCOUNT }}.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller:${{ github.event.inputs.tag }}-linux_arm64
+          aws ecr get-login-password --region us-west-2 | \
+            docker login --username AWS --password-stdin $IMAGE_HOST
+          # Note: right now, this pushes the amd image under the default. This
+          # behavior should be changed to supporting multiarch shortly.
+          docker buildx build --platform linux/amd64 -t "${IMAGE}:${IMAGE_TAG}" . --push
+          docker buildx build --platform linux/arm64 -t "${IMAGE}:${IMAGE_TAG_ARM}" . --push

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,32 +5,19 @@ on:
       - master
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
-  build:
-    name: integration-test
-    runs-on: [self-hosted, aws-app-mesh-controller-for-k8s, X64 ]
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-22.04
     steps:
-      - name: clean work dir from previous runs
-        run: |
-          rm -rf *
-      - name: setup go 1.17
-        uses: actions/setup-go@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Run integration test action
+        uses: ./.github/actions/integration-test
         with:
-          go-version: '1.17.*'
-        id: go
-      - name: setup environment
-        run: |
-          source ~/.bashrc
-      - name: checkout code
-        uses: actions/checkout@v2
-      - name: setup kind and run integration tests
-        run: make integration-test
-  cleanup:
-    runs-on: [self-hosted, aws-app-mesh-controller-for-k8s, X64]
-    if: ${{ always() }}
-    needs: [build]
-    steps:
-      - name: delete kind clusters
-        run: make delete-all-kind-clusters
+          aws_role: "${{ secrets.BETA_TEST_AWS_ROLE }}"
+          vpc_id: "${{ secrets.INTEG_TEST_VPC }}"
+          account_id: "${{ secrets.BETA_AWS_ACCOUNT }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
 
 # Build the controller binary
-FROM --platform=${TARGETPLATFORM} golang:1.17 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.17 as builder
 
 WORKDIR /workspace
 
@@ -15,7 +15,13 @@ ENV GOPROXY=${GOPROXY}
 
 RUN go mod download
 
-COPY . ./
+COPY ./main.go ./ATTRIBUTION.txt ./
+COPY .git/ ./.git/
+COPY pkg/ ./pkg/
+COPY apis/ ./apis/
+COPY controllers/ ./controllers/
+COPY mocks/ ./mocks/
+COPY webhooks/ ./webhooks/
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/config/helm/appmesh-controller/templates/deployment.yaml
+++ b/config/helm/appmesh-controller/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
         - --envoy-admin-access-enable-ipv6={{ .Values.sidecar.envoyAdminAccessEnableIPv6 }}
         - --dual-stack-endpoint={{ .Values.sidecar.useDualStackEndpoint }}
         - --fips-endpoint={{ .Values.sidecar.useFipsEndpoint }}
+        - --envoy-aws-access-key-id={{ .Values.sidecar.envoyAwsAccessKeyId }}
+        - --envoy-aws-secret-access-key={{ .Values.sidecar.envoyAwsSecretAccessKey }}
+        - --envoy-aws-session-token={{ .Values.sidecar.envoyAwsSessionToken }}
         - --preview={{ .Values.preview }}
         - --enable-sds={{ .Values.sds.enabled }}
         - --sds-uds-path={{ .Values.sds.udsPath }}

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -33,6 +33,10 @@ const (
 	flagWaitUntilProxyReady        = "wait-until-proxy-ready"
 	flagFipsEndpoint               = "fips-endpoint"
 
+	flagEnvoyAwsAccessKeyId     = "envoy-aws-access-key-id"
+	flagEnvoyAwsSecretAccessKey = "envoy-aws-secret-access-key"
+	flagEnvoyAwsSessionToken    = "envoy-aws-session-token"
+
 	flagInitImage  = "init-image"
 	flagIgnoredIPs = "ignored-ips"
 
@@ -90,6 +94,10 @@ type Config struct {
 	EnvoyAdminAccessEnableIPv6 bool
 	WaitUntilProxyReady        bool
 	FipsEndpoint               bool
+
+	EnvoyAwsAccessKeyId     string
+	EnvoyAwsSecretAccessKey string
+	EnvoyAwsSessionToken    string
 
 	// Init container settings
 	InitImage  string
@@ -210,6 +218,12 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&cfg.WaitUntilProxyReady, flagWaitUntilProxyReady, false,
 		"Enable pod postStart hook to delay application startup until proxy is ready to accept traffic")
 	fs.BoolVar(&cfg.FipsEndpoint, flagFipsEndpoint, false, "Use Fips Endpoint")
+	fs.StringVar(&cfg.EnvoyAwsAccessKeyId, flagEnvoyAwsAccessKeyId, "",
+		"Access key for envoy container (for integration testing)")
+	fs.StringVar(&cfg.EnvoyAwsSecretAccessKey, flagEnvoyAwsSecretAccessKey, "",
+		"Secret access key for envoy container (for integration testing)")
+	fs.StringVar(&cfg.EnvoyAwsSessionToken, flagEnvoyAwsSessionToken, "",
+		"Session token for envoy container (for integration testing)")
 }
 
 func (cfg *Config) BindEnv() error {

--- a/pkg/inject/envoy.go
+++ b/pkg/inject/envoy.go
@@ -53,6 +53,9 @@ type envoyMutatorConfig struct {
 	useDualStackEndpoint       bool
 	enableAdminAccessIPv6      bool
 	useFipsEndpoint            bool
+	awsAccessKeyId             string
+	awsSecretAccessKey         string
+	awsSessionToken            string
 }
 
 func newEnvoyMutator(mutatorConfig envoyMutatorConfig, ms *appmesh.Mesh, vn *appmesh.VirtualNode) *envoyMutator {
@@ -169,6 +172,9 @@ func (m *envoyMutator) buildTemplateVariables(pod *corev1.Pod) EnvoyTemplateVari
 		EnableAdminAccessForIpv6: m.mutatorConfig.enableAdminAccessIPv6,
 		WaitUntilProxyReady:      m.mutatorConfig.waitUntilProxyReady,
 		UseFipsEndpoint:          useFipsEndpoint,
+		AwsAccessKeyId:           m.mutatorConfig.awsAccessKeyId,
+		AwsSecretAccessKey:       m.mutatorConfig.awsSecretAccessKey,
+		AwsSessionToken:          m.mutatorConfig.awsSessionToken,
 	}
 }
 

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -153,6 +153,9 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 				postStartTimeout:           m.config.PostStartTimeout,
 				postStartInterval:          m.config.PostStartInterval,
 				useFipsEndpoint:            m.config.FipsEndpoint,
+				awsAccessKeyId:             m.config.EnvoyAwsAccessKeyId,
+				awsSecretAccessKey:         m.config.EnvoyAwsSecretAccessKey,
+				awsSessionToken:            m.config.EnvoyAwsSessionToken,
 			}, ms, vn),
 			newXrayMutator(xrayMutatorConfig{
 				awsRegion:             m.awsRegion,
@@ -206,6 +209,9 @@ func (m *SidecarInjector) injectAppMeshPatches(ms *appmesh.Mesh, vn *appmesh.Vir
 			useDualStackEndpoint:       m.config.DualStackEndpoint,
 			enableAdminAccessIPv6:      m.config.EnvoyAdminAccessEnableIPv6,
 			useFipsEndpoint:            m.config.FipsEndpoint,
+			awsAccessKeyId:             m.config.EnvoyAwsAccessKeyId,
+			awsSecretAccessKey:         m.config.EnvoyAwsSecretAccessKey,
+			awsSessionToken:            m.config.EnvoyAwsSessionToken,
 		}, ms, vg),
 			newXrayMutator(xrayMutatorConfig{
 				awsRegion:             m.awsRegion,

--- a/pkg/inject/sidecar_builder.go
+++ b/pkg/inject/sidecar_builder.go
@@ -51,6 +51,9 @@ type EnvoyTemplateVariables struct {
 	UseDualStackEndpoint     string
 	WaitUntilProxyReady      bool
 	UseFipsEndpoint          string
+	AwsAccessKeyId           string
+	AwsSecretAccessKey       string
+	AwsSessionToken          string
 }
 
 func updateEnvMapForEnvoy(vars EnvoyTemplateVariables, env map[string]string, vname string) error {
@@ -59,6 +62,18 @@ func updateEnvMapForEnvoy(vars EnvoyTemplateVariables, env map[string]string, vn
 	// 2) we don't allow overriding controller managed env with pod annotations
 	env["APPMESH_VIRTUAL_NODE_NAME"] = vname
 	env["AWS_REGION"] = vars.AWSRegion
+
+	// For usage outside traditional EC2 / Fargate IAM based profiles, this is needed to
+	// propagate permissions to envoy. This is a rare use-case that's mostly just for testing.
+	if len(vars.AwsAccessKeyId) > 0 {
+		env["AWS_ACCESS_KEY_ID"] = vars.AwsAccessKeyId
+	}
+	if len(vars.AwsSecretAccessKey) > 0 {
+		env["AWS_SECRET_ACCESS_KEY"] = vars.AwsSecretAccessKey
+	}
+	if len(vars.AwsSessionToken) > 0 {
+		env["AWS_SESSION_TOKEN"] = vars.AwsSessionToken
+	}
 
 	env["ENVOY_ADMIN_ACCESS_ENABLE_IPV6"] = strconv.FormatBool(vars.EnableAdminAccessForIpv6)
 

--- a/pkg/inject/virtualgateway_envoy.go
+++ b/pkg/inject/virtualgateway_envoy.go
@@ -42,6 +42,9 @@ type virtualGatwayEnvoyConfig struct {
 	useDualStackEndpoint       bool
 	enableAdminAccessIPv6      bool
 	useFipsEndpoint            bool
+	awsAccessKeyId             string
+	awsSecretAccessKey         string
+	awsSessionToken            string
 }
 
 // newVirtualGatewayEnvoyConfig constructs new newVirtualGatewayEnvoyConfig
@@ -149,6 +152,9 @@ func (m *virtualGatewayEnvoyConfig) buildTemplateVariables(pod *corev1.Pod) Envo
 		UseDualStackEndpoint:     useDualStackEndpoint,
 		EnableAdminAccessForIpv6: m.mutatorConfig.enableAdminAccessIPv6,
 		UseFipsEndpoint:          useFipsEndpoint,
+		AwsAccessKeyId:           m.mutatorConfig.awsAccessKeyId,
+		AwsSecretAccessKey:       m.mutatorConfig.awsSecretAccessKey,
+		AwsSessionToken:          m.mutatorConfig.awsSessionToken,
 	}
 }
 

--- a/scripts/test-with-kind.sh
+++ b/scripts/test-with-kind.sh
@@ -1,26 +1,33 @@
 #!/usr/bin/env bash
 
-# A script that builds the appmesh controller, provisions a KinD
-# Kubernetes cluster, installs appmesh CRDs and controller into that
-# Kubernetes cluster and runs a set of tests
+# ./scripts/test-with-kind.sh
+#
+# Runs integration tests against a kind cluster. This is mostly intended for
+# automated build systems, but can be used by developers on appropriately configured
+# linux machines as well.
+#
+# Configuration is done through environment variables. All of the following
+# must be set:
+#
+#   AWS_ACCOUNT_ID: aws account id to use in testing
+#   VPC_ID: aws vpc id to use for the tests
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN: session tokens to use
+#
+# There are some additional options that may be set:
+#
+#   AWS_REGION: region to run tests in (defaults to us-west-2)
+#   TEST_SUITES: space-separated set of test suites to run (e.g. "mesh sidecar virtualnode").
+#                If unset, all test suites are run.
+#   K8S_VERSION: kubernetes version to use with the tests (default 1.17)
+#   CLUSTER_NAME, KUBECONFIG: can be set to an existing kind cluster. If unset,
+#                             a new cluster will be created and used for the tests.
+#
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
-ROOT_DIR="$SCRIPTS_DIR/.."
+SCRIPTS_DIR="$(cd "$(dirname "$0")" || exit 1; pwd)"
+ROOT_DIR="$(cd "$SCRIPTS_DIR/.." || exit 1; pwd)"
 INT_TEST_DIR="$ROOT_DIR/test/integration"
-
-AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-""}
-AWS_REGION=${AWS_REGION:-"us-west-2"}
-IMAGE_NAME=amazon/appmesh-controller
-ECR_URL=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
-IMAGE=${ECR_URL}/${IMAGE_NAME}
-
-
-CLUSTER_NAME_BASE="test"
-CLUSTER_NAME=""
-K8S_VERSION="1.17"
-TMP_DIR=""
 
 source "$SCRIPTS_DIR/lib/aws.sh"
 source "$SCRIPTS_DIR/lib/common.sh"
@@ -36,14 +43,51 @@ check_is_installed kubectl "You can install kubectl with the helper scripts/inst
 check_is_installed kustomize "You can install kustomize with the helper scripts/install-kustomize.sh"
 check_is_installed controller-gen "You can install controller-gen with the helper scripts/install-controller-gen.sh"
 
+if [ -z "$AWS_ACCOUNT_ID" ]; then
+  echo "Must set 'AWS_ACCOUNT_ID'" >&2
+  exit 1
+fi
+AWS_REGION="${AWS_REGION:-"us-west-2"}"
 
-function setup_kind_cluster {
-    TEST_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
-    CLUSTER_NAME_BASE=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
-    CLUSTER_NAME="appmesh-test-$CLUSTER_NAME_BASE"-"${TEST_ID}"
-    TMP_DIR=$ROOT_DIR/build/tmp-$CLUSTER_NAME
-    $SCRIPTS_DIR/provision-kind-cluster.sh "${CLUSTER_NAME}" -v "${K8S_VERSION}"
-}
+if [[ -z "$VPC_ID" ]]; then
+  echo "Must set 'VPC_ID'" >&2
+  exit 1
+fi
+
+if [[ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" || -z "$AWS_SESSION_TOKEN" ]]; then
+  echo "AWS credentials must be set in env: 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'," \
+    " and 'AWS_SESSION_TOKEN' must all be set" >&2
+  exit 1
+fi
+
+if [[ -z "$TEST_SUITES" ]]; then
+  TEST_SUITES="$(ls "$INT_TEST_DIR")"
+fi
+
+K8S_VERSION=${K8S_VERSION:-"1.17"}
+
+# Creates a kind test cluster if none was provided.
+if [[ -z "$CLUSTER_NAME" || -z "$KUBECONFIG" ]]; then
+  echo "No test cluster detected, creating one..."
+  CLUSTER_NAME="appmesh-test-$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')"
+  TMP_DIR=$ROOT_DIR/build/tmp-$CLUSTER_NAME
+  $SCRIPTS_DIR/provision-kind-cluster.sh "${CLUSTER_NAME}" -v "${K8S_VERSION}"
+  KUBECONFIG="$TMP_DIR"/kubeconfig
+else
+  echo "Using existing cluster '$CLUSTER_NAME' for testing..."
+fi
+
+CONTROLLER_IMAGE="appmesh-controller"
+CONTROLLER_TAG="local"
+
+IMAGE_HOST="840364872350.dkr.ecr.us-west-2.amazonaws.com"
+
+ENVOY_IMAGE="$IMAGE_HOST/aws-appmesh-envoy"
+ENVOY_LATEST_TAG="v1.24.0.0-prod"
+ENVOY_1_22_TAG="v1.22.2.0-prod"
+
+PROXY_ROUTE_IMAGE="$IMAGE_HOST/aws-appmesh-proxy-route-manager"
+PROXY_ROUTE_TAG="v6-prod"
 
 function install_crds {
     echo "installing CRDs ... "
@@ -51,90 +95,86 @@ function install_crds {
     echo "ok."
 }
 
-function build_and_publish_controller {
-       echo -n "building and publishing appmesh controller  ... "
-       AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make docker-build
-       AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make docker-push
-       echo "ok."
-}
+# Fetches and builds all required images, and loads them into kind. Kind does
+# not inherit the docker registration settings for the host, so preloading
+# the images is necessary to make sure it has the required values.
+function build_and_load_images {
+  docker buildx build --platform linux/amd64 --build-arg GOPROXY="$GOPROXY" -t "$CONTROLLER_IMAGE:$CONTROLLER_TAG" . --load
+  kind load docker-image --name "$CLUSTER_NAME" "$CONTROLLER_IMAGE:$CONTROLLER_TAG"
 
-function install_controller {
-       echo -n "installing appmesh controller ... "
-       local __controller_name="appmesh-controller"
-       local __ns="appmesh-system"
-       kubectl create ns $__ns
-       APPMESH_PREVIEW=y AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION ENABLE_BACKEND_GROUPS=true make helm-deploy
-       check_deployment_rollout $__controller_name $__ns
-       echo -n "check the pods in appmesh-system namespace ... "
-       kubectl get pod -n $__ns
-       echo "ok."
+  ecr_login "$AWS_REGION" "$IMAGE_HOST"
 
+  local __images=(
+      "$PROXY_ROUTE_IMAGE:$PROXY_ROUTE_TAG"
+      "$ENVOY_IMAGE:$ENVOY_LATEST_TAG"
+      "$ENVOY_IMAGE:$ENVOY_1_22_TAG"
+  )
+  for image in "${__images[@]}"; do
+      docker pull "$image"
+      kind load docker-image --name "$CLUSTER_NAME" "$image"
+  done
 }
 
 function run_integration_tests {
-  local __vpc_id=$( vpc_id )
+  echo running tests
 
-  for __type in ${INT_TEST_DIR}/*
-  do
-    case `basename $__type` in
-      test_app) # /test_app contains test app images
-        continue
-        ;;
-      sidecar)
-       APPMESH_PREVIEW=y AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make helm-deploy WAIT_PROXY_READY=true
-       check_deployment_rollout appmesh-controller appmesh-system
-       kubectl get pod -n appmesh-system
-        ;;
-      sidecar-v1.22.2.0)
-       APPMESH_PREVIEW=y AWS_ACCOUNT=$AWS_ACCOUNT_ID AWS_REGION=$AWS_REGION make helm-deploy WAIT_PROXY_READY=true SIDECAR_IMAGE_TAG=v1.22.2.0-prod
-       check_deployment_rollout appmesh-controller appmesh-system
-       kubectl get pod -n appmesh-system
-        ;;
-    esac
+  kubectl delete ns appmesh-system || :
+  kubectl create ns appmesh-system
 
-    echo -n "running integration test type $__type ... "
-    ginkgo -v -r $__type -- --cluster-kubeconfig=${KUBECONFIG} \
-            --cluster-name=${CLUSTER_NAME} --aws-region=${AWS_REGION} \
-            --aws-vpc-id=$__vpc_id
+  for __test in ${TEST_SUITES[@]}; do
+    local __test_dir="test/integration/$__test"
+    local __envoy_version="$ENVOY_LATEST_TAG"
+
+    # /test_app contains test app images, and is not itself an integration test
+    if [[ "$__test" == "test_app" ]]; then
+      continue
+    fi
+
+    # This test specifically tests behavior for an older version of envoy
+    if [[ "$__test" == "sidecar-v1.22" ]]; then
+        __envoy_version="$ENVOY_1_22_TAG"
+    fi
+
+    # Try to delete the controller. Sometimes, carrying over controllers
+    # between tests can cause some minor issues.
+    helm delete -n=appmesh-system appmesh-controller || :
+
+    helm upgrade -i appmesh-controller config/helm/appmesh-controller --namespace appmesh-system \
+      --set image.repository="$CONTROLLER_IMAGE" \
+      --set image.tag="$CONTROLLER_TAG" \
+      --set sidecar.image.repository="$ENVOY_IMAGE" \
+      --set sidecar.image.tag="$__envoy_version" \
+      --set enableBackendGroups=true \
+      --set sidecar.waitUntilProxyReady=true \
+      --set region="$AWS_REGION" \
+      --set accountId="$AWS_ACCOUNT_ID" \
+      --set "env.AWS_DEFAULT_REGION='$AWS_REGION'" \
+      --set "env.AWS_ACCESS_KEY_ID='$AWS_ACCESS_KEY_ID'" \
+      --set "env.AWS_SECRET_ACCESS_KEY='$AWS_SECRET_ACCESS_KEY'" \
+      --set "env.AWS_SESSION_TOKEN='$AWS_SESSION_TOKEN'" \
+      --set sidecar.envoyAwsAccessKeyId="$AWS_ACCESS_KEY_ID" \
+      --set sidecar.envoyAwsSecretAccessKey="$AWS_SECRET_ACCESS_KEY" \
+      --set sidecar.envoyAwsSessionToken="$AWS_SESSION_TOKEN"
+
+    check_deployment_rollout appmesh-controller appmesh-system
+    kubectl get pod -n appmesh-system
+
+    echo -n "running integration test type $__test ... "
+    ginkgo --flakeAttempts=2 -v -r $__test_dir -- \
+      --cluster-kubeconfig="$KUBECONFIG" \
+      --cluster-name="$CLUSTER_NAME" \
+      --aws-region="$AWS_REGION" \
+      --aws-vpc-id="$VPC_ID"
     echo "ok."
   done
 }
 
-function clean_up {
-    if [ -v "$TMP_DIR" ]; then
-        "${SCRIPTS_DIR}"/delete-kind-cluster.sh -c "$TMP_DIR" || :
-    fi
-    return
-}
-
-trap "clean_up" EXIT
-
 aws_check_credentials
 
-if [ -z "$AWS_ACCOUNT_ID" ]; then
-    AWS_ACCOUNT_ID=$( aws_account_id )
-fi
-
-ecr_login $AWS_REGION $ECR_URL
-
-# Build and publish the controller image
-build_and_publish_controller
-
-setup_kind_cluster
-export KUBECONFIG="${TMP_DIR}/kubeconfig"
+build_and_load_images
 
 # Generate and install CRDs
 install_crds
-
-# Install the controller
-install_controller
-
-# Show the installed CRDs
 kubectl get crds
-
-#FIXME sometimes the test controller "deployment" is ready but internally process is not ready
-# leading to tests failing. Added this hack to workaround. Will be replaced with a better
-# check later
-sleep 15
 
 run_integration_tests

--- a/test/Readme.md
+++ b/test/Readme.md
@@ -60,5 +60,23 @@ ginkgo -v -r test/integration/virtualnode/ -- --cluster-kubeconfig=/Users/xxxx/.
 In case of failures, refer to [Troubleshooting](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/docs/guide/troubleshooting.md) guide.   
 
 
+### integration test suite with kind
 
+There is a test runner script, `scripts/test-with-kind.sh`, that can be used to run
+an isolated suite of tests in a local kubernetes cluster. This sets up a local test
+kubernetes cluster using kinD, which is able to run tests in isolation and without
+a EKS cluster.
 
+This tool is mostly for integration testing, but can be used on any linux machine. Refer
+to the script documentation for [execution and environment details](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/scripts/test-with-kind.sh).
+
+**Requirements:**
+
+- The suite has only been tested on linux. It's possible that it could be made work on macOS, but
+  it's not officially supported or verified.
+
+- The test suite has several local tools that must be present for the suite to run. The 
+  best reference is the [integration test setup for github](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/.github/actions/integration-test/action.yml).
+
+- There must be environment credentials - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` -
+  for a valid role with permissions to `AWSCloudMapFullAccess`, `AWSAppMeshFullAccess`, and `AWSAppMeshEnvoyAccess`.

--- a/test/integration/gatewayroute/gatewayroute_test.go
+++ b/test/integration/gatewayroute/gatewayroute_test.go
@@ -53,7 +53,7 @@ var _ = Describe("GatewayRoute", func() {
 		}
 	})
 
-	Context("Gateway Route scenaries", func() {
+	Context("Gateway Route scenarios", func() {
 		var meshTest mesh.MeshTest
 		var vsTest virtualservice.VirtualServiceTest
 		var vgTest virtualgateway.VirtualGatewayTest
@@ -86,7 +86,7 @@ var _ = Describe("GatewayRoute", func() {
 			meshTest.Cleanup(ctx, f)
 		})
 
-		It("Gateway Route Create Scenaries", func() {
+		It("Gateway Route Create Scenarios", func() {
 
 			meshName := fmt.Sprintf("%s-%s", f.Options.ClusterName, utils.RandomDNS1123Label(6))
 			mesh := &appmesh.Mesh{
@@ -238,7 +238,7 @@ var _ = Describe("GatewayRoute", func() {
 
 		})
 
-		It("Gateway Route Update Scenaries", func() {
+		It("Gateway Route Update Scenarios", func() {
 
 			meshName := fmt.Sprintf("%s-%s", f.Options.ClusterName, utils.RandomDNS1123Label(6))
 			mesh := &appmesh.Mesh{
@@ -383,7 +383,7 @@ var _ = Describe("GatewayRoute", func() {
 
 		})
 
-		It("Gateway Route Delete Scenaries", func() {
+		It("Gateway Route Delete Scenarios", func() {
 
 			meshName := fmt.Sprintf("%s-%s", f.Options.ClusterName, utils.RandomDNS1123Label(6))
 			mesh := &appmesh.Mesh{

--- a/test/integration/mesh/mesh_test.go
+++ b/test/integration/mesh/mesh_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Mesh", func() {
 		}
 	})
 
-	Context("Mesh create scenaries", func() {
+	Context("Mesh create scenarios", func() {
 		var meshTest mesh.MeshTest
 		meshTest = mesh.MeshTest{
 			Meshes: make(map[string]*appmesh.Mesh),
@@ -170,7 +170,7 @@ var _ = Describe("Mesh", func() {
 		})
 	})
 
-	Context("Mesh update scenaries", func() {
+	Context("Mesh update scenarios", func() {
 		var meshTest mesh.MeshTest
 		meshTest = mesh.MeshTest{
 			Meshes: make(map[string]*appmesh.Mesh),

--- a/test/integration/sidecar-v1.22/sidecar_stack.go
+++ b/test/integration/sidecar-v1.22/sidecar_stack.go
@@ -3,6 +3,7 @@ package sidecar_v1_22
 import (
 	"context"
 	"fmt"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/inject"
 
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework"
@@ -150,6 +151,9 @@ func (s *SidecarStack) createFrontendResources(ctx context.Context, f *framework
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							"app": "front",
+						},
+						Annotations: map[string]string{
+							inject.AppMeshIPV6Annotation: "disabled", // for github action compatibility
 						},
 					},
 					Spec: corev1.PodSpec{

--- a/test/integration/sidecar/sidecar_stack.go
+++ b/test/integration/sidecar/sidecar_stack.go
@@ -3,6 +3,7 @@ package sidecar
 import (
 	"context"
 	"fmt"
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/inject"
 	"time"
 
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
@@ -219,6 +220,9 @@ func (s *SidecarStack) createFrontendResources(ctx context.Context, f *framework
 						Labels: map[string]string{
 							"app": "front",
 						},
+						Annotations: map[string]string{
+							inject.AppMeshIPV6Annotation: "disabled", // for github action compatibility
+						},
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -349,6 +353,9 @@ func (s *SidecarStack) createBackendResources(ctx context.Context, f *framework.
 						Labels: map[string]string{
 							"app":     "color",
 							"version": "blue",
+						},
+						Annotations: map[string]string{
+							inject.AppMeshIPV6Annotation: "disabled",
 						},
 					},
 					Spec: corev1.PodSpec{

--- a/test/integration/timeout/timeout_stack.go
+++ b/test/integration/timeout/timeout_stack.go
@@ -81,6 +81,7 @@ func (s *TimeoutStack) DeployTimeoutStack(ctx context.Context, f *framework.Fram
 	mb := &manifest.ManifestBuilder{
 		Namespace:            s.namespace.Name,
 		ServiceDiscoveryType: s.ServiceDiscoveryType,
+		DisableIPv6:          true, // for github action compatibility
 	}
 	s.createVirtualNodeResourcesForTimeoutStack(ctx, f, mb)
 	s.createServicesForTimeoutStack(ctx, f)

--- a/test/integration/tls/tls_stack.go
+++ b/test/integration/tls/tls_stack.go
@@ -73,6 +73,7 @@ func (s *TLSStack) DeployTLSStack(ctx context.Context, f *framework.Framework) {
 	mb := &manifest.ManifestBuilder{
 		Namespace:            s.namespace.Name,
 		ServiceDiscoveryType: s.ServiceDiscoveryType,
+		DisableIPv6:          true, // for github action compatibility
 	}
 	s.createSecretsForTLSStack(ctx, f, mb)
 	s.createVirtualNodeResourcesForTLSStack(ctx, f, mb)
@@ -87,6 +88,7 @@ func (s *TLSStack) DeployPartialTLSStack(ctx context.Context, f *framework.Frame
 	mb := &manifest.ManifestBuilder{
 		Namespace:            s.namespace.Name,
 		ServiceDiscoveryType: s.ServiceDiscoveryType,
+		DisableIPv6:          true, // for github action compatibility
 	}
 	s.createSecretsForPartialTLSStack(ctx, f, mb)
 	s.createVirtualNodeResourcesForPartialTLSStack(ctx, f, mb)
@@ -102,6 +104,7 @@ func (s *TLSStack) DeployTLSValidationStack(ctx context.Context, f *framework.Fr
 	mb := &manifest.ManifestBuilder{
 		Namespace:            s.namespace.Name,
 		ServiceDiscoveryType: s.ServiceDiscoveryType,
+		DisableIPv6:          true,
 	}
 	s.createSecretsForTLSValidationStack(ctx, f, mb)
 	s.createVirtualNodeResourcesForTLSValidationStack(ctx, f, mb)

--- a/test/integration/virtualgateway/virtualgateway_test.go
+++ b/test/integration/virtualgateway/virtualgateway_test.go
@@ -51,7 +51,7 @@ var _ = Describe("VirtualGateway", func() {
 		}
 	})
 
-	Context("Virtual Gateway scenaries", func() {
+	Context("Virtual Gateway scenarios", func() {
 		var meshTest mesh.MeshTest
 		var vgTest virtualgateway.VirtualGatewayTest
 
@@ -70,7 +70,7 @@ var _ = Describe("VirtualGateway", func() {
 			meshTest.Cleanup(ctx, f)
 		})
 
-		It("Virtual Gateway Create Scenaries", func() {
+		It("Virtual Gateway Create Scenarios", func() {
 
 			meshName := fmt.Sprintf("%s-%s", f.Options.ClusterName, utils.RandomDNS1123Label(6))
 			mesh := &appmesh.Mesh{
@@ -197,7 +197,7 @@ var _ = Describe("VirtualGateway", func() {
 
 		})
 
-		It("Virtual Gateway Update Scenaries", func() {
+		It("Virtual Gateway Update Scenarios", func() {
 
 			meshName := fmt.Sprintf("%s-%s", f.Options.ClusterName, utils.RandomDNS1123Label(6))
 			mesh := &appmesh.Mesh{
@@ -298,7 +298,7 @@ var _ = Describe("VirtualGateway", func() {
 
 		})
 
-		It("Virtual Gateway Delete Scenaries", func() {
+		It("Virtual Gateway Delete Scenarios", func() {
 
 			meshName := fmt.Sprintf("%s-%s", f.Options.ClusterName, utils.RandomDNS1123Label(6))
 			mesh := &appmesh.Mesh{

--- a/test/integration/virtualnode/virtualnode_test.go
+++ b/test/integration/virtualnode/virtualnode_test.go
@@ -991,6 +991,7 @@ var _ = Describe("VirtualNode", func() {
 
 			mb = &manifest.ManifestBuilder{
 				ServiceDiscoveryType: manifest.CloudMapServiceDiscovery,
+				DisableIPv6:          true, // for github action compatibility
 			}
 
 			By("Create a namespace and add labels", func() {

--- a/test/integration/virtualrouter/virtualrouter_test.go
+++ b/test/integration/virtualrouter/virtualrouter_test.go
@@ -54,7 +54,7 @@ var _ = Describe("VirtualRouter", func() {
 		}
 	})
 
-	Context("Virtual Router scenaries", func() {
+	Context("Virtual Router scenarios", func() {
 		var meshTest mesh.MeshTest
 		var vnTest virtualnode.VirtualNodeTest
 		var vrTest virtualrouter.VirtualRouterTest

--- a/test/integration/virtualservice/virtualservice_test.go
+++ b/test/integration/virtualservice/virtualservice_test.go
@@ -53,7 +53,7 @@ var _ = Describe("VirtualService", func() {
 		}
 	})
 
-	Context("Virtual Router scenaries", func() {
+	Context("Virtual Router scenarios", func() {
 		var meshTest mesh.MeshTest
 		var vnTest virtualnode.VirtualNodeTest
 		var vrTest virtualrouter.VirtualRouterTest


### PR DESCRIPTION
This patch reworks the test and CI system for integration tests to make the execution of the tests more platform agnostic. A system to manage and inject credentials is added that makes the tests runnable outside of an AWS context, and substantial adaptations are made to the test setup and runtime to make them run on a pure github action or linux environment.

Example integration test run: https://github.com/BennettJames/aws-app-mesh-controller-for-k8s/actions/runs/3756588966/jobs/6382826436
Example beta release run: https://github.com/BennettJames/aws-app-mesh-controller-for-k8s/actions/runs/3760250999/jobs/6391541156

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
