### PR TITLE
updating controller to include APPMESH_RESOURCE_ARN env variable

### DIFF
--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -76,7 +76,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 			Namespace: "my-ns",
 			Name:      "my-pod",
 			Annotations: map[string]string{
-				"appmesh.k8s.aws/sidecarEnv": "DD_ENV=prod, APPMESH_VIRTUAL_NODE_NAME=random_val",
+				"appmesh.k8s.aws/sidecarEnv": "DD_ENV=prod, APPMESH_RESOURCE_ARN=random_val",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -259,7 +259,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -402,7 +402,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -544,7 +544,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -726,7 +726,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -879,7 +879,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1031,7 +1031,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1178,7 +1178,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1336,7 +1336,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1519,7 +1519,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1684,7 +1684,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1827,7 +1827,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1985,7 +1985,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2150,7 +2150,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2349,7 +2349,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2508,7 +2508,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2670,7 +2670,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2798,7 +2798,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 					Namespace: "my-ns",
 					Name:      "my-pod",
 					Annotations: map[string]string{
-						"appmesh.k8s.aws/sidecarEnv": "DD_ENV=prod, APPMESH_VIRTUAL_NODE_NAME=random_val",
+						"appmesh.k8s.aws/sidecarEnv": "DD_ENV=prod, APPMESH_RESOURCE_ARN=random_val",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -2843,7 +2843,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2998,7 +2998,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -76,7 +76,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 			Namespace: "my-ns",
 			Name:      "my-pod",
 			Annotations: map[string]string{
-				"appmesh.k8s.aws/sidecarEnv": "DD_ENV=prod, APPMESH_RESOURCE_ARN=random_val",
+				"appmesh.k8s.aws/sidecarEnv": "DD_ENV=prod, APPMESH_RESOURCE_ARN=random_val, APPMESH_VIRTUAL_NODE_NAME=random_val",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -263,6 +263,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -406,6 +410,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "1",
 								},
@@ -545,6 +553,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -730,6 +742,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -880,6 +896,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1035,6 +1055,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -1179,6 +1203,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1337,6 +1365,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1523,6 +1555,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "1",
 								},
@@ -1688,6 +1724,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "1",
 								},
@@ -1828,6 +1868,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -1986,6 +2030,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2151,6 +2199,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2353,6 +2405,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -2509,6 +2565,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2674,6 +2734,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -2798,7 +2862,7 @@ func Test_envoyMutator_mutate(t *testing.T) {
 					Namespace: "my-ns",
 					Name:      "my-pod",
 					Annotations: map[string]string{
-						"appmesh.k8s.aws/sidecarEnv": "DD_ENV=prod, APPMESH_RESOURCE_ARN=random_val",
+						"appmesh.k8s.aws/sidecarEnv": "DD_ENV=prod, APPMESH_RESOURCE_ARN=random_val, APPMESH_VIRTUAL_NODE_NAME=random_val",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -2844,6 +2908,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{
@@ -2999,6 +3067,10 @@ func Test_envoyMutator_mutate(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualNode/my-vn_my-ns",
 								},
 								{

--- a/pkg/inject/sidecar_builder.go
+++ b/pkg/inject/sidecar_builder.go
@@ -60,7 +60,7 @@ func updateEnvMapForEnvoy(vars EnvoyTemplateVariables, env map[string]string, vn
 	// add all the controller managed env to the map so
 	// 1) we remove duplicates
 	// 2) we don't allow overriding controller managed env with pod annotations
-	env["APPMESH_VIRTUAL_NODE_NAME"] = vname
+	env["APPMESH_RESOURCE_ARN"] = vname
 	env["AWS_REGION"] = vars.AWSRegion
 
 	// For usage outside traditional EC2 / Fargate IAM based profiles, this is needed to

--- a/pkg/inject/sidecar_builder.go
+++ b/pkg/inject/sidecar_builder.go
@@ -61,6 +61,7 @@ func updateEnvMapForEnvoy(vars EnvoyTemplateVariables, env map[string]string, vn
 	// 1) we remove duplicates
 	// 2) we don't allow overriding controller managed env with pod annotations
 	env["APPMESH_RESOURCE_ARN"] = vname
+	env["APPMESH_VIRTUAL_NODE_NAME"] = vname
 	env["AWS_REGION"] = vars.AWSRegion
 
 	// For usage outside traditional EC2 / Fargate IAM based profiles, this is needed to

--- a/pkg/inject/virtualgateway_envoy_test.go
+++ b/pkg/inject/virtualgateway_envoy_test.go
@@ -144,7 +144,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 							Value: "test_val",
 						},
 						{
-							Name:  "APPMESH_VIRTUAL_NODE_NAME",
+							Name:  "APPMESH_RESOURCE_ARN",
 							Value: "incorrect_node_name",
 						},
 						{
@@ -326,7 +326,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -442,7 +442,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -563,7 +563,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -664,7 +664,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "test_val",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -781,7 +781,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "test_val",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -898,7 +898,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "test_val",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1030,7 +1030,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1189,7 +1189,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1324,7 +1324,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1462,7 +1462,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1587,7 +1587,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1706,7 +1706,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "/run/spire/sockets/agent.sock",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1840,7 +1840,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "us-west-2",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1959,7 +1959,7 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "/run/spire/sockets/agent.sock",
 								},
 								{
-									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Name:  "APPMESH_RESOURCE_ARN",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{

--- a/pkg/inject/virtualgateway_envoy_test.go
+++ b/pkg/inject/virtualgateway_envoy_test.go
@@ -148,6 +148,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 							Value: "incorrect_node_name",
 						},
 						{
+							Name:  "APPMESH_VIRTUAL_NODE_NAME",
+							Value: "incorrect_node_name",
+						},
+						{
 							Name:  "APPMESH_PREVIEW",
 							Value: "1",
 						},
@@ -330,6 +334,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -443,6 +451,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								},
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -567,6 +579,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -665,6 +681,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								},
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -785,6 +805,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -899,6 +923,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								},
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1031,6 +1059,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								},
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1193,6 +1225,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -1325,6 +1361,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								},
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1466,6 +1506,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -1591,6 +1635,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -1707,6 +1755,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								},
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
@@ -1844,6 +1896,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
 									Name:  "APPMESH_PREVIEW",
 									Value: "0",
 								},
@@ -1960,6 +2016,10 @@ func Test_virtualGatewayEnvoyMutator_mutate(t *testing.T) {
 								},
 								{
 									Name:  "APPMESH_RESOURCE_ARN",
+									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
+								},
+								{
+									Name:  "APPMESH_VIRTUAL_NODE_NAME",
 									Value: "mesh/my-mesh/virtualGateway/my-vg_my-ns",
 								},
 								{


### PR DESCRIPTION
*Description of changes:*
Adding APPMESH_RESOURCE_ARN env variable to avoid discrepancies with the docs and leaving APPMESH_VIRTUAL_NODE_NAME because to make controller support older envoy versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
