### PR TITLE
adding sidecarEnvJson annotation

### DIFF
--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -56,6 +56,14 @@ const (
 	//
 	AppMeshEnvAnnotation = "appmesh.k8s.aws/sidecarEnv"
 
+	// AppMeshEnvJsonAnnotation which is similar AppMeshEnvAnnotation, but it is used to specify the list Jsons of environment variables that need to be programmed on Envoy sidecars
+	// Here's how a sample annotations will be like
+	//
+	//        e.g. appmesh.k8s.aws/sidecarEnvJson: '[{"DD_ENV":"prod","TEST_ENV":"env_val"}]'
+	//        e.g. appmesh.k8s.aws/sidecarEnvJson: '[{"DD_ENV":"prod"}]'
+	//
+	AppMeshEnvJsonAnnotation = "appmesh.k8s.aws/sidecarEnvJson"
+
 	// === begin xray daemon annotations ===
 
 	// AppMeshXrayAgentConfigAnnotation specifies the mount path for the Xray daemon's configuration file.

--- a/pkg/inject/envoy.go
+++ b/pkg/inject/envoy.go
@@ -2,6 +2,7 @@ package inject
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/json"
 	"strconv"
 	"strings"
 
@@ -90,6 +91,15 @@ func (m *envoyMutator) mutate(pod *corev1.Pod) error {
 	customEnv, err := m.getCustomEnv(pod)
 	if err != nil {
 		return err
+	}
+
+	customEnvJson, err := m.getCustomEnvJson(pod)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range customEnvJson {
+		customEnv[k] = v
 	}
 
 	container, err := buildEnvoySidecar(variables, customEnv)
@@ -247,6 +257,45 @@ func (m *envoyMutator) getCustomEnv(pod *corev1.Pod) (map[string]string, error) 
 		}
 	}
 	return customEnv, nil
+}
+
+type customEnvJsonType []map[string]string
+
+func (c *customEnvJsonType) UnmarshalJSON(data []byte) error {
+	var temp []map[string]interface{}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	*c = make(customEnvJsonType, 1)
+	(*c)[0] = make(map[string]string)
+	for _, item := range temp {
+		for key, value := range item {
+			if strValue, isString := value.(string); isString {
+				(*c)[0][key] = strValue
+			} else {
+				return errors.Errorf("nested json isn't supported with this annotation %s, expected format: %s", AppMeshEnvJsonAnnotation, `[{"DD_ENV":"prod","TEST_ENV":"env_val"}]`)
+			}
+		}
+	}
+	return nil
+}
+
+func (m *envoyMutator) getCustomEnvJson(pod *corev1.Pod) (map[string]string, error) {
+	var customEnvJson customEnvJsonType
+	if v, ok := pod.ObjectMeta.Annotations[AppMeshEnvJsonAnnotation]; ok {
+		err := json.Unmarshal([]byte(v), &customEnvJson)
+		if err != nil {
+			if strings.Contains(err.Error(), "nested json") {
+				return nil, err
+			}
+			err = errors.Errorf("malformed annotation %s, expected format: %s", AppMeshEnvJsonAnnotation, `[{"DD_ENV":"prod","TEST_ENV":"env_val"}]`)
+			return nil, err
+		}
+	}
+	if len(customEnvJson) > 0 {
+		return customEnvJson[0], nil
+	}
+	return map[string]string{}, nil
 }
 
 func (m *envoyMutator) mutateVolumeMounts(pod *corev1.Pod, envoyContainer *corev1.Container, volumeMounts map[string]string) {

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -3546,7 +3546,7 @@ func Test_envoyMutator_getCustomEnvJson(t *testing.T) {
 					},
 				},
 			},
-			want:    map[string]string{},
+			want:    nil,
 			wantErr: nil,
 		},
 		{
@@ -3574,6 +3574,19 @@ func Test_envoyMutator_getCustomEnvJson(t *testing.T) {
 				},
 			},
 			wantErr: errors.New("nested json isn't supported with this annotation appmesh.k8s.aws/sidecarEnvJson, expected format: [{\"DD_ENV\":\"prod\",\"TEST_ENV\":\"env_val\"}]"),
