### PR TITLE
Set workflow env to ubuntu 22.04

### DIFF
--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   prod-release:
     name: prod-release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - name: Set up Go 1.x


### PR DESCRIPTION
Because of a legacy issue, our workflow VM environment is not uniform (https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/399)
Ubuntu 18.04 Actions runner image began deprecation on 2022/08/08 and was fully unsupported by 2023/04/03 (https://github.com/actions/runner-images/issues/6002), so sync them together to 22.04


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
