### PR TITLE
update pdb api version

### DIFF
--- a/config/helm/appmesh-controller/Chart.yaml
+++ b/config/helm/appmesh-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-controller
 description: App Mesh controller Helm chart for Kubernetes
-version: 1.12.3
-appVersion: 1.12.3
+version: 1.12.4
+appVersion: 1.12.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/config/helm/appmesh-controller/templates/pdb.yaml
+++ b/config/helm/appmesh-controller/templates/pdb.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.podDisruptionBudget }}
 {{- if gt (int .Values.replicaCount) 1 }}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 metadata:
   name: {{ template "appmesh-controller.fullname" . }}-pdb
   namespace: {{ .Release.Namespace }} 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
PodDisruptionBudget.policy.v1beta1 has been deprecated in k8s 1.27
Update to policy/v1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