+		},
+		{
+			name: "pods with no_input appmesh.k8s.aws/sidecarEnvJson annotation",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"appmesh.k8s.aws/sidecarEnvJson": ``,
+						},
+					},
+				},
+			},
+			wantErr: errors.New("malformed annotation appmesh.k8s.aws/sidecarEnvJson, expected format: [{\"DD_ENV\":\"prod\",\"TEST_ENV\":\"env_val\"}]"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -3526,7 +3526,7 @@ func Test_envoyMutator_getCustomEnvJson(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"appmesh.k8s.aws/sidecarEnvJson": `[{"DD_ENV":"prod","TEST_ENV":"env_val"}]`,
+							"appmesh.k8s.aws/sidecarEnvJson": `[{"DD_ENV":"prod","TEST_ENV":"env_val"},{"PROD_ENV":"prod_env"}]`,
 						},
 					},
 				},
@@ -3534,6 +3534,7 @@ func Test_envoyMutator_getCustomEnvJson(t *testing.T) {
 			want: map[string]string{
 				"DD_ENV":   "prod",
 				"TEST_ENV": "env_val",
+				"PROD_ENV": "prod_env",
 			},
 			wantErr: nil,
 		},
@@ -3546,7 +3547,7 @@ func Test_envoyMutator_getCustomEnvJson(t *testing.T) {
 					},
 				},
 			},
-			want:    nil,
+			want:    map[string]string{},
 			wantErr: nil,
 		},
 		{

--- a/pkg/inject/envoy_test.go
+++ b/pkg/inject/envoy_test.go
@@ -3510,6 +3510,85 @@ func Test_envoyMutator_getCustomEnv(t *testing.T) {
 		})
 	}
 }
+func Test_envoyMutator_getCustomEnvJson(t *testing.T) {
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr error
+	}{
+		{
+			name: "pods with valid appmesh.k8s.aws/sidecarEnvJson annotation",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"appmesh.k8s.aws/sidecarEnvJson": `[{"DD_ENV":"prod","TEST_ENV":"env_val"}]`,
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"DD_ENV":   "prod",
+				"TEST_ENV": "env_val",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "pods with no appmesh.k8s.aws/sidecarEnvJson annotation",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			want:    map[string]string{},
+			wantErr: nil,
+		},
+		{
+			name: "pods with invalid appmesh.k8s.aws/sidecarEnvJson annotation",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"appmesh.k8s.aws/sidecarEnvJson": `[{"DD_ENV":"{PROD_ENV: "prod"}","TEST_ENV":"env_val"}]`,
+						},
+					},
+				},
+			},
+			wantErr: errors.New("malformed annotation appmesh.k8s.aws/sidecarEnvJson, expected format: [{\"DD_ENV\":\"prod\",\"TEST_ENV\":\"env_val\"}]"),
+		},
+		{
+			name: "pods with Nested Json appmesh.k8s.aws/sidecarEnvJson annotation",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"appmesh.k8s.aws/sidecarEnvJson": `[{"DD_ENV":{"PROD_ENV": "prod"},"TEST_ENV":"env_val"}]`,
+						},
+					},
+				},
+			},
+			wantErr: errors.New("nested json isn't supported with this annotation appmesh.k8s.aws/sidecarEnvJson, expected format: [{\"DD_ENV\":\"prod\",\"TEST_ENV\":\"env_val\"}]"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &envoyMutator{}
+			got, err := m.getCustomEnvJson(tt.args.pod)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, got, tt.want)
+			}
+		})
+	}
+}
 
 func Test_envoyMutator_getAugmentedMeshName(t *testing.T) {
 	type fields struct {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-app-mesh-controller-for-k8s/issues/724
*Description of changes:*
Adding Feature appmesh.k8s.aws/sidecarEnvJson that accepts json list as env for envoy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
