### PR TITLE
fix: httpRoute.match.prefix does not need to end in '/'

### DIFF
--- a/webhooks/appmesh/gatewayroute_validator.go
+++ b/webhooks/appmesh/gatewayroute_validator.go
@@ -193,8 +193,8 @@ func validateHTTPRouteRewrite(rewrite *appmesh.HTTPGatewayRouteRewrite, match ap
 		return errors.New("Both prefix and path for rewrites cannot be specified. Only 1 allowed")
 	}
 	if rewrite.Prefix != nil {
-		if match.Prefix != nil && (!strings.HasSuffix(*match.Prefix, "/") || !strings.HasPrefix(*match.Prefix, "/")) {
-			return errors.New("Prefix to be matched on must start and end with '/'")
+		if match.Prefix != nil && !strings.HasPrefix(*match.Prefix, "/") {
+			return errors.New("Prefix to be matched on must start with '/'")
 		}
 		return validatePrefixRewrite(rewrite.Prefix)
 	}

--- a/webhooks/appmesh/gatewayroute_validator_test.go
+++ b/webhooks/appmesh/gatewayroute_validator_test.go
@@ -362,7 +362,7 @@ func Test_gatewayRouteValidator_validateHTTPRouteRewrite(t *testing.T) {
 					Value: aws.String("/test/"),
 				},
 			},
-			wantErr: errors.New("Prefix to be matched on must start and end with '/'"),
+			wantErr: errors.New("Prefix to be matched on must start with '/'"),
 		},
 		{
 			name: "Incorrect Prefix Rewrite format - case2",

--- a/webhooks/appmesh/gatewayroute_validator_test.go
+++ b/webhooks/appmesh/gatewayroute_validator_test.go
@@ -341,18 +341,6 @@ func Test_gatewayRouteValidator_validateHTTPRouteRewrite(t *testing.T) {
 			wantErr: errors.New("Both prefix and path for rewrites cannot be specified. Only 1 allowed"),
 		},
 		{
-			name: "Incorrect Prefix Match format",
-			match: appmesh.HTTPGatewayRouteMatch{
-				Prefix: aws.String("/red"),
-			},
-			rewrite: appmesh.HTTPGatewayRouteRewrite{
-				Prefix: &appmesh.GatewayRoutePrefixRewrite{
-					Value: aws.String("/test/"),
-				},
-			},
-			wantErr: errors.New("Prefix to be matched on must start and end with '/'"),
-		},
-		{
 			name: "Incorrect Prefix Rewrite format",
 			match: appmesh.HTTPGatewayRouteMatch{
 				Prefix: aws.String("/red/"),


### PR DESCRIPTION
*Issue #, if available:* #712

*Description of changes:* Remove obligation for httpRoute.match.prefix to end in `/` - this does not match API behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
