### PR TITLE
adding feature to set TLS configuration

### DIFF
--- a/config/helm/appmesh-controller/templates/deployment.yaml
+++ b/config/helm/appmesh-controller/templates/deployment.yaml
@@ -124,6 +124,9 @@ spec:
         # this must be same as livenessProbe port which can be configured 
         - --health-probe-port={{ .Values.livenessProbe.httpGet.port }}
         - --wait-until-proxy-ready={{ .Values.sidecar.waitUntilProxyReady }}
+        # TLS configuration
+        - --tls-min-version={{ .Values.tlsMinVersion }}
+        - --tls-cipher-suite={{ .Values.tlsCipherSuite }}
         {{- if .Values.env }}
         env:
           {{- range $key, $value := .Values.env }}

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -144,6 +144,10 @@ enableCertManager: false
 podDisruptionBudget: {}
 #  minAvailable: 1
 
+# TLS setting for appmesh-controller
+tlsMinVersion: ""
+tlsCipherSuite: ""
+
 # Environment variables to set in appmesh-controller pod
 env: {}
 

--- a/main.go
+++ b/main.go
@@ -19,10 +19,11 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"github.com/aws/aws-sdk-go/service/eks"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/eks"
 
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/aws/throttle"
 	"github.com/aws/aws-app-mesh-controller-for-k8s/pkg/cloudmap"
@@ -332,6 +333,7 @@ func tlsConfigSetting(cfg *tls.Config, tlsOpt tlsConfig) {
 	tlsVersion, err := k8sapiflag.TLSVersion(tlsOpt.minVersion)
 	if err != nil {
 		setupLog.Error(err, "TLS version invalid")
+		os.Exit(1)
 	}
 	cfg.MinVersion = tlsVersion
 
@@ -339,6 +341,7 @@ func tlsConfigSetting(cfg *tls.Config, tlsOpt tlsConfig) {
 	cipherSuiteIDs, err := k8sapiflag.TLSCipherSuites(tlsOpt.cipherSuites)
 	if err != nil {
 		setupLog.Error(err, "Failed to convert TLS cipher suite name to ID")
+		os.Exit(1)
 	}
 	cfg.CipherSuites = cipherSuiteIDs
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is enable user to configure TLS setting for the controller manager
- setting for minimum TLS version
- setting for preferred TLS cipher suites

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
