### PR TITLE
Add length validation to route name

### DIFF
--- a/apis/appmesh/v1beta2/virtualrouter_types.go
+++ b/apis/appmesh/v1beta2/virtualrouter_types.go
@@ -247,6 +247,8 @@ type GRPCRoute struct {
 // Route refers to https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_RouteSpec.html
 type Route struct {
 	// Route's name
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=255
 	Name string `json:"name"`
 	// An object that represents the specification of a gRPC route.
 	// +optional

--- a/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
+++ b/config/crd/bases/appmesh.k8s.aws_virtualrouters.yaml
@@ -943,6 +943,8 @@ spec:
                       type: object
                     name:
                       description: Route's name
+                      maxLength: 255
+                      minLength: 1
                       type: string
                     priority:
                       description: The priority for the route.

--- a/config/helm/appmesh-controller/crds/crds.yaml
+++ b/config/helm/appmesh-controller/crds/crds.yaml
@@ -3813,6 +3813,8 @@ spec:
                       type: object
                     name:
                       description: Route's name
+                      maxLength: 255
+                      minLength: 1
                       type: string
                     priority:
                       description: The priority for the route.


### PR DESCRIPTION
*Description of changes:*

According to the API reference, the route name must be at least 1 character and at most 255 characters. https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_RouteData.html

Currently an empty string is valid input for the CRD, which results in an API error during reconcile. This can be caught early with a validation rule.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
