### PR TITLE
Fix flaky backend group test with proper comparison ordering

### DIFF
--- a/test/framework/resource/virtualnode/manager.go
+++ b/test/framework/resource/virtualnode/manager.go
@@ -169,7 +169,7 @@ func (m *defaultManager) checkVirtualNodeBackends(ctx context.Context, ms *appme
 		return err
 	}
 
-	less := func(a, b appmeshsdk.Backend) bool {
+	less := func(a, b *appmeshsdk.Backend) bool {
 		return *a.VirtualService.VirtualServiceName < *b.VirtualService.VirtualServiceName
 	}
 	if cmp.Equal(desiredSDKVNSpec.Backends, resp.VirtualNode.Spec.Backends, cmpopts.SortSlices(less)) {


### PR DESCRIPTION
*Flaky Backend Group Test Fix*
Fixes flakiness in backend group tests by resolving an issue with the ordering used for expected/actual backend comparison.

The less function being provided did not match the type on the VirtualNode.Spec.Backends slice, so was being ignored.
