### PR TITLE
Helm Chart: Allow extra volume mounts for controller

### DIFF
--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -430,3 +430,5 @@ Parameter | Description | Default
 `env` |  environment variables to be injected into the appmesh-controller pod | `{}`
 `livenessProbe` | Liveness probe settings for the controller | (see `values.yaml`)
 `podDisruptionBudget` | PodDisruptionBudget | `{}`
+`extraVolumes` | Extra volumes for the controller pod | `[]`
+`extraVolumeMounts` | Extra volume mounts for the controller pod | `[]`

--- a/config/helm/appmesh-controller/templates/deployment.yaml
+++ b/config/helm/appmesh-controller/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ template "appmesh-controller.fullname" . }}-webhook-server-cert
+      {{- with .Values.extraVolumes }}
+{{ toYaml . | nindent 6 }}
+      {{- end }}
       containers:
       - name: controller
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -51,6 +54,9 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        {{- with .Values.extraVolumeMounts }}
+{{ toYaml . | nindent 8 }}
+        {{- end }}
         command:
         - /controller
         args:

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -162,3 +162,20 @@ livenessProbe:
     scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 10
+
+# extraVolumeMounts are the additional volume mounts. This enables setting up IRSA on non-EKS Kubernetes cluster
+extraVolumeMounts:
+  # - name: aws-iam-token
+  #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+  #   readOnly: true
+
+# extraVolumes for the extraVolumeMounts. Useful to mount a projected service account token for example.
+extraVolumes:
+  # - name: aws-iam-token
+  #   projected:
+  #     defaultMode: 420
+  #     sources:
+  #     - serviceAccountToken:
+  #         audience: sts.amazonaws.com
+  #         expirationSeconds: 86400
+  #         path: token


### PR DESCRIPTION
*Description of changes:*

Add support for deploying additional volumes and mounts into the controller with the Helm chart. Modeled after the same functionality in the `aws-load-balancer-controller` chart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
