### PR TITLE
adding test cases for TcpRouteMatch

### DIFF
--- a/test/framework/manifest/virtualrouter.go
+++ b/test/framework/manifest/virtualrouter.go
@@ -14,6 +14,13 @@ type RouteToWeightedVirtualNodes struct {
 	WeightedTargets []WeightedVirtualNode
 }
 
+type TcpRouteToWeightedVirtualNodes struct {
+	Match           *TCPRouteMatch
+	WeightedTargets []WeightedVirtualNode
+}
+type TCPRouteMatch struct {
+	Port *int64
+}
 type WeightedVirtualNode struct {
 	VirtualNode types.NamespacedName
 	Weight      int64
@@ -68,6 +75,34 @@ func (b *VRBuilder) BuildRoutes(routeCfgs []RouteToWeightedVirtualNodes) []appme
 	return routes
 
 }
+func (b *VRBuilder) TcpBuildRoutes(tcpRoutesCFgs []TcpRouteToWeightedVirtualNodes) []appmesh.Route {
+
+	var routes []appmesh.Route
+	for index, tcpRouteCfg := range tcpRoutesCFgs {
+		var targets []appmesh.WeightedTarget
+		for _, weightedTarget := range tcpRouteCfg.WeightedTargets {
+			targets = append(targets, appmesh.WeightedTarget{
+				VirtualNodeRef: &appmesh.VirtualNodeReference{
+					Namespace: aws.String(weightedTarget.VirtualNode.Namespace),
+					Name:      weightedTarget.VirtualNode.Name,
+				},
+				Weight: weightedTarget.Weight,
+			})
+		}
+		//match:= if tcpRouteCfg.
+		routes = append(routes, appmesh.Route{
+			Name: fmt.Sprintf("route-%d", index),
+			TCPRoute: &appmesh.TCPRoute{
+				Match: (*appmesh.TCPRouteMatch)(tcpRouteCfg.Match),
+				Action: appmesh.TCPRouteAction{
+					WeightedTargets: targets,
+				},
+				Timeout: nil,
+			},
+		})
+	}
+	return routes
+}
 
 func (b *VRBuilder) BuildVirtualRouterListener(protocol appmesh.PortProtocol, port appmesh.PortNumber) appmesh.VirtualRouterListener {
 	return appmesh.VirtualRouterListener{
@@ -75,6 +110,12 @@ func (b *VRBuilder) BuildVirtualRouterListener(protocol appmesh.PortProtocol, po
 			Port:     port,
 			Protocol: protocol,
 		},
+	}
+}
+
+func (b *VRBuilder) BuildTcpRouteMatch(port *int64) *TCPRouteMatch {
+	return &TCPRouteMatch{
+		Port: port,
 	}
 }
 

--- a/test/integration/virtualrouter/virtualrouter_test.go
+++ b/test/integration/virtualrouter/virtualrouter_test.go
@@ -173,6 +173,47 @@ var _ = Describe("VirtualRouter", func() {
 
 			})
 
