### PR TITLE
Preserve grpc port value from crd

### DIFF
--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.12.0
-appVersion: 1.12.0
+version: 1.12.1
+appVersion: 1.12.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/config/helm/appmesh-controller/ci/values.yaml
+++ b/config/helm/appmesh-controller/ci/values.yaml
@@ -5,5 +5,5 @@ accountId: 123456789
 region: us-west-2
 image:
   repository: public.ecr.aws/appmesh/appmesh-controller
-  tag: v1.12.0
+  tag: v1.12.1
   pullPolicy: IfNotPresent

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -12,7 +12,7 @@ useAwsFIPSEndpoint: false
 
 image:
   repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.12.0
+  tag: v1.12.1
   pullPolicy: IfNotPresent
 
 sidecar:

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -13,7 +13,7 @@ useAwsFIPSEndpoint: false
 
 image:
   repository: 840364872350.dkr.ecr.us-west-2.amazonaws.com/amazon/appmesh-controller
-  tag: v1.12.0
+  tag: v1.12.1
   pullPolicy: IfNotPresent
 
 sidecar:

--- a/pkg/conversions/virtualrouter_types_conversion.go
+++ b/pkg/conversions/virtualrouter_types_conversion.go
@@ -333,8 +333,8 @@ func Convert_CRD_GRPCRouteMatch_To_SDK_GrpcRouteMatch(crdObj *appmesh.GRPCRouteM
 	sdkObj.Metadata = sdkMetadataList
 	sdkObj.MethodName = crdObj.MethodName
 	sdkObj.ServiceName = crdObj.ServiceName
+	sdkObj.Port = crdObj.Port
 	return nil
-
 }
 
 func Convert_CRD_GRPCRouteAction_To_SDK_GrpcRouteAction(crdObj *appmesh.GRPCRouteAction,

--- a/pkg/conversions/virtualrouter_types_conversion_test.go
+++ b/pkg/conversions/virtualrouter_types_conversion_test.go
@@ -1453,8 +1453,8 @@ func TestConvert_CRD_GRPCRouteMatch_To_SDK_GrpcRouteMatch(t *testing.T) {
 					},
 					MethodName:  aws.String("stream"),
 					ServiceName: aws.String("foo.foodomain.local"),
+					Port:        aws.Int64(9090),
 				},
-
 				sdkObj: &appmeshsdk.GrpcRouteMatch{},
 				scope:  nil,
 			},
@@ -1491,6 +1491,7 @@ func TestConvert_CRD_GRPCRouteMatch_To_SDK_GrpcRouteMatch(t *testing.T) {
 				},
 				MethodName:  aws.String("stream"),
 				ServiceName: aws.String("foo.foodomain.local"),
+				Port:        aws.Int64(9090),
 			},
 		},
 		{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix behavior for #710: ensure port is carried over for grpc route targets in virtual router.

When multiple listener support was added in #630, all targets were updated to handle crd -> sdk conversion except grpc ports. This adds matching support for grpc.

*Testing:*

Re-created the issue; patched the controller; deployed it; confirmed it resolved it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
