### PR TITLE
Bump Envoy image version to v1.25.3.0-prod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Set up Go 1.17
       uses: actions/setup-go@v3

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: unit-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: setup go 1.17
       uses: actions/setup-go@v3

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE ?= $(REPO):$(VERSION)
 PREVIEW=false
 ENABLE_BACKEND_GROUPS?=false
 WAIT_PROXY_READY=false
-SIDECAR_IMAGE_TAG=v1.25.1.0-prod
+SIDECAR_IMAGE_TAG=v1.25.3.0-prod
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1"

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -18,7 +18,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.25.1.0-prod
+    tag: v1.25.3.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -19,7 +19,7 @@ image:
 sidecar:
   image:
     repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy
-    tag: v1.25.1.0-prod
+    tag: v1.25.3.0-prod
     # sidecar.logLevel: Envoy log level can be info, warn, error or debug
   logLevel: info
   envoyAdminAccessPort: 9901

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -147,7 +147,7 @@ func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&cfg.EnableBackendGroups, flagEnableBackendGroups, false, "If enabled, experimental Backend Groups feature will be enabled.")
 	fs.StringVar(&cfg.SidecarImageRepository, flagSidecarImageRepository, "public.ecr.aws/appmesh/aws-appmesh-envoy",
 		"Envoy sidecar container image repository.")
-	fs.StringVar(&cfg.SidecarImageTag, flagSidecarImageTag, "v1.25.1.0-prod", "Envoy sidecar container image tag.")
+	fs.StringVar(&cfg.SidecarImageTag, flagSidecarImageTag, "v1.25.3.0-prod", "Envoy sidecar container image tag.")
 	fs.StringVar(&cfg.SidecarCpuRequests, flagSidecarCpuRequests, "10m",
 		"Sidecar CPU resources requests.")
 	fs.StringVar(&cfg.SidecarMemoryRequests, flagSidecarMemoryRequests, "32Mi",

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -24,7 +24,7 @@ func getConfig(fp func(Config) Config) Config {
 		LogLevel:                    "debug",
 		Preview:                     false,
 		SidecarImageRepository:      "public.ecr.aws/appmesh/aws-appmesh-envoy",
-		SidecarImageTag:             "v1.25.1.0-prod",
+		SidecarImageTag:             "v1.25.3.0-prod",
 		InitImage:                   "840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-proxy-route-manager:v7-prod",
 		SidecarMemoryRequests:       "32Mi",
 		SidecarCpuRequests:          "10m",

--- a/scripts/test-with-kind.sh
+++ b/scripts/test-with-kind.sh
@@ -83,7 +83,7 @@ CONTROLLER_TAG="local"
 IMAGE_HOST="840364872350.dkr.ecr.us-west-2.amazonaws.com"
 
 ENVOY_IMAGE="$IMAGE_HOST/aws-appmesh-envoy"
-ENVOY_LATEST_TAG="v1.25.1.0-prod"
+ENVOY_LATEST_TAG="v1.25.3.0-prod"
 ENVOY_1_22_TAG="v1.22.2.0-prod"
 
 PROXY_ROUTE_IMAGE="$IMAGE_HOST/aws-appmesh-proxy-route-manager"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Bump AppMesh Envoy image version from v1.25.1.0-prod to v1.25.3.0-prod .
Ref: https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/682
 Envoy v1.25.3 release notes: https://www.envoyproxy.io/docs/envoy/v1.25.3/version_history/v1.25/v1.25.3

Note: please monitor this https://github.com/aws/aws-app-mesh-roadmap/issues/458 and make sure the v1.25.3.0 Envoy image is available in public ECR before merging this PR.

Update the runner image because [Ubuntu 18.04 is deprecated](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/). Use the same runner as other actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.