+			tcpRouteCfgsWithMatch := []manifest.TcpRouteToWeightedVirtualNodes{{
+				WeightedTargets: weightedTargets,
+				Match:           vrBuilder.BuildTcpRouteMatch(aws.Int64(8080)),
+			},
+			}
+			tcpRoutes := vrBuilder.TcpBuildRoutes(tcpRouteCfgsWithMatch)
+			vrBuilder.Listeners = []appmesh.VirtualRouterListener{vrBuilder.BuildVirtualRouterListener("tcp", 8080)}
+			vrName = fmt.Sprintf("vr-%s", utils.RandomDNS1123Label(8))
+			vr = vrBuilder.BuildVirtualRouter(vrName, tcpRoutes)
+
+			By("Creating a virtual router resource with TCP listener and Port Match in k8s", func() {
+				err := vrTest.Create(ctx, f, vr)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("Validating the virtual router with TCP listener and Port Match in AWS", func() {
+				err := vrTest.CheckInAWS(ctx, f, mesh, vr)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+
+			tcpRouteCfgsWithoutMatch := []manifest.TcpRouteToWeightedVirtualNodes{{
+				WeightedTargets: weightedTargets,
+			},
+			}
+			tcpRoutes = vrBuilder.TcpBuildRoutes(tcpRouteCfgsWithoutMatch)
+			vrBuilder.Listeners = []appmesh.VirtualRouterListener{vrBuilder.BuildVirtualRouterListener("tcp", 8080)}
+			vrName = fmt.Sprintf("vr-%s", utils.RandomDNS1123Label(8))
+			vr = vrBuilder.BuildVirtualRouter(vrName, tcpRoutes)
+
+			By("Creating a virtual router resource with TCP listener and Port Match in k8s", func() {
+				err := vrTest.Create(ctx, f, vr)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("Validating the virtual router with TCP listener and Port Match in AWS", func() {
+				err := vrTest.CheckInAWS(ctx, f, mesh, vr)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+
 			routes = vrBuilder.BuildRoutes(routeCfgs)
 			vrBuilder.Listeners = []appmesh.VirtualRouterListener{vrBuilder.BuildVirtualRouterListener("http", 8080)}
 			vrName = fmt.Sprintf("vr-%s", utils.RandomDNS1123Label(8))
@@ -355,6 +396,79 @@ var _ = Describe("VirtualRouter", func() {
 				}}
 
 				routes := vrBuilder.BuildRoutes(routeCfgs)
+				vrTest.VirtualRouters[vr.Name].Spec.Routes = routes
+
+				err := vrTest.Update(ctx, f, vrTest.VirtualRouters[vr.Name], oldVR)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = vrTest.CheckInAWS(ctx, f, mesh, vrTest.VirtualRouters[vr.Name])
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			tcpRouteCfgsWithMatch := []manifest.TcpRouteToWeightedVirtualNodes{{
+				WeightedTargets: weightedTargets,
+				Match:           vrBuilder.BuildTcpRouteMatch(aws.Int64(8080)),
+			},
+			}
+			tcpRoutes := vrBuilder.TcpBuildRoutes(tcpRouteCfgsWithMatch)
+			vrBuilder.Listeners = []appmesh.VirtualRouterListener{vrBuilder.BuildVirtualRouterListener("tcp", 8080)}
+			vrName = fmt.Sprintf("vr-%s", utils.RandomDNS1123Label(8))
+			vr = vrBuilder.BuildVirtualRouter(vrName, tcpRoutes)
+
+			By("Creating a virtual router resource with TCP listener and Port Match in k8s", func() {
+				err := vrTest.Create(ctx, f, vr)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("Validating the virtual router with TCP listener and Port Match in AWS", func() {
+				err := vrTest.CheckInAWS(ctx, f, mesh, vr)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+			By("Update the virtual router to not have Match and validating", func() {
+				oldVR := vrTest.VirtualRouters[vr.Name].DeepCopy()
+
+				tcpRouteCfgs := []manifest.TcpRouteToWeightedVirtualNodes{{
+					WeightedTargets: weightedTargets,
+				}}
+
+				routes := vrBuilder.TcpBuildRoutes(tcpRouteCfgs)
+				vrTest.VirtualRouters[vr.Name].Spec.Routes = routes
+
+				err := vrTest.Update(ctx, f, vrTest.VirtualRouters[vr.Name], oldVR)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = vrTest.CheckInAWS(ctx, f, mesh, vrTest.VirtualRouters[vr.Name])
+				Expect(err).NotTo(HaveOccurred())
+			})
+			tcpRouteCfgsWithoutMatch := []manifest.TcpRouteToWeightedVirtualNodes{{
+				WeightedTargets: weightedTargets,
+			},
+			}
+			tcpRoutes = vrBuilder.TcpBuildRoutes(tcpRouteCfgsWithoutMatch)
+			vrBuilder.Listeners = []appmesh.VirtualRouterListener{vrBuilder.BuildVirtualRouterListener("tcp", 8080)}
+			vrName = fmt.Sprintf("vr-%s", utils.RandomDNS1123Label(8))
+			vr = vrBuilder.BuildVirtualRouter(vrName, tcpRoutes)
+
+			By("Creating a virtual router resource with TCP listener and Port Match in k8s", func() {
+				err := vrTest.Create(ctx, f, vr)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("Validating the virtual router with TCP listener and Port Match in AWS", func() {
+				err := vrTest.CheckInAWS(ctx, f, mesh, vr)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+			By("Update the virtual router to have Match and validating", func() {
+				oldVR := vrTest.VirtualRouters[vr.Name].DeepCopy()
+
+				tcpRouteCfgs := []manifest.TcpRouteToWeightedVirtualNodes{{
+					WeightedTargets: weightedTargets,
+					Match:           vrBuilder.BuildTcpRouteMatch(aws.Int64(8080)),
+				}}
+
+				routes := vrBuilder.TcpBuildRoutes(tcpRouteCfgs)
 				vrTest.VirtualRouters[vr.Name].Spec.Routes = routes
 
 				err := vrTest.Update(ctx, f, vrTest.VirtualRouters[vr.Name], oldVR)


### PR DESCRIPTION
*Description of changes:*
Adding test cases for this [change](https://github.com/aws/aws-app-mesh-controller-for-k8s/pull/719) to ensure the functionality of TcpRouteMatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
