### PR TITLE
adding optional support for topologySpreadConstraints to helm chart

### DIFF
--- a/config/helm/appmesh-controller/README.md
+++ b/config/helm/appmesh-controller/README.md
@@ -451,3 +451,4 @@ Parameter | Description | Default
 `podDisruptionBudget` | PodDisruptionBudget | `{}`
 `tlsMinVersion` | Minimum TLS version for the controller webhook server as shown in [here](https://github.com/kubernetes/component-base/blob/master/cli/flag/ciphersuites_flag.go#L114) | `VersionTLS12`
 `tlsCipherSuite` | Comma delimited TLS cipher suites for the controller webhook server as shown [here](https://pkg.go.dev/crypto/tls#pkg-constants) | None
+`topologySpreadConstraints` | Topology Spread Constraints for pod assignment | `{}`

--- a/config/helm/appmesh-controller/templates/deployment.yaml
+++ b/config/helm/appmesh-controller/templates/deployment.yaml
@@ -150,3 +150,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{- toYaml . | indent 8 }}
+    {{- end }}

--- a/config/helm/appmesh-controller/test.yaml
+++ b/config/helm/appmesh-controller/test.yaml
@@ -80,6 +80,13 @@ affinity: {
     test: test
 }
 
+# topologySpreadConstraints is a stable feature of k8s v1.19 which provides the ability to
+# control how Pods are spread across your cluster among failure-domains such as regions, zones,
+# nodes, and other user-defined topology domains.
+#
+# more details here: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: {}
+
 podAnnotations: {
     test: test
 }

--- a/config/helm/appmesh-controller/values.yaml
+++ b/config/helm/appmesh-controller/values.yaml
@@ -73,6 +73,13 @@ tolerations: []
 
 affinity: {}
 
+# topologySpreadConstraints is a stable feature of k8s v1.19 which provides the ability to
+# control how Pods are spread across your cluster among failure-domains such as regions, zones,
+# nodes, and other user-defined topology domains.
+#
+# more details here: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: {}
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
This adds optional (defaulting to empty) topologySpreadConstraints to the helm chart.

Similar to https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2575

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
