### PR TITLE
Update test docker image URIs

### DIFF
--- a/test/integration/sidecar-v1.22/sidecar_stack.go
+++ b/test/integration/sidecar-v1.22/sidecar_stack.go
@@ -3,6 +3,7 @@ package sidecar_v1_22
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/inject"
 
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
@@ -17,7 +18,7 @@ import (
 )
 
 const (
-	defaultImage = "public.ecr.aws/b7m0w2t6/color-be-app:2.0.2"
+	defaultImage = "public.ecr.aws/e4i4k4a4/appmesh-k8s-test:color-be-app"
 )
 
 type SidecarStack struct {

--- a/test/integration/sidecar/sidecar_stack.go
+++ b/test/integration/sidecar/sidecar_stack.go
@@ -3,8 +3,9 @@ package sidecar
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/inject"
 	"time"
+
+	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/inject"
 
 	appmesh "github.com/aws/aws-app-mesh-controller-for-k8s/apis/appmesh/v1beta2"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/test/framework"
@@ -22,8 +23,8 @@ import (
 )
 
 const (
-	defaultFrontendImage = "public.ecr.aws/b7m0w2t6/color-fe-app:2.0.3"
-	defaultBackendImage  = "public.ecr.aws/b7m0w2t6/color-be-app:2.0.2"
+	defaultFrontendImage = "public.ecr.aws/e4i4k4a4/appmesh-k8s-test:color-fe-app"
+	defaultBackendImage  = "public.ecr.aws/e4i4k4a4/appmesh-k8s-test:color-be-app"
 )
 
 type SidecarStack struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Due to deletion of AWS account holding the previous docker images, the integration tests are failing. I have rebuilt the images from the [code repo](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/test/integration/test_app) and published them to the AWS account that holds the beta images.

We will need to eventually do the same for the rest of the ECR public references in this repo, but I would like to unblock the integration tests first.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
